### PR TITLE
NetBindingSliceInstantiationHandler

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.cpp
@@ -45,6 +45,16 @@ namespace AzFramework
         }
     }
 
+    NetBindingSliceInstantiationHandler::~NetBindingSliceInstantiationHandler()
+    {
+        // m_bindRequests in NetBindingSystemImpl could be cleaned before slice instantiation finished
+        if (!IsBindingComplete())
+        {
+            AzFramework::SliceInstantiationResultBus::Handler::BusDisconnect();
+            EBUS_EVENT(GameEntityContextRequestBus, CancelDynamicSliceInstantiation, m_ticket);
+        }
+    }
+
     void NetBindingSliceInstantiationHandler::InstantiateEntities()
     {
         if (m_sliceAssetId.IsValid())

--- a/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.h
@@ -43,6 +43,8 @@ namespace AzFramework
         : public SliceInstantiationResultBus::Handler
     {
     public:
+        virtual ~NetBindingSliceInstantiationHandler();
+
         void InstantiateEntities();
         bool IsInstantiated();
         bool IsBindingComplete();


### PR DESCRIPTION
fix crash in NetBindingSliceInstantiationHandler, after disconnect from dedicated server before all assets was instantiated on remotes