### PR TITLE
Support log in Release

### DIFF
--- a/dev/Code/CryEngine/CrySystem/AZCoreLogSink.h
+++ b/dev/Code/CryEngine/CrySystem/AZCoreLogSink.h
@@ -135,6 +135,17 @@ public:
         return true;
     }
 
+    bool OnPrintfAlways(const char* window, const char* message) override
+    {
+        (void)window;
+        if (!IsCryLogReady())
+        {
+            return false;
+        }
+        CryLogAlways("%s", message);
+        return true;
+    }
+
 private:
 
     using IgnoredAssertMap = AZStd::unordered_map<AZ::Crc32, bool, AZStd::hash<AZ::Crc32>, AZStd::equal_to<AZ::Crc32>, AZ::OSStdAllocator>;

--- a/dev/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -307,6 +307,32 @@ namespace AZ {
     }
 
     //=========================================================================
+    // PrintfAlways
+    // [9/8/2017]
+    //=========================================================================
+    void
+        Trace::PrintfAlways(const char* window, const char* format, ...)
+    {
+        char message[g_maxMessageLength];
+
+        va_list mark;
+        va_start(mark, format);
+        azvsnprintf(message, g_maxMessageLength, format, mark);
+        va_end(mark);
+
+        EBUS_EVENT(TraceMessageDrillerBus, OnPrintfAlways, window, message);
+
+        TraceMessageResult result;
+        EBUS_EVENT_RESULT(result, TraceMessageBus, OnPrintfAlways, window, message);
+        if (result.m_value)
+        {
+            return;
+        }
+
+        Output(window, message);
+    }
+
+    //=========================================================================
     // Output
     // [8/3/2009]
     //=========================================================================

--- a/dev/Code/Framework/AzCore/AzCore/Debug/Trace.h
+++ b/dev/Code/Framework/AzCore/AzCore/Debug/Trace.h
@@ -57,6 +57,7 @@ namespace AZ
             static void Error(const char* fileName, int line, const char* funcName, const char* window, const char* format, ...);
             static void Warning(const char* fileName, int line, const char* funcName, const char* window, const char* format, ...);
             static void Printf(const char* window, const char* format, ...);
+            static void PrintfAlways(const char* window, const char* format, ...);
 
             static void Output(const char* window, const char* message);
 
@@ -154,6 +155,7 @@ namespace AZ
 #endif  // AZ_ENABLE_TRACING
 
 #define AZ_Printf(window, ...)       AZ::Debug::Trace::Instance().Printf(window, __VA_ARGS__);
+#define AZ_PrintfAlways(window, ...)       AZ::Debug::Trace::Instance().PrintfAlways(window, __VA_ARGS__);
 
 #if defined(AZ_DEBUG_BUILD)
 #   define AZ_DbgIf(expression)         if (expression)

--- a/dev/Code/Framework/AzCore/AzCore/Debug/TraceMessageBus.h
+++ b/dev/Code/Framework/AzCore/AzCore/Debug/TraceMessageBus.h
@@ -44,6 +44,7 @@ namespace AZ
             virtual bool OnPreWarning(const char* /*window*/, const char* /*fileName*/, int /*line*/, const char* /*func*/, const char* /*message*/) { return false; }
             virtual bool OnWarning(const char* /*window*/, const char* /*message*/) { return false; }
             virtual bool OnPrintf(const char* /*window*/, const char* /*message*/) { return false; }
+            virtual bool OnPrintfAlways(const char* /*window*/, const char* /*message*/) { return false; }
 
             /**
             * All trace functions you output to anything. So if you want to handle all the output this is the place.

--- a/dev/Code/Framework/AzCore/AzCore/Debug/TraceMessagesDriller.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/Debug/TraceMessagesDriller.cpp
@@ -103,6 +103,20 @@ namespace AZ
             m_output->EndTag(AZ_CRC("OnPrintf", 0xd4b5c294));
             m_output->EndTag(AZ_CRC("TraceMessagesDriller", 0xa61d1b00));
         }
+
+        //=========================================================================
+        // OnPrintfAlways
+        // [9/8/2017]
+        //=========================================================================
+        void TraceMessagesDriller::OnPrintfAlways(const char* window, const char* message)
+        {
+            m_output->BeginTag(AZ_CRC("TraceMessagesDriller", 0xa61d1b00));
+            m_output->BeginTag(AZ_CRC("OnPrintfAlways", 0x13aaf0b1));
+            m_output->Write(AZ_CRC("Window", 0x8be4f9dd), window);
+            m_output->Write(AZ_CRC("Message", 0xb6bd307f), message);
+            m_output->EndTag(AZ_CRC("OnPrintfAlways", 0x13aaf0b1));
+            m_output->EndTag(AZ_CRC("TraceMessagesDriller", 0xa61d1b00));
+        }
     } // namespace Debug
 } // namespace AZ
 

--- a/dev/Code/Framework/AzCore/AzCore/Debug/TraceMessagesDriller.h
+++ b/dev/Code/Framework/AzCore/AzCore/Debug/TraceMessagesDriller.h
@@ -47,6 +47,7 @@ namespace AZ
             virtual void OnError(const char* window, const char* message);
             virtual void OnWarning(const char* window, const char* message);
             virtual void OnPrintf(const char* window, const char* message);
+            virtual void OnPrintfAlways(const char* window, const char* message);
             //////////////////////////////////////////////////////////////////////////
         };
     } // namespace Debug

--- a/dev/Code/Framework/AzCore/AzCore/Debug/TraceMessagesDrillerBus.h
+++ b/dev/Code/Framework/AzCore/AzCore/Debug/TraceMessagesDrillerBus.h
@@ -44,6 +44,7 @@ namespace AZ
             virtual void OnPreWarning(const char* /*window*/, const char* /*fileName*/, int /*line*/, const char* /*func*/, const char* /*message*/) {}
             virtual void OnWarning(const char* /*window*/, const char* /*message*/) {}
             virtual void OnPrintf(const char* /*window*/, const char* /*message*/) {}
+            virtual void OnPrintfAlways(const char* /*window*/, const char* /*message*/) {}
             /**
              * All trace functions you output to anything. So if you want to handle all the output this is the place.
              * You are not given the choice to disable the system output as if you listen at that level you can't make


### PR DESCRIPTION
Implement wrapper around CryLogAlways in AZCoreLogSink

Only info messages with type ILog::eAlways would be logged in Release build