### PR TITLE
23) Add text input clipboard support

### DIFF
--- a/dev/Gems/LyShine/Code/Source/UiClipboard.cpp
+++ b/dev/Gems/LyShine/Code/Source/UiClipboard.cpp
@@ -1,0 +1,57 @@
+// UiClipboard is responsible setting and getting clipboard data for the UI elements in a platform-independent way.
+
+#include "StdAfx.h"
+#include "UiClipboard.h"
+#include <AzCore/PlatformIncl.h>
+#include <StringUtils.h>
+
+bool UiClipboard::SetText(const AZStd::string& text)
+{
+    bool success = false;
+#if defined(WIN32)
+    if (OpenClipboard(nullptr))
+    {
+        if (EmptyClipboard())
+        {
+            if (text.length() > 0)
+            {
+                auto wstr = CryStringUtils::UTF8ToWStr(text.c_str());
+                const SIZE_T buffSize = (wstr.size() + 1) * sizeof(WCHAR);
+                if (HGLOBAL hBuffer = GlobalAlloc(GMEM_MOVEABLE, buffSize))
+                {
+                    auto buffer = static_cast<WCHAR*>(GlobalLock(hBuffer));
+                    memcpy_s(buffer, buffSize, wstr.data(), wstr.size() * sizeof(wchar_t));
+                    buffer[wstr.size()] = WCHAR(0);
+                    GlobalUnlock(hBuffer);
+                    SetClipboardData(CF_UNICODETEXT, hBuffer); // Clipboard now owns the hBuffer
+                    success = true;
+                }
+            }
+        }
+        CloseClipboard();
+    }
+#else
+    // Do nothing. For now we only support Windows, and don't want errors/warnings during Linux dedicated server compilation
+#endif
+    return success;
+}
+
+AZStd::string UiClipboard::GetText()
+{
+    AZStd::string outText;
+#if defined(WIN32)
+    if (OpenClipboard(nullptr))
+    {
+        if (HANDLE hText = GetClipboardData(CF_UNICODETEXT))
+        {
+            const WCHAR* text = static_cast<const WCHAR*>(GlobalLock(hText));
+            outText = CryStringUtils::WStrToUTF8(text);
+            GlobalUnlock(hText);
+        }
+        CloseClipboard();
+}
+#else
+    // Do nothing. For now we only support Windows, and don't want errors/warnings during Linux dedicated server compilation
+#endif
+    return outText;
+}

--- a/dev/Gems/LyShine/Code/Source/UiClipboard.h
+++ b/dev/Gems/LyShine/Code/Source/UiClipboard.h
@@ -1,0 +1,12 @@
+#pragma once
+// UiClipboard is responsible setting and getting clipboard data for the UI elements in a platform-independent way.
+
+#include <AzCore/std/string/string.h>
+
+class UiClipboard
+{
+public:
+    // UiClipboard strings are UTF8
+    static bool SetText(const AZStd::string& text);
+    static AZStd::string GetText();
+};

--- a/dev/Gems/LyShine/Code/Source/UiTextInputComponent.h
+++ b/dev/Gems/LyShine/Code/Source/UiTextInputComponent.h
@@ -211,4 +211,6 @@ private: // data
     bool m_isPasswordField;             //!< True if m_textEntity should be treated as a password field, false otherwise
 
     bool m_clipInputText;               //!< True if input text should be visually clipped to child text element, false otherwise.
+
+    bool m_enableClipboard;             //!< True if copy/cut/paste should be supported, false otherwise.
 };

--- a/dev/Gems/LyShine/Code/lyshine.waf_files
+++ b/dev/Gems/LyShine/Code/lyshine.waf_files
@@ -41,7 +41,7 @@
             "Source/UiDropdownComponent.cpp",
             "Source/UiDropdownComponent.h",
             "Source/UiDropdownOptionComponent.cpp",
-            "Source/UiDropdownOptionComponent.h", 
+            "Source/UiDropdownOptionComponent.h",
             "Source/UiDynamicLayoutComponent.cpp",
             "Source/UiDynamicLayoutComponent.h",
             "Source/UiDynamicScrollBoxComponent.cpp",
@@ -107,8 +107,10 @@
             "Source/UiTooltipDisplayComponent.cpp",
             "Source/UiTooltipDisplayComponent.h",
             "Source/UiTransform2dComponent.cpp",
-            "Source/UiTransform2dComponent.h"
-		],
+            "Source/UiTransform2dComponent.h",
+            "Source/UiClipboard.cpp",
+            "Source/UiClipboard.h"
+        ],
         "Source/Sprite Support":
         [
             "Source/Sprite.cpp",


### PR DESCRIPTION
## Add UiClipboard

### Description 
Usability feature - added clipboard support for the UiTextInput LyShine component.
On Windows, UiTextInput now supports cut, copy, and paste and functions.