### PR TITLE
Fix for Lua netSynced properties.

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
@@ -671,6 +671,13 @@ namespace AzFramework
             lua_pop(lua, 1); // remove the OnActivate result
         }
 
+        if (m_netBindingTable)
+        {
+            // Set the flag indicating that the owning entity is active. 
+            // This means that from this point on DataSet OnNewValue can be sent.
+            m_netBindingTable->SetIsOwningEntityActive(true);
+        }
+
         lua_pop(lua, 2); // remove the base property table and base script table
     }
 
@@ -681,6 +688,13 @@ namespace AzFramework
     {
         if (m_table != LUA_NOREF)
         {
+            if (m_netBindingTable)
+            {
+                // Set the flag indicating that the owning entity is no longer active. 
+                // This means that from this point on DataSet OnNewValue should not be sent.
+                m_netBindingTable->SetIsOwningEntityActive(false);
+            }
+
             lua_State* lua = m_context->NativeContext();
             LSV_BEGIN(lua, 0);
 

--- a/dev/Code/Framework/AzFramework/AzFramework/Script/ScriptNetBindings.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Script/ScriptNetBindings.h
@@ -171,6 +171,8 @@ namespace AzFramework
         AZ::ScriptContext* GetScriptContext() const;
 
         bool IsMaster() const;
+        void SetIsOwningEntityActive(bool isActive);
+        bool IsOwningEntityActive() const;
 
         //////////////////////////////////////////////////////////////////////////////////////////////////////
         // DataSet Functionality
@@ -236,6 +238,8 @@ namespace AzFramework
 
         NetworkedTableMap         m_networkedTable;
         RPCHelperMap              m_rpcHelperMap;
+
+        bool m_isOwnerActivated;
     };
 
     // Typedeffing out the RPC and DataSet definitions.
@@ -298,6 +302,13 @@ namespace AzFramework
 
         // Called from teh Proxy. Will Assign the TableValue to the DataSet that contains the target property        
         void AssignDataSetForProperty(ScriptNetBindingTable::NetworkedTableValue& helper, AZ::ScriptProperty* targetProperty);
+
+        // Called from the Proxy when the script chunk is assigned to ScriptNetBindingTable, and when a new property is registered.
+        // This will initialise NetworkedTableValue with the current property (if there is one already available).
+        // This ensures that we start using proper (not shimmed) properties as soon as they are available (rather than after they have changed at least once).
+        // Without this fix, if property doesn't change after a client connected to the server, the client
+        // will never use the actual property value, and happily use the shimmed property value instead).
+        bool AssignDataSetIfAvailable(const AZStd::string& valueName, ScriptNetBindingTable::NetworkedTableValue& tableValue);
 
         // Only called inside of an assert, checks that the DataSet that the targetProperty is in is the same as the assumedDataSet
         // Used to confirm that we don't get a confusion between master/proxy about which ScriptProperty is assigned to which DataSet.


### PR DESCRIPTION
# Lua NetSynced Properties Fix

### Description
Lua netSynced properties were initialized on first dataset update, that means if a dataset changed value infrequently (i.e. its value was set once on server in OnActivate() to a different value than the one in the properties section in the script), the clients would never see it.

ScriptComponentReplicaChunk::AssignDataSetIfAvailable(const AZStd::string& valueName, ScriptNetBindingTable::NetworkedTableValue& tableValue) is called from the Proxy when the script chunk is assigned to ScriptNetBindingTable, and when a new property is registered.
This will initialize NetworkedTableValue with the current property (if there is one already available).
This ensures that we start using proper, not shimmed, properties as soon as they are available rather than after they have changed at least once.
Without this fix, if a property doesn't change after a client connected to the server, the client will never use the actual property value, and happily use the shimmed property value instead.

### Tested against
LY 1.12 D.R.G. Initiative.