### PR TITLE
GetChildByName method in TransformComponent

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Component/TransformBus.h
+++ b/dev/Code/Framework/AzCore/AzCore/Component/TransformBus.h
@@ -526,6 +526,12 @@ namespace AZ
         virtual void SetParentRelative(EntityId /*id*/) {}
 
         /**
+        * Searches child entity by name and returns it's ID.
+        * @return Child entity id or empty entity id(if child not found).
+        */
+        virtual AZ::EntityId GetChildByName(const AZStd::string& /*child name*/) { return AZ::EntityId(); };
+
+        /**
          * Returns the entity IDs of the entity's immediate children.
          * @return A vector that contains the entity IDs of the entity's immediate children.
          */

--- a/dev/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -835,6 +835,25 @@ namespace AzFramework
         return scale;
     }
 
+    AZ::EntityId TransformComponent::GetChildByName(const AZStd::string& entityName)
+    {
+        AZStd::vector<AZ::EntityId> children;
+        EBUS_EVENT_ID(GetEntityId(), AZ::TransformHierarchyInformationBus, GatherChildren, children);
+
+        for (AZ::EntityId childId : children)
+        {
+            AZStd::string childName;
+            EBUS_EVENT_RESULT(childName, AZ::ComponentApplicationBus, GetEntityName, childId);
+
+            if (entityName == childName)
+            {
+                return childId;
+            }
+        }
+
+        return AZ::EntityId();
+    }
+
     AZStd::vector<AZ::EntityId> TransformComponent::GetChildren()
     {
         AZStd::vector<AZ::EntityId> children;
@@ -1345,6 +1364,7 @@ namespace AzFramework
                     ->Attribute("Scale", AZ::Edit::Attributes::PropertyScale)
                 ->VirtualProperty("Scale", "GetLocalScale", "SetLocalScale")
                 ->Event("GetWorldScale", &AZ::TransformBus::Events::GetWorldScale)
+                ->Event("GetChildByName", &AZ::TransformBus::Events::GetChildByName)
                 ->Event("GetChildren", &AZ::TransformBus::Events::GetChildren)
                 ->Event("GetAllDescendants", &AZ::TransformBus::Events::GetAllDescendants)
                 ->Event("GetEntityAndAllDescendants", &AZ::TransformBus::Events::GetEntityAndAllDescendants)

--- a/dev/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
@@ -193,7 +193,7 @@ namespace AzFramework
         */
         void SetParentRelative(AZ::EntityId id) override;
 
-
+        AZ::EntityId GetChildByName(const AZStd::string& entityName) override;
         AZStd::vector<AZ::EntityId> GetChildren() override;
         AZStd::vector<AZ::EntityId> GetAllDescendants() override;
         AZStd::vector<AZ::EntityId> GetEntityAndAllDescendants() override;


### PR DESCRIPTION
GetChildByName method is required to be able to manipulate entities inside slice(which has script canvas) if slice was spawned dynamically, and there is no possibility to link in advance(unlike static entities on level)