### PR TITLE
8) Fix for UIAnimTrack memory leak

### DIFF
--- a/dev/Gems/LyShine/Code/Source/Animation/2DSpline.h
+++ b/dev/Gems/LyShine/Code/Source/Animation/2DSpline.h
@@ -57,6 +57,7 @@ namespace UiSpline
             m_curr = 0;
             m_rangeStart = 0;
             m_rangeEnd = 0;
+            m_refCount = 0;
         }
 
         virtual ~TSpline() {};
@@ -276,6 +277,25 @@ namespace UiSpline
                         t = spline::fast_fmod(t, endtime);
                     }
                 }
+            }
+        }
+
+    private:
+        int m_refCount;
+
+    public:
+
+        inline void add_ref()
+        {
+            ++m_refCount;
+        };
+
+        inline void release()
+        {
+            AZ_Assert(m_refCount > 0, "Reference count logic error, trying to decrement reference when refCount is 0");
+            if (--m_refCount == 0)
+            {
+                delete this;
             }
         }
     };

--- a/dev/Gems/LyShine/Code/Source/Animation/AnimSplineTrack.h
+++ b/dev/Gems/LyShine/Code/Source/Animation/AnimSplineTrack.h
@@ -41,7 +41,7 @@ public:
     }
     ~TUiAnimSplineTrack()
     {
-        delete m_spline;
+        m_spline.reset();
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -63,7 +63,7 @@ public:
     virtual void GetKeyValueRange(float& fMin, float& fMax) const { fMin = m_fMinKeyValue; fMax = m_fMaxKeyValue; };
     virtual void SetKeyValueRange(float fMin, float fMax){ m_fMinKeyValue = fMin; m_fMaxKeyValue = fMax; };
 
-    ISplineInterpolator* GetSpline() const { return m_spline; };
+    ISplineInterpolator* GetSpline() const { return m_spline.get(); };
 
     virtual bool IsKeySelected(int key) const
     {
@@ -367,7 +367,7 @@ private:
     int m_refCount;
 
     typedef UiSpline::TrackSplineInterpolator<ValueType> Spline;
-    Spline* m_spline;
+    AZStd::intrusive_ptr<Spline> m_spline;
     ValueType m_defaultValue;
 
     //! Keys of float track.


### PR DESCRIPTION
# UIAnimTrack Memory Leak Fix

### Description
Added a version converter for TUiAnimSplineTrack.

When TUiAnimSplineTrack<Vec2> is deserialized, a spline instance is first created in the TUiAnimSplineTrack<Vec2> constructor _(via AllocSpline())_, then the pointer is overwritten when "Spline" field is deserialized. 

To prevent a memory leak, m_spline is now an intrusive pointer, so that if/when the "Spline" field is deserialized, the old object will be deleted.