### PR TITLE
21) Fix resource compiler pak file directory problems

### DIFF
--- a/dev/Code/Tools/RC/ResourceCompiler/ResourceCompiler.cpp
+++ b/dev/Code/Tools/RC/ResourceCompiler/ResourceCompiler.cpp
@@ -721,8 +721,16 @@ bool ResourceCompiler::CollectFilesToCompile(const string& filespec, std::vector
                             sourceLeftPath = sourceRoot;
                             sourceInnerPathAndName = PathHelpers::Join(PathHelpers::GetDirectory(tokens[t]), filenames[i]);
                         }
-                        AddRcFile(files, addedFiles, sourceRootsReversed, sourceLeftPath, sourceInnerPathAndName, targetLeftPath);
-                    }
+
+                        const DWORD dwFileSpecAttr = GetFileAttributes(PathHelpers::Join(sourceLeftPath, sourceInnerPathAndName));
+                        if (dwFileSpecAttr & FILE_ATTRIBUTE_DIRECTORY)
+                        {
+                            RCLog("Skipping adding file '%s' matched by wildcard '%s' because it is a directory", sourceInnerPathAndName, filespec.c_str());
+                        }
+                        else
+                        {
+                            AddRcFile(files, addedFiles, sourceRootsReversed, sourceLeftPath, sourceInnerPathAndName, targetLeftPath);
+                        }
                 }
             }
 


### PR DESCRIPTION
## Resource compiler bug fix present since LY 1.7

### Description
If a pak job wildcard matched a directory then the resource compiler would attempt to add that directory to the pak file, this causes errors when the pak file is written because the PakManager expects to receive file paths and therefore attempts to read the directory as though it were a file, causing it to fail to add to the pak. 

This was observed with FBX files containing embedded materials, the asset processor extracts the fbx materials to a directory called "fbxfile.fbm" which matches the typical "*.*" wildcard used to define files which should be added to a pak. 

The fix is to simply skip adding any file which is a directory. Any files in the directory are still matched by recursive wildcards and so the actual directory does not need to be added.