### PR TITLE
18) Add Unordered Map Lua Reflection

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
+++ b/dev/Code/Framework/AzCore/AzCore/RTTI/AzStdOnDemandReflection.inl
@@ -528,6 +528,11 @@ namespace AZ
     {
         using ContainerType = AZStd::unordered_map<Key, MappedType, Hasher, EqualKey, Allocator>;
 
+        static void Insert(ContainerType* thisPtr, Key& key, MappedType& value)
+        {
+            (*thisPtr)[key] = value;
+        }
+
         static void Reflect(ReflectContext* context)
         {
             BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context);
@@ -535,7 +540,11 @@ namespace AZ
             {
                 behaviorContext->Class<ContainerType>()
                     ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                    ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::ScriptOwn);
+                    ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::ScriptOwn)
+                    ->template Method<MappedType&(ContainerType::*)(const Key&)>("at", &ContainerType::at)
+                    ->Method("insert", &Insert)
+                    ->Method("size", [](ContainerType* thisPtr) { return aznumeric_cast<int>(thisPtr->size()); })
+                        ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::Length);
             }
         }
     };


### PR DESCRIPTION
# Add Reflection of Unordered_map to Lua.

### Description
This is a very simple productivity improvement to Lua scripting; reflecting some unordered map functions.

### Usage
```c++
	// Alias an unordered_map so Lua scripts can use ExampleUnorderedMapInitialiser instead of unordered_map_xxx() directly.
	using ExampleUnorderedMapInitialiser = AZStd::unordered_map<AZStd::string, size_t>;

	// Reflect this alias to the behavior context.
	behaviorContext->Method("ExampleUnorderedMapInitialiser", []() -> ExampleUnorderedMapInitialiser{
		return ExampleUnorderedMapInitialiser();
	});
```

```Lua
	-- Create a map and add some key/value pairs
	local exampleMap = ExampleUnorderedMapInitialiser ()
	exampleMap:insert("Key1", 1)
	exampleMap:insert("Key2", 2)

	-- Read it out again
	local value1 = exampleMap:at("Key1")
	local value2 = exampleMap:at("Key2")
	Debug.Log(tostring(value1) .. tostring(value2)) -- Output: 12
```
