### PR TITLE
19) Fix for camera framework memory leaks 

### DIFF
--- a/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.cpp
+++ b/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.cpp
@@ -21,6 +21,23 @@
 
 namespace Camera
 {
+    // Clean up the behaviours instantiated for us by the editor/serialization system
+    CameraRigComponent::~CameraRigComponent()
+    {
+        for (ICameraTargetAcquirer* targetAcquirer : m_targetAcquirers)
+        {
+            delete targetAcquirer;
+        }
+        for (ICameraLookAtBehavior* lookAtBehavior : m_lookAtBehaviors)
+        {
+            delete lookAtBehavior;
+        }
+        for (ICameraTransformBehavior* transformBehavior : m_transformBehaviors)
+        {
+            delete transformBehavior;
+        }
+    }
+
     void CameraRigComponent::Init()
     {
         for (ICameraTargetAcquirer* targetAcquirer : m_targetAcquirers)

--- a/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.h
+++ b/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.h
@@ -32,7 +32,7 @@ namespace Camera
     {
     public:
         AZ_COMPONENT(CameraRigComponent, "{286BF97A-1B4A-4EE1-944F-C13B2396227B}");
-        virtual ~CameraRigComponent() = default;
+        ~CameraRigComponent() override; ///< Define a destructor, we need to clean up the behaviours instantiated for us by the editor/serialization system
 
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/OffsetPosition.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/OffsetPosition.h
@@ -14,6 +14,7 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Transform.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
 {
@@ -31,6 +32,7 @@ namespace Camera
     public:
         ~OffsetPosition() override = default;
         AZ_RTTI(OffsetPosition, "{5B2975A6-839B-4DE0-842B-EDE78D778BC9}", ICameraLookAtBehavior);
+        AZ_CLASS_ALLOCATOR(OffsetPosition, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/RotateCameraLookAt.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/RotateCameraLookAt.h
@@ -16,6 +16,7 @@
 #include <AzCore/std/string/string.h>
 #include <GameplayEventBus.h>
 #include "StartingPointCamera/StartingPointCameraConstants.h"
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace Camera
 {
@@ -33,6 +34,7 @@ namespace Camera
     public:
         ~RotateCameraLookAt() override = default;
         AZ_RTTI(RotateCameraLookAt, "{B72C5BE7-2DAF-412B-BBBB-F216B3DFB9A0}", ICameraLookAtBehavior);
+        AZ_CLASS_ALLOCATOR(RotateCameraLookAt, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
@@ -14,6 +14,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include "StartingPointCamera/StartingPointCameraConstants.h"
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace Camera
 {
@@ -31,7 +32,8 @@ namespace Camera
     {
     public:
         ~SlideAlongAxisBasedOnAngle() override = default;
-        AZ_RTTI(CameraTargetComponent, "{8DDA8D0B-5BC3-437E-894B-5144E6E81236}", ICameraLookAtBehavior);
+        AZ_RTTI(SlideAlongAxisBasedOnAngle, "{8DDA8D0B-5BC3-437E-894B-5144E6E81236}", ICameraLookAtBehavior);
+        AZ_CLASS_ALLOCATOR(SlideAlongAxisBasedOnAngle, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByEntityId.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByEntityId.h
@@ -14,6 +14,7 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <CameraFramework/ICameraTargetAcquirer.h>
 #include <AzCore/Component/Component.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
 {
@@ -32,6 +33,7 @@ namespace Camera
     public:
         ~AcquireByEntityId() override = default;
         AZ_RTTI(AcquireByEntityId, "{14D0D355-1F83-4F46-9DE1-D41D23BDFC3C}", ICameraTargetAcquirer)
+        AZ_CLASS_ALLOCATOR(AcquireByEntityId, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByTag.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByTag.h
@@ -14,6 +14,7 @@
 #include <CameraFramework/ICameraTargetAcquirer.h>
 #include <AzCore/Component/Component.h>
 #include <LmbrCentral/Scripting/TagComponentBus.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
 {
@@ -33,6 +34,7 @@ namespace Camera
     public:
         ~AcquireByTag() override = default;
         AZ_RTTI(AcquireByTag, "{E76621A5-E5A8-41B0-AC1D-EC87553181F5}", ICameraTargetAcquirer)
+        AZ_CLASS_ALLOCATOR(AcquireByTag, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/FaceTarget.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/FaceTarget.h
@@ -13,6 +13,7 @@
 #include <CameraFramework/ICameraTransformBehavior.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Math/Transform.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
 {
@@ -30,6 +31,7 @@ namespace Camera
     public:
         ~FaceTarget() override = default;
         AZ_RTTI(FaceTarget, "{1A2CBCD0-1841-493C-8DB7-1BCA0D293019}", ICameraTransformBehavior)
+        AZ_CLASS_ALLOCATOR(FaceTarget, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/FollowTargetFromAngle.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/FollowTargetFromAngle.h
@@ -14,6 +14,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include "StartingPointCamera/StartingPointCameraConstants.h"
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace Camera
 {
@@ -27,6 +28,7 @@ namespace Camera
     public:
         ~FollowTargetFromAngle() override = default;
         AZ_RTTI(FollowTargetFromAngle, "{4DBE7A2C-8E93-422E-8942-9601A270D37E}", ICameraTransformBehavior)
+        AZ_CLASS_ALLOCATOR(FollowTargetFromAngle, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/FollowTargetFromDistance.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/FollowTargetFromDistance.h
@@ -14,6 +14,7 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Math/Transform.h>
 #include <GameplayEventBus.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
 {
@@ -34,6 +35,7 @@ namespace Camera
     public:
         ~FollowTargetFromDistance() override = default;
         AZ_RTTI(FollowTargetFromDistance, "{E6BEDB2C-6812-4369-8C0F-C1E72F380E50}", ICameraTransformBehavior)
+        AZ_CLASS_ALLOCATOR(FollowTargetFromDistance, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/OffsetCameraPosition.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/OffsetCameraPosition.h
@@ -13,6 +13,7 @@
 #include <CameraFramework/ICameraTransformBehavior.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace Camera
 {
@@ -25,6 +26,7 @@ namespace Camera
     public:
         ~OffsetCameraPosition() override = default;
         AZ_RTTI(OffsetCameraPosition, "{DB64D5DA-84B7-45B7-B221-B5A07BDA2F69}", ICameraTransformBehavior)
+        AZ_CLASS_ALLOCATOR(OffsetCameraPosition, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/Rotate.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTransformBehaviors/Rotate.h
@@ -14,6 +14,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include "StartingPointCamera/StartingPointCameraConstants.h"
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace Camera
 {
@@ -26,6 +27,7 @@ namespace Camera
     public:
         ~Rotate() override = default;
         AZ_RTTI(Rotate, "{EE06111E-75E8-47F0-B243-5A5308A5F605}", ICameraTransformBehavior)
+        AZ_CLASS_ALLOCATOR(Rotate, AZ::SystemAllocator, 0); ///< Use AZ::SystemAllocator, otherwise a CryEngine allocator will be used. This will cause the Asset Processor to crash when this object is deleted, because of the wrong uninitialisation order
         static void Reflect(AZ::ReflectContext* reflection);
 
         //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description 

Fixed AZ CameraFramework memory leaks; this will clean up the behaviours instantiated by the editor/serialization system.