### PR TITLE
11) Fix editor silent crash

### DIFF
--- a/dev/Code/Sandbox/Editor/CryEdit.cpp
+++ b/dev/Code/Sandbox/Editor/CryEdit.cpp
@@ -2016,11 +2016,24 @@ void CCryEditApp::InitDirectory()
     QString szExeFileName = qApp->applicationDirPath();
 
     // Remove Bin32/Bin64 folder/
-    szExeFileName.remove(QRegularExpression(R"((\\|/)Bin32.*)"));
-
-    const QString bin = QRegularExpression::escape(BINFOLDER_NAME);
-    const QString reg = QStringLiteral("(\\\\|/)%1.*").arg(bin);
-    szExeFileName.remove(QRegularExpression(reg));
+    // Replaced regex-replace string modification with a simpler one (endsWith() + chop()).
+    // There were two issues with the regex:
+    //  1) It was case-sensitive, and failed when executable path was using lower case(i.e. app path used bin32 instead on Bin32)
+    //  2) The regex would replace all occurrences of Bin32/Bin64 instead of only the one at the end of the path.
+    szExeFileName.replace('/', '\\');
+    QString binFolderName = QString('\\').append(BINFOLDER_NAME); // BINFOLDER_NAME is the Bin64 editor executable name
+    if (szExeFileName.endsWith(binFolderName, Qt::CaseInsensitive))
+    {
+        szExeFileName.chop(binFolderName.length());
+    }
+    else
+    {
+        QString bin32FolderName("\\Bin32");
+        if (szExeFileName.endsWith(bin32FolderName, Qt::CaseInsensitive))
+        {
+            szExeFileName.chop(bin32FolderName.length());
+        }
+    }
 
     QDir::setCurrent(szExeFileName);
 }

--- a/dev/Code/Sandbox/Editor/IEditorImpl.cpp
+++ b/dev/Code/Sandbox/Editor/IEditorImpl.cpp
@@ -550,10 +550,24 @@ void CEditorImpl::SetMasterCDFolder()
     QString szFolder = qApp->applicationDirPath();
 
     // Remove Bin32/Bin64 folder/
-    szFolder.remove(QRegularExpression(R"((\\|/)Bin32.*)"));
-
-    szFolder.remove(QRegularExpression(QStringLiteral("(\\\\|/)%1.*").arg(QRegularExpression::escape(BINFOLDER_NAME))));
-
+    // Replaced regex-replace string modification with a simpler one (endsWith() + chop()).
+    // There were two issues with the regex:
+    //  1) It was case-sensitive, and failed when executable path was using lower case(i.e. app path used bin32 instead on Bin32)
+    //  2) The regex would replace all occurrences of Bin32/Bin64 instead of only the one at the end of the path.
+    szFolder.replace('/', '\\');
+    QString binFolderName = QString('\\').append(BINFOLDER_NAME); // BINFOLDER_NAME is the Bin64 editor executable name
+    if (szFolder.endsWith(binFolderName, Qt::CaseInsensitive))
+    {
+        szFolder.chop(binFolderName.length());
+    }
+    else
+    {
+        QString bin32FolderName("\\Bin32");
+        if (szFolder.endsWith(bin32FolderName, Qt::CaseInsensitive))
+        {
+            szFolder.chop(bin32FolderName.length());
+        }
+    }
 
     m_masterCDFolder = QDir::toNativeSeparators(szFolder);
 


### PR DESCRIPTION
## Fix editor silent crash

### Description
Fix for the editor silently crashing when the bin folder is named bin64vc140 instead of Bin64vc140 (upper/lower case 'B').

Replaced regex-replace string modification with a simpler one (endsWith() + chop()).

There were two issues with the regex:
1) It is case-sensitive and failed when the executable path was using lower case (i.e. app path used bin32 instead on Bin32)
2) The regex would replace all occurrences of Bin32/Bin64 instead of only the one at the end of the path.

### Note 

On testing it looks like the silent crash initially discovered appears to have been fixed, however, when single-stepping ::InitDirectory and ::SetMasterCDFolder it is trivial to see that the regex code is flawed as described above and should be replaced with the simpler and more correct version.
