### PR TITLE
25) Fix for CryPhysics memory leaks

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/utils.cpp
+++ b/dev/Code/CryEngine/CryPhysics/utils.cpp
@@ -623,12 +623,7 @@ int BakeScaleIntoGeometry(phys_geometry*& pgeom, IGeomManager* pGeoman, const Ve
             pGeoman->UnregisterGeometry(pgeom);
         }
         pGeomScaled->SetForeignData(pgeom, DATA_UNSCALED_GEOM);
-        int* pMatMapping = 0;
-        if (pgeom->nMats)
-        {
-            memcpy(pMatMapping = new int[pgeom->nMats], pgeom->pMatMapping, pgeom->nMats * sizeof(int));
-        }
-        pgeom = pGeoman->RegisterGeometry(pGeomScaled, pgeom->surface_idx, pMatMapping, pgeom->nMats);
+        pgeom = pGeoman->RegisterGeometry(pGeomScaled, pgeom->surface_idx, (pgeom->nMats ? pgeom->pMatMapping : nullptr), pgeom->nMats); ///< pass in pgeom->pMatMapping rather than a copy, mappings are copied internally anyway
         pgeom->nRefCount = 0;
         pGeomScaled->Release();
         return 1;


### PR DESCRIPTION
## CryPhysics memory leak fix (material mappings)

### Description
Do not copy material mappings. RegisterGeometry() makes a copy internally anyway.