### PR TITLE
31) Fix for numerous chatplay nodes

### DIFF
--- a/dev/Gems/ChatPlay/Code/Source/ChatPlay/ChatPlay.cpp
+++ b/dev/Gems/ChatPlay/Code/Source/ChatPlay/ChatPlay.cpp
@@ -1238,7 +1238,7 @@ namespace ChatPlay
                 RegisterOptions();
             }
         }
-        return static_cast<bool>(channel);
+        return !m_channel.expired();    ///< Fix for bad logic when determining the return value of SetChannel.
     }
 
     void ChatPlayVoteImpl::Visit(const AZStd::function<void(VoteOption& option)>& visitor)

--- a/dev/Gems/ChatPlay/Code/Source/FlowGraph/FlowChatPlayNodes.cpp
+++ b/dev/Gems/ChatPlay/Code/Source/FlowGraph/FlowChatPlayNodes.cpp
@@ -163,9 +163,9 @@ namespace ChatPlay
         CallbackToken m_callbackToken;
 
         // Cache connection state flags so we can ensure edge-triggered behavior
-        bool m_connectedState;
-        bool m_connectingState;
-        bool m_errorState;
+        bool m_connectedState = false;
+        bool m_connectingState = false;
+        bool m_errorState = false;
 
         // Callback used with IChatChannel
         void OnConnectionStateChange(ConnectionState connectionState);
@@ -291,19 +291,29 @@ namespace ChatPlay
 
         if (m_connectedState != connected)
         {
-            ActivateOutput<bool>(&m_actInfo, OutputPorts::OutputPorts_Connected, connected);
+            if (connected)
+            {
+                ActivateOutput<bool>(&m_actInfo, OutputPorts::OutputPorts_Connected, connected);
+            }
             m_connectedState = connected;
         }
 
         if (m_connectingState != connecting)
         {
-            ActivateOutput<bool>(&m_actInfo, OutputPorts::OutputPorts_Connecting, connecting);
+            if (connecting)
+            {
+                ActivateOutput<bool>(&m_actInfo, OutputPorts::OutputPorts_Connecting, connecting);
+            }
             m_connectingState = connecting;
+
         }
 
         if (m_errorState != error)
         {
-            ActivateOutput<bool>(&m_actInfo, OutputPorts::OutputPorts_Error, error);
+            if (error)
+            {
+                ActivateOutput<bool>(&m_actInfo, OutputPorts::OutputPorts_Error, error);
+            }
             m_errorState = error;
         }
     }
@@ -460,19 +470,9 @@ namespace ChatPlay
             AZStd::string channelId = GetPortString(pActInfo, InputPorts_Channel).c_str();
             AZStd::string keyword = GetPortString(pActInfo, InputPorts_Keyword).c_str();
 
-            bool channelExists = false;
-            ChatPlayRequestBus::BroadcastResult(channelExists, &ChatPlayRequestBus::Events::CreateChannel, m_channelId);
-
-            if (channelExists)
-            {
-                SetChatChannel(channelId);
-                SetKeyword(keyword);
-            }
-            else
-            {
-                ActivateOutput<bool>(&m_actInfo, OutputPorts::OutputPorts_Error, true);
-                CryLogAlways("Warning: ChatPlay is disabled or not available on this platform.");
-            }
+            // Fix for keyword nodes creating an empty channel when they initialise
+            SetChatChannel(channelId);
+            SetKeyword(keyword);
 
             m_signalCount = GetPortInt(pActInfo, InputPorts_Reset);
 
@@ -489,9 +489,10 @@ namespace ChatPlay
 
         case eFE_Activate:
 
+            // Fix for keyword nodes creating an empty channel when they initialise
             // Check if the ChatChannel exists
-            bool channelExists = false;
-            ChatPlayRequestBus::BroadcastResult(channelExists, &ChatPlayRequestBus::Events::CreateChannel, m_channelId);
+            //bool channelExists = false;
+            //ChatPlayRequestBus::BroadcastResult(channelExists, &ChatPlayRequestBus::Events::CreateChannel, m_channelId);
 
             if (IsPortActive(pActInfo, InputPorts_Channel))
             {

--- a/dev/Gems/ChatPlay/Code/Source/FlowGraph/FlowChatPlayVoteNodes.cpp
+++ b/dev/Gems/ChatPlay/Code/Source/FlowGraph/FlowChatPlayVoteNodes.cpp
@@ -630,7 +630,7 @@ namespace ChatPlay
                     };
                     AZStd::sort(options.begin(), options.end(), countComparator);
 
-                    auto it = options.rbegin();
+                    auto it = options.begin(); ///< Voting results were being delivered in reverse order due to sorting highest -> lowest AND using a reverse iterator
 
                     for (int i = 0; i < 4; ++i, ++it)
                     {


### PR DESCRIPTION
# Chatplay Fixes

### Description

- Fix for bad logic when determining the return value of SetChannel.
- Fix for un-initialized variables in flow nodes.
- Fixed logic in connection state tracking.
- Fix for keyword nodes creating an empty channel when they initialize.
- Fix for voting awarding the losing team instead of the winning team.
