### PR TITLE
Gems configuration for dedicated server

### DIFF
--- a/dev/Code/CryEngine/CrySystem/GemManager.cpp
+++ b/dev/Code/CryEngine/CrySystem/GemManager.cpp
@@ -141,7 +141,6 @@ bool GemManager::LoadGems(const SSystemInitParams& initParams)
 
     // get the game name:
 
-    //FL[FD-362] Gems configuration for dedicated server
     if (!m_projectSettings->Initialize("@assets@", initParams.bDedicatedServer))
     {
         const char* assetPath = initParams.UseAssetCache() ? initParams.assetsPathCache : initParams.assetsPath;

--- a/dev/Code/CryEngine/CrySystem/GemManager.cpp
+++ b/dev/Code/CryEngine/CrySystem/GemManager.cpp
@@ -141,7 +141,8 @@ bool GemManager::LoadGems(const SSystemInitParams& initParams)
 
     // get the game name:
 
-    if (!m_projectSettings->Initialize("@assets@"))
+    //FL[FD-362] Gems configuration for dedicated server
+    if (!m_projectSettings->Initialize("@assets@", initParams.bDedicatedServer))
     {
         const char* assetPath = initParams.UseAssetCache() ? initParams.assetsPathCache : initParams.assetsPath;
         AZ_Error("Gems", false, "Error initializing Gems::ProjectSettings for project. Add gems.json to %s at enabled Gems", assetPath);

--- a/dev/Code/Tools/GemRegistry/include/GemRegistry/IGemRegistry.h
+++ b/dev/Code/Tools/GemRegistry/include/GemRegistry/IGemRegistry.h
@@ -113,7 +113,7 @@ namespace Gems
          *
          * \returns                 True on success, false on failure.
          */
-        virtual AZ::Outcome<void, AZStd::string> Initialize(const AZStd::string& projectFolder) = 0;
+        virtual AZ::Outcome<void, AZStd::string> Initialize(const AZStd::string& projectFolder, bool bDedicatedServer) = 0;
 
         /**
          * Enables the specified instance of a Gem.

--- a/dev/Code/Tools/GemRegistry/source/GemRegistry.h
+++ b/dev/Code/Tools/GemRegistry/source/GemRegistry.h
@@ -23,6 +23,7 @@
 #define GEM_DEF_FILE "gem.json"
 #define GEM_DEF_FILE_VERSION 3
 #define GEMS_PROJECT_FILE "gems.json"
+#define GEMS_SERVER_PROJECT_FILE "gems_server.json"
 #define GEMS_PROJECT_FILE_VERSION 2
 
 // Gem project file JSON tags

--- a/dev/Code/Tools/GemRegistry/source/ProjectSettings.cpp
+++ b/dev/Code/Tools/GemRegistry/source/ProjectSettings.cpp
@@ -44,12 +44,14 @@ namespace Gems
     {
     }
 
-    AZ::Outcome<void, AZStd::string> ProjectSettings::Initialize(const AZStd::string& projectFolder)
+    AZ::Outcome<void, AZStd::string> ProjectSettings::Initialize(const AZStd::string& projectFolder, bool bDedicatedServer)
     {
         AZ_Assert(!m_initialized, "ProjectSettings has been initialized already.");
 
         // Project file lives in (ProjectFolder)/gems.json - which might be @assets@/gems.json or an absolute path (in tools)
-        AzFramework::StringFunc::Path::Join(projectFolder.c_str(), GEMS_PROJECT_FILE, m_settingsFilePath);
+        AzFramework::StringFunc::Path::Join(projectFolder.c_str(),
+            bDedicatedServer ? GEMS_SERVER_PROJECT_FILE : GEMS_PROJECT_FILE,
+            m_settingsFilePath);
 
         auto loadOutcome = LoadSettings();
         m_initialized = loadOutcome.IsSuccess();

--- a/dev/Code/Tools/GemRegistry/source/ProjectSettings.h
+++ b/dev/Code/Tools/GemRegistry/source/ProjectSettings.h
@@ -28,7 +28,7 @@ namespace Gems
         ~ProjectSettings() override = default;
 
         // IProjectSettings
-        AZ::Outcome<void, AZStd::string> Initialize(const AZStd::string& projectFolder) override;
+        AZ::Outcome<void, AZStd::string> Initialize(const AZStd::string& projectFolder, bool bDedicatedServer) override;
 
         bool EnableGem(const ProjectGemSpecifier& spec) override;
         bool DisableGem(const GemSpecifier& spec) override;

--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/gems.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/gems.py
@@ -620,7 +620,7 @@ class GemManager(object):
     def contains_gem(self, *gem_spec):
         return self.get_gem_by_spec(*gem_spec) != None
 
-    def process(self, is_server):
+    def process(self, is_server=False):
         """
         Process current directory for gems
 

--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/gems.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/gems.py
@@ -23,6 +23,7 @@ GEMS_UUID_KEY = "Uuid"
 GEMS_VERSION_KEY = "Version"
 GEMS_PATH_KEY = "Path"
 GEMS_LIST_FILE = "gems.json"
+GEMS_SERVER_LIST_FILE = "gems_server.json"
 GEMS_DEFINITION_FILE = "gem.json"
 GEMS_CODE_FOLDER = 'Code'
 GEMS_FOLDER = 'Gems'
@@ -619,7 +620,7 @@ class GemManager(object):
     def contains_gem(self, *gem_spec):
         return self.get_gem_by_spec(*gem_spec) != None
 
-    def process(self):
+    def process(self, is_server):
         """
         Process current directory for gems
 
@@ -651,7 +652,7 @@ class GemManager(object):
         for game_project in game_projects:
             Logs.debug('gems: Game Project: %s' % game_project)
 
-            gems_list_file = self.ctx.get_project_node(game_project).make_node(GEMS_LIST_FILE)
+            gems_list_file = self.ctx.get_project_node(game_project).make_node(GEMS_SERVER_LIST_FILE if is_server else GEMS_LIST_FILE)
 
             if not os.path.isfile(gems_list_file.abspath()):
                 if self.ctx.is_option_true('gems_optional'):
@@ -798,7 +799,7 @@ class GemManager(object):
         """
         if not hasattr(ctx, 'gem_manager'):
             ctx.gem_manager = GemManager(ctx)
-            ctx.gem_manager.process()
+            ctx.gem_manager.process(ctx.cmd.endswith('_dedicated'))
         return ctx.gem_manager
 
 @conf


### PR DESCRIPTION
Create separated gems config for Dedicated Server
This give possibility to load only server related gems

Configuration file named gems_server.json, it stored in <game_folder>/ (same folder as gems.json)
Known Issue: ProjectConfigurator.exe dosn't change gems_server.json (it should be filled manually)