### PR TITLE
22) Fix for dynamic module initialization problems

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Module/DynamicModuleHandle.h
+++ b/dev/Code/Framework/AzCore/AzCore/Module/DynamicModuleHandle.h
@@ -99,6 +99,15 @@ namespace AZ
      * to find in a dynamic module.
      */
 
+     /// \code
+     /// extern "C" AZ_DLL_EXPORT
+     /// bool IsInitializedDynamicModule()
+     /// \endcode
+     /// Used to determine if a dynamic module that is loaded is initialized, modules auto laoded by the OS may not be initialized
+     /// Implementations should return true if initialized, false otherwise
+    using IsInitializedDynamicModuleFunction = bool(*)();
+    const char IsInitializedDynamicModuleFunctionName[] = "IsInitializedDynamicModule";
+    
     /// \code
     /// extern "C" AZ_DLL_EXPORT
     /// void InitializeDynamicModule(void* sharedEnvironment)

--- a/dev/Code/Framework/AzCore/AzCore/Module/Environment.h
+++ b/dev/Code/Framework/AzCore/AzCore/Module/Environment.h
@@ -646,14 +646,26 @@ namespace AZ
 
 #ifdef AZ_MONOLITHIC_BUILD
 #define AZ_DECLARE_MODULE_INITIALIZATION
+#define AZ_DEFAULT_MODDULE_IS_INITIALIZED_METHOD        ///< Add dummy define for monolithic builds
 #else
+
+  /// Default implementation for dll IsInitialized function
+  /// For more details see:
+  /// \ref AZ::IsInitializedDynamicModuleFunction
+#define AZ_DEFAULT_MODDULE_IS_INITIALIZED_METHOD \
+    extern "C" AZ_DLL_EXPORT bool IsInitializedDynamicModule() \
+    { \
+        return AZ::Internal::EnvironmentInterface::s_environment != nullptr; \
+    }
 
 /// Default implementations of functions invoked upon loading a dynamic module.
 /// For dynamic modules which define a \ref AZ::Module class, use \ref AZ_DECLARE_MODULE_CLASS instead.
 ///
 /// For more details see:
 /// \ref AZ::InitializeDynamicModuleFunction, \ref AZ::UninitializeDynamicModuleFunction
+/// Auto included default IsInitialized function in to all AZ modules
 #define AZ_DECLARE_MODULE_INITIALIZATION \
+        AZ_DEFAULT_MODDULE_IS_INITIALIZED_METHOD \
     extern "C" AZ_DLL_EXPORT void InitializeDynamicModule(void* env) \
     { \
         AZ_Assert(!AZ::Internal::EnvironmentInterface::s_environment, "This module already has an attached environment"); \

--- a/dev/Code/Framework/AzCore/Tests/DLLMainTest.cpp
+++ b/dev/Code/Framework/AzCore/Tests/DLLMainTest.cpp
@@ -107,6 +107,12 @@ extern "C" AZ_DLL_EXPORT void DestroyDLLTestVirtualClass()
 }
 //////////////////////////////////////////////////////////////////////////
 
+/// Added IsInitialized function to the test dll
+extern "C" AZ_DLL_EXPORT bool IsInitializedDynamicModule()
+{
+    AZ_Printf("DLL", "IsInitializedDynamicModule called");
+    return AZ::Internal::EnvironmentInterface::s_environment != nullptr;
+}
 
 extern "C" AZ_DLL_EXPORT void InitializeDynamicModule(void* azEnvironmentInstance)
 {

--- a/dev/Code/Tools/SceneAPI/FbxSceneBuilder/DllMain.cpp
+++ b/dev/Code/Tools/SceneAPI/FbxSceneBuilder/DllMain.cpp
@@ -33,6 +33,8 @@
 static AZ::SceneAPI::FbxSceneImporter::FbxImportRequestHandler* g_fbxImporter = nullptr;
 static AZStd::vector<AZ::ComponentDescriptor*> g_componentDescriptors;
 
+AZ_DEFAULT_MODDULE_IS_INITIALIZED_METHOD    ///< Add default IsInitialized function to the dll
+
 extern "C" AZ_DLL_EXPORT void InitializeDynamicModule(void* env)
 {
     using namespace AZ::SceneAPI;

--- a/dev/Code/Tools/SceneAPI/SceneCore/DllMain.cpp
+++ b/dev/Code/Tools/SceneAPI/SceneCore/DllMain.cpp
@@ -90,6 +90,8 @@ public:
     }
 };
 
+AZ_DEFAULT_MODDULE_IS_INITIALIZED_METHOD    ///< Add default IsInitialized function to the dll
+
 extern "C" AZ_DLL_EXPORT void InitializeDynamicModule(void* env)
 {
     AZ::Environment::Attach(static_cast<AZ::EnvironmentInstance>(env));

--- a/dev/Code/Tools/SceneAPI/SceneData/DllMain.cpp
+++ b/dev/Code/Tools/SceneAPI/SceneData/DllMain.cpp
@@ -24,6 +24,8 @@
 static AZ::SceneAPI::SceneData::ManifestMetaInfoHandler* g_manifestMetaInfoHandler = nullptr;
 static AZ::SceneAPI::SceneData::Registry::ComponentDescriptorList g_componentDescriptors;
 
+AZ_DEFAULT_MODDULE_IS_INITIALIZED_METHOD    ///< Add default IsInitialized function to the dll
+
 extern "C" AZ_DLL_EXPORT void InitializeDynamicModule(void* env)
 {
     AZ::Environment::Attach(static_cast<AZ::EnvironmentInstance>(env));

--- a/dev/Code/Tools/SceneAPI/SceneUI/DllMain.cpp
+++ b/dev/Code/Tools/SceneAPI/SceneUI/DllMain.cpp
@@ -28,6 +28,8 @@
 static AZ::SceneAPI::UI::GraphMetaInfoHandler* g_graphMetaInfoHandler = nullptr;
 static AZ::SceneAPI::UI::ManifestMetaInfoHandler* g_manifestMetaInfoHandler = nullptr;
 
+AZ_DEFAULT_MODDULE_IS_INITIALIZED_METHOD    ///< Add default IsInitialized function to the dll
+
 extern "C" AZ_DLL_EXPORT void InitializeDynamicModule(void* env)
 {
     AZ::Environment::Attach(static_cast<AZ::EnvironmentInstance>(env));


### PR DESCRIPTION
### Description 
Fix for dynamic modules not being initialised if they were already loaded during startup by the OS as a dependency for a different module.