### PR TITLE
6) Fix for crash in UI system

### DIFF
--- a/dev/Gems/LyShine/Code/Source/UiSliderComponent.cpp
+++ b/dev/Gems/LyShine/Code/Source/UiSliderComponent.cpp
@@ -101,7 +101,7 @@ void UiSliderComponent::SetValue(float value)
     }
 
     float valueRange = fabsf(m_maxValue - m_minValue);
-    float unitValue = fabsf(m_value - m_minValue) / valueRange;
+    float unitValue = valueRange > 0.0f ? (fabsf(m_value - m_minValue) / valueRange) : 0.0f;
 
     if (m_fillEntity.IsValid())
     {


### PR DESCRIPTION
# Fix For UI Slider Division By Zero

### Description
Fix for division by zero when a slider's minimum and maximum initial values are set to 0.