### PR TITLE
Alembic vertex geoscope

### DIFF
--- a/dev/Code/Tools/RC/ResourceCompilerABC/AlembicCompiler.cpp
+++ b/dev/Code/Tools/RC/ResourceCompilerABC/AlembicCompiler.cpp
@@ -1841,24 +1841,30 @@ bool AlembicCompiler::ComputeVertexHashes(std::vector<uint64>& abcVertexHashes, 
                 int32_t normalIndex = 0;
                 int32_t texcoordsIndex = 0;
 
-                if (bHasNormals && normalGeoScope == Alembic::AbcGeom::kFacevaryingScope)
+                if (bHasNormals)
                 {
-                    normalIndex = (*pFrameAbcNormalIndices)[currentIndexArraysIndex];
-                }
-                else
-                {
-                    AZ_Assert(normalGeoScope == Alembic::AbcGeom::kVertexScope, "If you implement more geoscopes, update this if/else statement");
-                    normalIndex = positionIndex;
+                    if (normalGeoScope == Alembic::AbcGeom::kFacevaryingScope)
+                    {
+                        normalIndex = (*pFrameAbcNormalIndices)[currentIndexArraysIndex];
+                    }
+                    else
+                    {
+                        AZ_Assert(normalGeoScope == Alembic::AbcGeom::kVertexScope, "If you implement more geoscopes, update this if/else statement");
+                        normalIndex = positionIndex;
+                    }
                 }
 
-                if (bHasTexcoords && texcoordGeoScope == Alembic::AbcGeom::kFacevaryingScope)
+                if (bHasTexcoords)
                 {
-                    texcoordsIndex = (*pFrameAbcTexcoordIndices)[currentIndexArraysIndex];
-                }
-                else
-                {
-                    AZ_Assert(texcoordGeoScope == Alembic::AbcGeom::kVertexScope, "If you implement more geoscopes, update this if/else statement.");
-                    texcoordsIndex = positionIndex;
+                    if (texcoordGeoScope == Alembic::AbcGeom::kFacevaryingScope)
+                    {
+                        texcoordsIndex = (*pFrameAbcTexcoordIndices)[currentIndexArraysIndex];
+                    }
+                    else
+                    {
+                        AZ_Assert(texcoordGeoScope == Alembic::AbcGeom::kVertexScope, "If you implement more geoscopes, update this if/else statement.");
+                        texcoordsIndex = positionIndex;
+                    }
                 }
 
                 const int32_t colorsIndex = frameColors.getIndex(currentIndexArraysIndex);
@@ -2025,24 +2031,30 @@ bool AlembicCompiler::CompileFullMesh(GeomCache::Mesh& mesh, const size_t curren
             int32_t normalIndex = 0;
             int32_t texcoordsIndex = 0;
 
-            if (bHasNormals && normalGeoScope == Alembic::AbcGeom::kFacevaryingScope)
+            if (bHasNormals)
             {
-                normalIndex = (*pAbcNormalIndices)[currentIndexArraysIndex];
-            }
-            else
-            {
-                AZ_Assert(normalGeoScope == Alembic::AbcGeom::kVertexScope, "If you implement more geoscopes, update this if/else statement");
-                normalIndex = positionIndex;
+                if (normalGeoScope == Alembic::AbcGeom::kFacevaryingScope)
+                {
+                    normalIndex = (*pAbcNormalIndices)[currentIndexArraysIndex];
+                }
+                else
+                {
+                    AZ_Assert(normalGeoScope == Alembic::AbcGeom::kVertexScope, "If you implement more geoscopes, update this if/else statement");
+                    normalIndex = positionIndex;
+                }
             }
 
-            if (bHasTexcoords && texcoordGeoScope == Alembic::AbcGeom::kFacevaryingScope)
+            if (bHasTexcoords)
             {
-                texcoordsIndex = (*pAbcTexcoordIndices)[currentIndexArraysIndex];
-            }
-            else
-            {
-                AZ_Assert(texcoordGeoScope == Alembic::AbcGeom::kVertexScope, "If you implement more geoscopes, update this if/else statement.");
-                texcoordsIndex = positionIndex;
+                if (texcoordGeoScope == Alembic::AbcGeom::kFacevaryingScope)
+                {
+                    texcoordsIndex = (*pAbcTexcoordIndices)[currentIndexArraysIndex];
+                }
+                else
+                {
+                    AZ_Assert(texcoordGeoScope == Alembic::AbcGeom::kVertexScope, "If you implement more geoscopes, update this if/else statement.");
+                    texcoordsIndex = positionIndex;
+                }
             }
 
 


### PR DESCRIPTION
second attempt: It seems stable now. I've been trying out several blend file I downloaded and it all seems to import correctly. If you could test max & maya imports on your side to make sure they still work. Should've left the original pr open but thought there would be more issues.

If you come across a bug, post the .abc file somewhere and I'll debug it. I'd rather have you expend your resources to improve other parts of the engine.

(original pr)
Background:
I was trying out the geometry cache component and I found out that it wouldn't process an animation I made in blender that I tried to export as an alembic file.

Issue:
The alembic part of the resource compiler only supported face-varying indexing while blender can export it as vertex indexing (Alembic::AbcGeom::kVertexScope vs Alembic::AbcGeom::kFacevaryingScope) 
  