### PR TITLE
Entity pick control cancelation

### DIFF
--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEntityIdCtrl.cpp
@@ -107,6 +107,7 @@ namespace AzToolsFramework
             EditorPickModeRequests::Bus::Handler::BusConnect();
         }
         EBUS_EVENT(AzToolsFramework::EditorPickModeRequests::Bus, StartObjectPickMode);
+        m_pickButton->setChecked(true);
     }
 
     void PropertyEntityIdCtrl::StopObjectPickMode()
@@ -115,6 +116,7 @@ namespace AzToolsFramework
         {
             EditorPickModeRequests::Bus::Handler::BusDisconnect();
         }
+        m_pickButton->setChecked(false);
     }
 
     void PropertyEntityIdCtrl::OnPickModeSelect(AZ::EntityId id)

--- a/dev/Code/Sandbox/Editor/CryEdit.cpp
+++ b/dev/Code/Sandbox/Editor/CryEdit.cpp
@@ -4100,6 +4100,8 @@ void CCryEditApp::OnEditClone()
 
 void CCryEditApp::OnEditEscape()
 {
+    EBUS_EVENT(AzToolsFramework::EditorPickModeRequests::Bus, StopObjectPickMode);
+
     CEditTool* pEditTool = GetIEditor()->GetEditTool();
     // Abort current operation.
     if (pEditTool)


### PR DESCRIPTION
Code proposal that fixes few issues:
1) Pick entity button toggle state is not changed after entity picked
2) It is not possible to cancel pick process(in ScriptCanvas 'Variable')