### PR TITLE
FillSpaceTool creates backfacing faces (Render camera is not valid)

### DIFF
--- a/dev/Code/Sandbox/Plugins/CryDesigner/Tools/Edit/FillSpaceTool.cpp
+++ b/dev/Code/Sandbox/Plugins/CryDesigner/Tools/Edit/FillSpaceTool.cpp
@@ -279,7 +279,7 @@ bool FillSpaceTool::FillHoleBasedOnSelectedElements()
 
     Matrix34 invWorldTM = GetBaseObject()->GetWorldTM().GetInverted();
 
-    const CCamera& camera = GetIEditor()->GetRenderer()->GetCamera();
+    const CCamera& camera = GetIEditor()->GetSystem()->GetViewCamera();
     BrushVec3 vLocalCameraNormal = ToBrushVec3(invWorldTM.TransformVector(camera.GetViewdir()));
     if (vLocalCameraNormal.Dot(plane.Normal()) > 0)
     {


### PR DESCRIPTION
1) Create designer object (Cube)
2) Delete few faces(one that is looking into positive X direction, another that is looking into opposite)
3) Recreate both faces. Face that is looking to X negative direction will face opposite from camera direction, and will be clipped.