### PR TITLE
4) Add Dynamic Slice Network Cloning

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextBus.h
@@ -123,6 +123,14 @@ namespace AzFramework
         virtual bool DestroyDynamicSliceByEntity(const AZ::EntityId& /*id*/) = 0;
         
         /**
+        * Clone an entire dynamic slice instance given the ID of any entity within the slice.
+        * @param entityId The ID of the entity whose dynamic slice instance you want to clone.
+        * @param entityIdMap A reference to a map that will be filled with source->copy entity ID mappings.
+        * @return Cloned slice address if the dynamic slice instance was successfully cloned, null address otherwise.
+        */
+        virtual AZ::SliceComponent::SliceInstanceAddress CloneDynamicSliceByEntity(const AZ::EntityId& /*entityId*/, AZ::SliceComponent::EntityIdToEntityIdMap& /*entityIdMap*/) { return AZ::SliceComponent::SliceInstanceAddress(); }
+
+        /**
          * Instantiates a dynamic slice asynchronously.
          * @param sliceAsset A reference to the slice asset data.
          * @param worldTransform A reference to the world transform to apply to the slice. 

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -339,6 +339,28 @@ namespace AzFramework
     }
 
     //=========================================================================
+    // GameEntityContextRequestBus::CloneDynamicSliceByEntity
+    //=========================================================================
+    AZ::SliceComponent::SliceInstanceAddress GameEntityContextComponent::CloneDynamicSliceByEntity(const AZ::EntityId& entityId, AZ::SliceComponent::EntityIdToEntityIdMap& entityIdMap)
+    {
+        AZ::SliceComponent* rootSlice = GetRootSlice();
+        if (rootSlice)
+        {
+            auto address = rootSlice->FindSlice(entityId);
+            if (address.second)
+            {
+                auto cloneAddress = CloneSliceInstance(address, entityIdMap);
+                if (cloneAddress.second)
+                {
+                    HandleEntitiesAdded(cloneAddress.second->GetInstantiated()->m_entities);
+                    return cloneAddress;
+                }
+            }
+        }
+        return AZ::SliceComponent::SliceInstanceAddress();
+    }
+
+    //=========================================================================
     // GameEntityContextRequestBus::InstantiateDynamicSlice
     //=========================================================================
     SliceInstantiationTicket GameEntityContextComponent::InstantiateDynamicSlice(const AZ::Data::Asset<AZ::Data::AssetData>& sliceAsset, const AZ::Transform& worldTransform, const AZ::IdUtils::Remapper<AZ::EntityId>::IdMapper& customIdMapper)

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.h
@@ -60,6 +60,7 @@ namespace AzFramework
         bool DestroyDynamicSliceByEntity(const AZ::EntityId&) override;
         void ActivateGameEntity(const AZ::EntityId&) override;
         void DeactivateGameEntity(const AZ::EntityId&) override;
+        AZ::SliceComponent::SliceInstanceAddress CloneDynamicSliceByEntity(const AZ::EntityId&, AZ::SliceComponent::EntityIdToEntityIdMap&) override;
         SliceInstantiationTicket InstantiateDynamicSlice(const AZ::Data::Asset<AZ::Data::AssetData>& sliceAsset, const AZ::Transform& worldTransform, const AZ::IdUtils::Remapper<AZ::EntityId>::IdMapper& customIdMapper) override;
         void CancelDynamicSliceInstantiation(const SliceInstantiationTicket& ticket) override;
         bool LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds) override;


### PR DESCRIPTION
## Add Cloning Dynamic Slices

### Description
Added cloning dynamic slices support to game entity context bus.

### Usage

```c++
        AZ::EntityId ExampleInventoryComponent::CloneItem(AZ::EntityId itemId, AZ::EntityId parentId)
        {
        // 	If it is an item from a slice, clone the entire slice. 
	//	That way the ancestry info will be preserved.
            if (!parentId.IsValid())
            {
                AZ::SliceComponent::SliceInstanceAddress sliceAddr;
                EBUS_EVENT_ID_RESULT(sliceAddr, itemId, AzFramework::EntityIdContextQueryBus, GetOwningSlice);
                if (sliceAddr.first && sliceAddr.second)
                {
                    // This is a slice entity. Clone the entire slice
                    AZ::SliceComponent::EntityIdToEntityIdMap entityIdMap;
                    AZ::SliceComponent::SliceInstanceAddress clonedSliceAddr;
                    EBUS_EVENT_RESULT(clonedSliceAddr, AzFramework::GameEntityContextRequestBus, CloneDynamicSliceByEntity, itemId, entityIdMap);
                    if (clonedSliceAddr.first && clonedSliceAddr.second)
                    {
                        auto clonedItemId = entityIdMap[itemId];
                        return clonedItemId;
                    }
                    else
                    {
                        // We were unable to clone the slice. In theory we could just fall back to cloning entities one by one,
                        // but that would hide the bug that caused the cloning operation to fail.
                        AZ_Error("ExampleInventoryComponent", false, "Failed to clone dynamic slice");
                        return AZ::EntityId();
                    }
                }
                // else - Not a slice entity. Fall back to cloning entities one by one
            }

            // Clone entities one by one recursively.
            // ...

            return clonedItemId;
        }
```