### PR TITLE
17) Fix for ambiguous entity id compile issue

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Ai/NavigationSystemComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Ai/NavigationSystemComponent.cpp
@@ -25,10 +25,11 @@
 #include <functor.h> // needed in <INavigationSystem.h>
 #include <INavigationSystem.h>
 
-using namespace AZ;
 
 namespace LmbrCentral
 {
+    using namespace AZ;
+
     AZ_CLASS_ALLOCATOR_IMPL(NavRayCastResult, SystemAllocator, 0)
 
     void NavigationSystemComponent::Reflect(ReflectContext* context)

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/StereoRendererComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/StereoRendererComponent.cpp
@@ -17,10 +17,11 @@
 
 #include "StereoRendererComponent.h"
 
-using namespace AZ;
 
 namespace LmbrCentral
 {
+    using namespace AZ;
+
     void StereoRendererComponent::Reflect(ReflectContext* context)
     {
         SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);


### PR DESCRIPTION
### Description

Simple one here; fix for Linux uber build where a "using namespace AZ" bleeds out to other CPPs and causes an ambiguous EntityId issue (As compiler cannot choose between the old cry EntityId or the newer AZ:EntityId).