### PR TITLE
24) Fix for Lua enums

### DIFF
--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.cpp
@@ -86,6 +86,21 @@ namespace AzToolsFramework
         m_pComboBox->blockSignals(false);
     }
 
+    void PropertyStringComboBoxCtrl::Add(const AZStd::pair<AZStd::string, AZStd::string>& value)
+    {
+        m_pComboBox->blockSignals(true);
+        m_values.push_back(value.first);
+        if (value.first != "---")
+        {
+            m_pComboBox->addItem(value.second.c_str());
+        }
+        else
+        {
+            m_pComboBox->insertSeparator(m_pComboBox->count());
+        }
+        m_pComboBox->blockSignals(false);
+    }
+
     void PropertyStringComboBoxCtrl::Add(const AZStd::vector<AZStd::string>& vals)
     {
         m_pComboBox->blockSignals(true);
@@ -154,6 +169,20 @@ namespace AzToolsFramework
             {
                 (void)debugName;
                 AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'StringList' attribute from property '%s' into string combo box. Expected string vector.", debugName);
+            }
+        }
+        else if (attrib == AZ::Edit::InternalAttributes::EnumValue)
+        {
+            // Handle "enumValue" attribute, used by Lua scripts
+            AZStd::pair<AZStd::string, AZStd::string> enumValue;
+            if (attrValue->Read<AZStd::pair<AZStd::string, AZStd::string>>(enumValue))
+            {
+                GUI->Add(enumValue);
+            }
+            else
+            {
+                // emit a warning!
+                AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'EnumValue' attribute from property '%s' into enum combo box", debugName);
             }
         }
         else if (attrib == AZ::Edit::Attributes::ComboBoxEditable)

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.hxx
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringComboBoxCtrl.hxx
@@ -16,6 +16,7 @@
 #include <AzCore/base.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include "PropertyEditorAPI.h"
+#include <AzCore/std/utils.h>
 
 #include <QWidget>
 
@@ -41,6 +42,7 @@ namespace AzToolsFramework
         AZStd::string value() const;
 
         void Add(const AZStd::string& value);
+        void Add(const AZStd::pair<AZStd::string, AZStd::string>& value); ///< Lua enums use pair<string,string>
         void Add(const AZStd::vector<AZStd::string>& value);
 
         QWidget* GetFirstInTabOrder();


### PR DESCRIPTION
## Fix for Lua enums

### Description
Fix the string combo box handler to handle enumValue attributes. These use pair<string,string> in Lua.

### Usage
Put the following code into a Lua script and test before and after this change. Lua enum properties should now work correctly.

```c++	
local EnumTest = 
{
	Properties = 
	{
		EnumType = 		
		{
    		default = "DefaultType",
    		ui = "ComboBox",
			enumValues =	
			{
				{ "1", "DefaultType" },
				{ "2", "OtherType" },
			}
		},
	},
}

function EnumTest:OnActivate()
	Debug.Log(self.Properties.EnumType)
end

return EnumTest
```