### PR TITLE
38) Add "Collapse All" button to the Property Editor UI

### DIFF
--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1100,12 +1100,9 @@ namespace AzToolsFramework
     {
         if (m_gui && m_gui->m_collapseComponentsButton)
         {
-            static const char* collapseAllText = "Collapse All";
-            static const char* expandAllText = "Expand All";
-
             m_componentsExpanded = !m_componentsExpanded;
 
-            m_gui->m_collapseComponentsButton->setText(m_componentsExpanded ? collapseAllText : expandAllText);
+            m_gui->m_collapseComponentsButton->setText(m_componentsExpanded ? tr("Collapse All") : tr("Expand All"));
             for (auto componentEditor : m_componentEditors)
             {
                 componentEditor->SetExpanded(m_componentsExpanded);

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -209,6 +209,7 @@ namespace AzToolsFramework
             const AZStd::vector<AZ::ComponentServiceType>& serviceFilter);
 
         QAction* m_actionToAddComponents;
+        QAction* m_actionToCollapseAllComponents;
         QAction* m_actionToDeleteComponents;
         QAction* m_actionToCutComponents;
         QAction* m_actionToCopyComponents;
@@ -403,6 +404,8 @@ namespace AzToolsFramework
         QIcon m_emptyIcon;
         QIcon m_clearIcon;
 
+        bool m_componentsExpanded;
+
         private slots:
         void OnPropertyRefreshRequired(); // refresh is needed for a property.
         void UpdateContents();
@@ -417,6 +420,7 @@ namespace AzToolsFramework
         void ClearSearchFilter();
 
         bool SelectedEntitiesAreFromSameSourceSliceEntity() const;
+        void OnCollapseAllComponents();
     };
 
 }

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.ui
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.ui
@@ -276,6 +276,13 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QPushButton" name="m_collapseComponentsButton">
+         <property name="text">
+          <string>Collapse All</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>


### PR DESCRIPTION
# Add "Collapse All" Button To Editor Property UI

### Description
This is actually one of the simplest, yet one of my favorite, additions to the Lumberyard UI; adding a "Collapse All" button to the UI. 

The "Collapse All" button is incredibly useful when working on a component entity with a large number of components on it. For example, our player character has around thirty components on it. This means that to find the component you wish to change, there is a lot of scrolling required and even when you find the correct component there is a lot of visual clutter. If you wish to edit a couple of components at once, being able to collapse all but the ones you are interested in reduces the amount of excess noise.

Admittedly this modification is a bit subjective but I can confirm that our lead designer approves of this feature and uses it over the search bar!

Hope you like it.

### Check it out in action
![expandallgif](https://user-images.githubusercontent.com/36986799/37462687-bfb06866-284a-11e8-9903-82db000fd285.gif)