### PR TITLE
Fix For Lua Net Bindings Crash

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Script/ScriptNetBindings.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Script/ScriptNetBindings.cpp
@@ -1297,12 +1297,24 @@ namespace AzFramework
         {
             ScriptPropertyDataSet& dataSet = m_propertyDataSets[i];
 
-            dataSet.Modify([](AZ::ScriptProperty*& scriptProperty)
+            // If this dataset is bound to a network table value, unbind it.
+            // This will transfer the script property ownership to the reserver,
+            // so it should not be deleted here.
+            if (dataSet.IsReserved())
             {
-                delete scriptProperty;
-                scriptProperty =  nullptr;
-                return false;
-            });
+                AZ_Assert(dataSet.m_reserver->GetDataSet() == &dataSet, "Invalid ScriptProperty <-> DataSet binding detected!");
+                dataSet.m_reserver->UnbindFromDataSet();
+            }
+            else
+            {
+                // No Lua network table value is bound to this dataset - delete the script property
+                dataSet.Modify([](AZ::ScriptProperty*& scriptProperty)
+                {
+                    delete scriptProperty;
+                    scriptProperty = nullptr;
+                    return false;
+                });
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Fix for Lua net bindings trying to delete their datasets multiple times, which leads to a crash - datasets bound to a network table value should transfer the script property ownership to the reserver instead of deleting it. If there is no network table value bound to the dataset delete it as before.