### PR TITLE
Fix an AZ Input Related Memory Leak.

### DIFF
--- a/dev/Code/CryEngine/CrySystem/System.h
+++ b/dev/Code/CryEngine/CrySystem/System.h
@@ -35,6 +35,8 @@
 
 #include "CheatProtection.h"
 
+#include <AzCore/std/containers/vector.h>
+
 struct IConsoleCmdArgs;
 class CServerThrottle;
 struct ICryFactoryRegistryImpl;
@@ -1140,6 +1142,8 @@ protected: // -------------------------------------------------------------
     std::vector<IWindowMessageHandler*> m_windowMessageHandlers;
     bool m_initedOSAllocator = false;
     bool m_initedSysAllocator = false;
+
+    AZStd::vector<AZ::u8> m_rawInputDataBuffer; ///< using AZStd::vector as a growable buffer for storing bytes returned by ::GetRawInputData()
 };
 
 /*extern static */ bool QueryModuleMemoryInfo(SCryEngineStatsModuleInfo& moduleInfo, int index);

--- a/dev/Code/Sandbox/Editor/Core/QtEditorApplication.cpp
+++ b/dev/Code/Sandbox/Editor/Core/QtEditorApplication.cpp
@@ -370,13 +370,17 @@ namespace Editor
             const UINT rawInputHeaderSize = sizeof(RAWINPUTHEADER);
             GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, NULL, &rawInputSize, rawInputHeaderSize);
 
-            LPBYTE rawInputBytes = new BYTE[rawInputSize];
-            CRY_ASSERT(rawInputBytes);
+            // Using AZStd::vector as a growable buffer for storing bytes returned by ::GetRawInputData().
+            // Previously a new array was dynamically allocated here, and never deleted.
+            if (rawInputSize > m_rawInputDataBuffer.size())
+            {
+                m_rawInputDataBuffer.resize_no_construct(rawInputSize);
+            }
 
-            const UINT bytesCopied = GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, rawInputBytes, &rawInputSize, rawInputHeaderSize);
+            const UINT bytesCopied = GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, m_rawInputDataBuffer.data(), &rawInputSize, rawInputHeaderSize); ///< replaced the rawInputBytes parameter with m_rawInputDataBuffer.data()
             CRY_ASSERT(bytesCopied == rawInputSize);
 
-            RAWINPUT* rawInput = (RAWINPUT*)rawInputBytes;
+            RAWINPUT* rawInput = (RAWINPUT*)m_rawInputDataBuffer.data(); ///< replaced the rawInputBytes parameter with m_rawInputDataBuffer.data()
             CRY_ASSERT(rawInput);
 
             AzFramework::RawInputNotificationBusWin::Broadcast(&AzFramework::RawInputNotificationsWin::OnRawInputEvent, *rawInput);

--- a/dev/Code/Sandbox/Editor/Core/QtEditorApplication.h
+++ b/dev/Code/Sandbox/Editor/Core/QtEditorApplication.h
@@ -24,6 +24,8 @@
 
 #include <AzCore/UserSettings/UserSettingsProvider.h>
 
+#include <AzCore/std/containers/vector.h>
+
 class QFileInfo;
 typedef QList<QFileInfo> QFileInfoList;
 class QByteArray;
@@ -139,5 +141,7 @@ namespace Editor
         bool m_activatedLocalUserSettings = false;
 
         QScopedPointer<AZ::Entity> m_qtEntity;
+
+        AZStd::vector<AZ::u8> m_rawInputDataBuffer; ///< using AZStd::vector as a growable buffer for storing bytes returned by ::GetRawInputData()
     };
 } // namespace editor


### PR DESCRIPTION
## Fix an AZ Input Related Memory Leak.

### Description
Use AZStd::vector as a growable buffer for storing bytes returned by ::GetRawInputData(). 
Previously a new array was dynamically allocated, and never deleted.