### PR TITLE
Warning is reported to editor log if 'project_id' is not set at 'project.json'

### DIFF
--- a/dev/Code/Sandbox/Editor/IEditorImpl.cpp
+++ b/dev/Code/Sandbox/Editor/IEditorImpl.cpp
@@ -1698,7 +1698,7 @@ void CEditorImpl::InitMetrics()
             // Therefore, if the UUID from the project name is the same as the UUID in the file, it's one of our projects
             // and we can therefore send the name back, making it easier for Metrics to determine which level it was.
             // We are checking to see if this is a project we ship with Lumberyard, and therefore we can unobfuscate non-customer information.
-            if (projectId && editorProjectName.compare(projectName, Qt::CaseInsensitive) == 0 &&
+            if (projectId[0] != '\0' && editorProjectName.compare(projectName, Qt::CaseInsensitive) == 0 &&
                 (id == AZ::Uuid(projectId)))
             {
                 QByteArray projectNameUtf8 = projectName.toUtf8();

--- a/dev/Code/Sandbox/Plugins/CryDesigner/Objects/DesignerObject.cpp
+++ b/dev/Code/Sandbox/Plugins/CryDesigner/Objects/DesignerObject.cpp
@@ -377,7 +377,7 @@ void DesignerObject::Serialize(CObjectArchive& ar)
         {
             ar.node->setAttr("RndFlags", ERF_GET_WRITABLE(GetCompiler()->GetRenderFlags()));
             ar.node->setAttr("StaticObjFlags", ERF_GET_WRITABLE(GetCompiler()->GetStaticObjFlags()));
-            ar.node->setAttr("ViewDistMultiplier", GetCompiler()->GetViewDistanceMultiplier());
+            ar.node->setAttr("ViewDistRatio", GetCompiler()->GetViewDistanceMultiplier());
             if (!GetCompiler()->IsValid())
             {
                 GetCompiler()->Compile(this, GetModel());

--- a/dev/Code/Sandbox/Plugins/CryDesigner/Objects/DesignerObject.cpp
+++ b/dev/Code/Sandbox/Plugins/CryDesigner/Objects/DesignerObject.cpp
@@ -377,7 +377,7 @@ void DesignerObject::Serialize(CObjectArchive& ar)
         {
             ar.node->setAttr("RndFlags", ERF_GET_WRITABLE(GetCompiler()->GetRenderFlags()));
             ar.node->setAttr("StaticObjFlags", ERF_GET_WRITABLE(GetCompiler()->GetStaticObjFlags()));
-            ar.node->setAttr("ViewDistRatio", GetCompiler()->GetViewDistanceMultiplier());
+            ar.node->setAttr("ViewDistMultiplier", GetCompiler()->GetViewDistanceMultiplier());
             if (!GetCompiler()->IsValid())
             {
                 GetCompiler()->Compile(this, GetModel());


### PR DESCRIPTION
1) Warning is reported to editor log if 'project_id' is not set at 'project.json':
Warning in editor.log after start Editor ([Warning] Invalid UUID format (must be) {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx} (or without dashes and braces))

It seems like last condition(that causes warning to appear) should not be evaluated if projectId string is empty.