### PR TITLE
2) Fix for AssetProcessorManager thread-safety

### DIFF
--- a/dev/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/dev/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -371,6 +371,11 @@ Q_SIGNALS:
         AZStd::multimap<QString, QString> m_dependsOnSourceToSourceMap; //multimap since different source files can declare dependency on the same file
         AZStd::multimap <AZ::Uuid, QString > m_dependsOnSourceUuidToSourceMap; //multimap since different source files can declare dependency on the same file
         bool m_SourceDependencyInfoNeedsUpdate = false;
+		
+	// Added mutex & wait condition used when IsIdle() is called from a thread different than the asset processor worker.
+    private:
+        QMutex m_idleMutex;
+        QWaitCondition m_idleWaitable;
     };
 } // namespace AssetProcessor
 


### PR DESCRIPTION
# AssetProcessorManager::IsIdle is not thread-safe

### Description
Modified AssetProcessorManager::IsIdle to make it (more) thread-safe and mitigate against un-defined behavior.

IsIdle() is normally called from the AssetProcessorManager's worker thread only, however, in batch mode, it is also called from the main thread, making m_filesToExamine.isEmpty(), m_activeFiles.isEmpty(), etc. not safe.
The solution presented is not pretty, but it avoids locking when IsIdle() is called from the worker, which occurs pretty much constantly, whereas IsIdle() on the main thread is called infrequently, only in batch mode, when OnBecameIdle signal is emitted.

### Tested against
LY 1.12 StarterGame,
LY 1.12 D.R.G. Initiative.