### PR TITLE
Change destroy loop bounds in CryArray

### DIFF
--- a/dev/Code/CryEngine/CryCommon/CryArray.h
+++ b/dev/Code/CryEngine/CryCommon/CryArray.h
@@ -397,7 +397,7 @@ struct Array
     void destroy()
     {
         // Destroy in reverse order, to complement construction order.
-        for (iterator it = end(); it-- > begin(); )
+        for (iterator it = rbegin(); it > rend(); --it)
         {
             it->~T();
         }


### PR DESCRIPTION
Iterator end() point to an element after the last element in array, so calling destructor for it isn't secure.