### PR TITLE
32) Fix D3D renderer crash

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DSystem.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DSystem.cpp
@@ -1962,8 +1962,12 @@ bool CD3D9Renderer::CheckSSAAChange()
 {
     const int width = m_CVWidth ? m_CVWidth->GetIVal() : m_width;
     const int height = m_CVHeight ? m_CVHeight->GetIVal() : m_height;
-    const int maxSamples = min(m_MaxTextureSize / width, m_MaxTextureSize / height);
-    const int numSSAASamples = clamp_tpl(CV_r_Supersampling, 1, maxSamples);
+    int numSSAASamples = 1;
+    if (width > 0 && height > 0)
+    {
+        const int maxSamples = min(m_MaxTextureSize / width, m_MaxTextureSize / height);
+        numSSAASamples = clamp_tpl(CV_r_Supersampling, 1, maxSamples);
+    }
     if (m_numSSAASamples != numSSAASamples)
     {
         m_numSSAASamples = numSSAASamples;


### PR DESCRIPTION
### Description 

Safety check against DBZ in CD3D9Renderer::CheckSSAAChange where width/height came through as zero, potentially due to cvar problems which we didn't get to the bottom of but could at least protect against.