### PR TITLE
parse argc/argv

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -145,11 +145,6 @@ namespace AzFramework
         }
     }
     
-    Application::Application()
-    : Application(nullptr, nullptr)
-    {
-    }
-    
     Application::Application(int* argc, char*** argv)
         : m_appRootInitialized(false)
     {
@@ -157,7 +152,6 @@ namespace AzFramework
         m_appRoot[0] = '\0';
         m_assetRoot[0] = '\0';
         m_engineRoot[0] = '\0';
-        
 
         if ((argc) && (argv))
         {
@@ -317,11 +311,6 @@ namespace AzFramework
         {
             m_commandLine.Parse(*m_argC, *m_argV);
         }
-        else
-        {
-            m_commandLine.Parse();
-        }
-        
 
         systemEntity->Init();
         systemEntity->Activate();

--- a/dev/Code/Framework/AzFramework/AzFramework/Application/Application.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Application/Application.h
@@ -77,7 +77,6 @@ namespace AzFramework
          * see notes in GetArgC() and GetArgV() for details about the arguments.
          */
         Application(int* argc, char*** argv);  ///< recommended:  supply &argc and &argv from void main(...) here.
-        Application(); ///< for backward compatibility.  If you call this, GetArgC and GetArgV will return nullptr.
         ~Application();
 
         /**
@@ -88,7 +87,7 @@ namespace AzFramework
         * and making some assumptions.  Instead, we allow you to pass your args in from void main().
         * Another thing to notice here is that these are non-const pointers to the argc and argv values
         * instead of int, char**, these are int*, char***.  
-        * This is becuase some application layers (such as Qt) actually require that the ArgC and ArgV are modifiable, 
+        * This is because some application layers (such as Qt) actually require that the ArgC and ArgV are modifiable, 
         * as they actually patch them to add/remove command line parameters during initialization.
         * but also to highlight the fact that they are pointers to static memory that must remain relevant throughout the existence
         * of the Application object.

--- a/dev/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
+++ b/dev/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
@@ -20,7 +20,8 @@
 
 namespace AzGameFramework
 {
-    GameApplication::GameApplication()
+    GameApplication::GameApplication(int* argc, char ***argv)
+        : Application(argc, argv)
     {
     }
 

--- a/dev/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.h
+++ b/dev/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.h
@@ -27,7 +27,7 @@ namespace AzGameFramework
 
         AZ_CLASS_ALLOCATOR(GameApplication, AZ::SystemAllocator, 0);
 
-        GameApplication();
+        GameApplication(int* argc = nullptr, char*** argv = nullptr);
         ~GameApplication();
 
         void RegisterCoreComponents() override;

--- a/dev/Code/Launcher/DedicatedLauncher/Main.cpp
+++ b/dev/Code/Launcher/DedicatedLauncher/Main.cpp
@@ -225,7 +225,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
     int result = 0;
 
-    AzGameFramework::GameApplication gameApp;
+    AzGameFramework::GameApplication gameApp(&__argc, &__argv);
     {
         CEngineConfig engineCfg;
 

--- a/dev/Code/Launcher/LinuxLauncher/Main.cpp
+++ b/dev/Code/Launcher/LinuxLauncher/Main.cpp
@@ -290,9 +290,9 @@ static void InitStackTracer(const char* libPath)
 }
 
 //-------------------------------------------------------------------------------------
-int RunGame(const char*) __attribute__ ((noreturn));
+int RunGame(const char*, int, char**) __attribute__ ((noreturn));
 
-int RunGame(const char* commandLine)
+int RunGame(const char* commandLine, int argc = 0, char** argv = nullptr)
 {
     char exePath[ MAX_PATH];
     memset(exePath, 0, sizeof(exePath));
@@ -330,7 +330,7 @@ int RunGame(const char* commandLine)
     char configPath[AZ_MAX_PATH_LEN];
     AzGameFramework::GameApplication::GetGameDescriptorPath(configPath, engineCfg.m_gameFolder);
 
-    AzGameFramework::GameApplication gameApp;
+    AzGameFramework::GameApplication gameApp(&argc, &argv);
     AzGameFramework::GameApplication::StartupParameters gameAppParams;
 #ifdef AZ_MONOLITHIC_BUILD
     gameAppParams.m_createStaticModulesCallback = CreateStaticModules;
@@ -596,7 +596,7 @@ int main(int argc, char** argv)
     *q = 0;
     assert(q - cmdLine == cmdLength);
 
-    int result = RunGame(cmdLine);
+    int result = RunGame(cmdLine, argc, argv);
 
     return result;
 }

--- a/dev/Code/Launcher/WindowsLauncher/Main.cpp
+++ b/dev/Code/Launcher/WindowsLauncher/Main.cpp
@@ -360,7 +360,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
     char szExeFileName[AZ_MAX_PATH_LEN];
     InitRootDir(szExeFileName, AZ_MAX_PATH_LEN);
     int nRes = 0;
-    AzGameFramework::GameApplication gameApp;
+    AzGameFramework::GameApplication gameApp(&__argc, &__argv);
 
     {
         CEngineConfig engineCfg;


### PR DESCRIPTION
Currently argc and argv in AzFramework::Application  is always initialized with default values.

pass argc/argv from launcher (main) to Application, so that AzFramework::CommandLine could parse correct values.