### PR TITLE
Update values when changed for mesh asset and material override

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.cpp
@@ -280,7 +280,7 @@ namespace LmbrCentral
         m_renderOptions.m_attachedToEntityId = id;
     }
 
-    void MeshComponentRenderNode::OnAssetPropertyChanged()
+    AZ::u32 MeshComponentRenderNode::OnAssetPropertyChanged()
     {
         if (HasMesh())
         {
@@ -290,6 +290,7 @@ namespace LmbrCentral
         AZ::Data::AssetBus::Handler::BusDisconnect();
 
         CreateMesh();
+        return AZ::Edit::PropertyRefreshLevels::ValuesOnly;
     }
 
     void MeshComponentRenderNode::RefreshRenderState()

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.h
@@ -78,7 +78,7 @@ namespace LmbrCentral
         AZ::Data::Asset<AZ::Data::AssetData> GetMeshAsset() { return m_meshAsset; }
 
         //! Invoked in the editor when the user assigns a new asset.
-        void OnAssetPropertyChanged();
+        AZ::u32 OnAssetPropertyChanged();
 
         //! Render the mesh
         void RenderMesh(const struct SRendParams& inRenderParams, const struct SRenderingPassInfo& passInfo);


### PR DESCRIPTION
Issue:
When you change "Mesh asset" or "Material override" in the mesh component in the editor the strings don't update and shows the previous value.

Reproduce: 
Select an object (mesh)
Change material override. 
Change it again. 
-> string doesn't update (shows 'old' value in the editor)

(Yeah, I know... small bug :-) 