### PR TITLE
use LyShine сursor in XConsole

### DIFF
--- a/dev/Code/CryEngine/CrySystem/XConsole.cpp
+++ b/dev/Code/CryEngine/CrySystem/XConsole.cpp
@@ -38,6 +38,8 @@
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzCore/std/string/conversions.h>
 
+#include <LyShine/Bus/UiCursorBus.h>
+
 //#define DEFENCE_CVAR_HASH_LOGGING
 
 static inline void AssertName(const char* szName)
@@ -1034,18 +1036,11 @@ void    CXConsole::ShowConsole(bool show, const int iRequestScrollMax)
 
     if (show && !m_bConsoleActive)
     {
-        AzFramework::InputSystemCursorRequestBus::EventResult(m_previousSystemCursorState,
-                                                              AzFramework::InputDeviceMouse::Id,
-                                                              &AzFramework::InputSystemCursorRequests::GetSystemCursorState);
-        AzFramework::InputSystemCursorRequestBus::Event(AzFramework::InputDeviceMouse::Id,
-                                                        &AzFramework::InputSystemCursorRequests::SetSystemCursorState,
-                                                        AzFramework::SystemCursorState::UnconstrainedAndVisible);
+        EBUS_EVENT(UiCursorBus, IncrementVisibleCounter);
     }
     else if (!show && m_bConsoleActive)
     {
-        AzFramework::InputSystemCursorRequestBus::Event(AzFramework::InputDeviceMouse::Id,
-                                                        &AzFramework::InputSystemCursorRequests::SetSystemCursorState,
-                                                        m_previousSystemCursorState);
+        EBUS_EVENT(UiCursorBus, DecrementVisibleCounter);
     }
 
     SetStatus(show);

--- a/dev/Code/CryEngine/CrySystem/XConsole.h
+++ b/dev/Code/CryEngine/CrySystem/XConsole.h
@@ -21,7 +21,6 @@
 #include "Timer.h"
 #include <AzFramework/Components/ConsoleBus.h>
 
-#include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
 #include <AzFramework/Input/Events/InputChannelEventListener.h>
 #include <AzFramework/Input/Events/InputTextEventListener.h>
 
@@ -389,7 +388,6 @@ private: // ----------------------------------------------------------
 
     ScrollDir                                               m_sdScrollDir;
 
-    AzFramework::SystemCursorState                              m_previousSystemCursorState;
     bool                                                        m_bConsoleActive;
     bool                                                        m_bActivationKeyEnable;
     bool                                                        m_bIsProcessingGroup;


### PR DESCRIPTION
In-case console is opened while system cursor is hidden/replaced with game cursor, system cursor remains invisible.