### PR TITLE
Fix NANs produced by particles when Facing is set to Free

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/ParticleRender.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/ParticleRender.cpp
@@ -886,7 +886,7 @@ void CParticle::GetRenderMatrix(Vec3& vX, Vec3& vY, Vec3& vZ, Vec3& vT, const Qu
         float sizeY = params.fSizeY.GetValueFromMod(m_BaseMods.SizeY, fRelativeAge);
         if (abs(sizeY) < 0.0001f || abs(m_sizeScale.y) < 0.0001f)
         {
-            aspect = 0;
+            aspect = 1.0f;
         }
         else
         {


### PR DESCRIPTION
NANs produced particles shader when Facing is set to Free. Setting Aspect to 0 makes basis vector vX == 0.