### PR TITLE
33) Fix for render thread stall

### DIFF
--- a/dev/Code/CryEngine/CrySystem/ThreadTask.cpp
+++ b/dev/Code/CryEngine/CrySystem/ThreadTask.cpp
@@ -392,7 +392,10 @@ void CThreadTaskManager::InitThreads()
 
     // Create a dummy thread that is used for main thread.
     m_threads.resize(1);
-    m_threads[0] = new CThreadTask_Thread(this, "Main Thread", 0, ((CSystem*)gEnv->pSystem)->m_sys_main_CPU->GetIVal(), THREAD_PRIORITY_NORMAL);
+
+    //  Make the render and main thread above normal priority. 
+    //  We want them to favour taking a core each and running whenever they have something to do. This should push job threads on to other cores.
+    m_threads[0] = new CThreadTask_Thread(this, "Main Thread", 0, ((CSystem*)gEnv->pSystem)->m_sys_main_CPU->GetIVal(), THREAD_PRIORITY_ABOVE_NORMAL);	
 
     CCpuFeatures* pCPU = ((CSystem*)gEnv->pSystem)->GetCPUFeatures();
 

--- a/dev/Code/CryEngine/RenderDll/Common/RenderThread.h
+++ b/dev/Code/CryEngine/RenderDll/Common/RenderThread.h
@@ -234,10 +234,11 @@ struct SRenderThread
 #ifdef USE_LOCKS_FOR_FLUSH_SYNC
     int m_nFlush;
     CryMutex                            m_LockFlushNotify;
-    CryConditionVariable    m_FlushCondition;
 #if defined(USE_HANDLE_FOR_FINAL_FLUSH_SYNC)
+    HANDLE m_FlushCondition;
     HANDLE m_FlushFinishedCondition;
 #else
+    CryConditionVariable    m_FlushCondition;
     CryConditionVariable    m_FlushFinishedCondition;
 #endif
 #else
@@ -301,7 +302,11 @@ struct SRenderThread
 #endif
         m_nFlush = 1;
 #ifdef USE_LOCKS_FOR_FLUSH_SYNC
+#if defined(USE_HANDLE_FOR_FINAL_FLUSH_SYNC)
+        SetEvent(m_FlushCondition);
+#else
         m_FlushCondition.Notify();
+#endif
         m_LockFlushNotify.Unlock();
 #else
         READ_WRITE_BARRIER
@@ -315,7 +320,11 @@ struct SRenderThread
 #endif
         m_bQuit = 1;
 #ifdef USE_LOCKS_FOR_FLUSH_SYNC
+#if defined(USE_HANDLE_FOR_FINAL_FLUSH_SYNC)
+        SetEvent(m_FlushCondition);
+#else
         m_FlushCondition.Notify();
+#endif
         m_LockFlushNotify.Unlock();
 #else
         READ_WRITE_BARRIER


### PR DESCRIPTION
### Description
Fix for render thread stall caused by the use of an inefficient condition variable being used for lock-stepping. The render thread was often not waking for several milliseconds after the main thread signalled it, causing a CPU bottleneck. Fixed by changing it to use an Event.

Upped the main thread and render thread priorities to ABOVE_NORMAL. The reasoning is that these threads drive the job threads, so we don't want them delaying if they have something to do. By putting them at the same priority, Windows should favour putting them each on their own cores, with the job threads moving on to the spare cores.
 