### PR TITLE
3) Add local scale net interpolation

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Component/TransformBus.h
+++ b/dev/Code/Framework/AzCore/AzCore/Component/TransformBus.h
@@ -566,6 +566,12 @@ namespace AZ
         * @return True if rotation of transform is interpolated via network sync.
         */
         virtual bool IsRotationInterpolated() = 0;
+
+        /**
+        * Returns whether scale of transform is interpolated via network sync.
+        * @return True if scale of transform is interpolated via network sync.
+        */
+        virtual bool IsScaleInterpolated() = 0;
     };
 
 
@@ -722,6 +728,11 @@ namespace AZ
          * Behavior for smoothing of rotation between network updates.
          */
         InterpolationMode m_interpolateRotation = InterpolationMode::NoInterpolation;
+
+        /**
+        * Behavior for smoothing of scale between network updates.
+        */
+        InterpolationMode m_interpolateScale = InterpolationMode::NoInterpolation;
 
         /**
          * Whether the transform is static.

--- a/dev/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.h
@@ -176,6 +176,8 @@ namespace AzFramework
 
         AZ::Vector3 GetLocalScale() override;
         AZ::Vector3 GetWorldScale() override;
+
+        bool IsScaleInterpolated() override;
         //////////////////////////////////////////////////////////////////////////
 
         /// Returns parent EntityID or
@@ -280,6 +282,7 @@ namespace AzFramework
         bool                                    m_isStatic;                 ///< If true, the transform is static and doesn't move while entity is active.
         AZ::InterpolationMode                   m_interpolatePosition;      ///< Interpolation mode for net-synced position updates
         AZ::InterpolationMode                   m_interpolateRotation;      ///< Interpolation mode for net-synced rotation updates
+        AZ::InterpolationMode                   m_interpolateScale;         ///< Interpolation mode for net-synced scale updates
 
         //////////////////////////////////////////////////////////////////////////
         // TransformHierarchyInformationBus
@@ -301,10 +304,11 @@ namespace AzFramework
         void CreateSamples();
         void CreateTranslationSample();
         void CreateRotationSample();
+        void CreateScaleSample();
 
         AZStd::unique_ptr<AZ::Sample<AZ::Vector3>>    m_netTargetTranslation;
         AZStd::unique_ptr<AZ::Sample<AZ::Quaternion>> m_netTargetRotation;
-        AZ::Vector3 m_netTargetScale;
+        AZStd::unique_ptr<AZ::Sample<AZ::Vector3>>    m_netTargetScale;
 
         AZ::Transform GetInterpolatedTransform(unsigned int localTime);
         //////////////////////////////////////////////////////////////////////////////

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -148,6 +148,7 @@ namespace AzToolsFramework
             , m_netSyncEnabled(false)
             , m_interpolatePosition(AZ::InterpolationMode::NoInterpolation)
             , m_interpolateRotation(AZ::InterpolationMode::NoInterpolation)
+            , m_interpolateScale(AZ::InterpolationMode::NoInterpolation)
         {
         }
 
@@ -249,6 +250,11 @@ namespace AzToolsFramework
         bool TransformComponent::IsRotationInterpolated()
         {
             return m_interpolateRotation != AZ::InterpolationMode::NoInterpolation;
+        }
+
+        bool TransformComponent::IsScaleInterpolated()
+        {
+            return m_interpolateScale != AZ::InterpolationMode::NoInterpolation;
         }
 
         void TransformComponent::CheckApplyCachedWorldTransform(const AZ::Transform& parentWorld)
@@ -1064,6 +1070,7 @@ namespace AzToolsFramework
             configuration.m_isStatic = m_isStatic;
             configuration.m_interpolatePosition = m_interpolatePosition;
             configuration.m_interpolateRotation = m_interpolateRotation;
+            configuration.m_interpolateScale = m_interpolateScale;
 
             gameEntity->CreateComponent<AzFramework::TransformComponent>()->SetConfiguration(configuration);
         }
@@ -1099,6 +1106,7 @@ namespace AzToolsFramework
                     Field("Sync Enabled", &TransformComponent::m_netSyncEnabled)->
                     Field("InterpolatePosition", &TransformComponent::m_interpolatePosition)->
                     Field("InterpolateRotation", &TransformComponent::m_interpolateRotation)->
+                    Field("InterpolateScale", &TransformComponent::m_interpolateScale)->
                     Version(8, &Internal::TransformComponentDataConverter);
 
                 if (AZ::EditContext* ptrEdit = serializeContext->GetEditContext())
@@ -1138,6 +1146,11 @@ namespace AzToolsFramework
 
                         DataElement(AZ::Edit::UIHandlers::ComboBox, &TransformComponent::m_interpolateRotation,
                             "Rotation Interpolation", "Enable local interpolation of rotation.")->
+                        EnumAttribute(AZ::InterpolationMode::NoInterpolation, "None")->
+                        EnumAttribute(AZ::InterpolationMode::LinearInterpolation, "Linear")->
+
+                        DataElement(AZ::Edit::UIHandlers::ComboBox, &TransformComponent::m_interpolateScale,
+                            "Scale Interpolation", "Enable local interpolation of scale.")->
                         EnumAttribute(AZ::InterpolationMode::NoInterpolation, "None")->
                         EnumAttribute(AZ::InterpolationMode::LinearInterpolation, "Linear");
 

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
@@ -196,6 +196,7 @@ namespace AzToolsFramework
 
             bool IsPositionInterpolated() override;
             bool IsRotationInterpolated() override;
+            bool IsScaleInterpolated() override;
 
             //////////////////////////////////////////////////////////////////////////
             // SliceEntityHierarchyRequestBus
@@ -267,6 +268,7 @@ namespace AzToolsFramework
             bool m_netSyncEnabled;
             AZ::InterpolationMode m_interpolatePosition;
             AZ::InterpolationMode m_interpolateRotation;
+            AZ::InterpolationMode m_interpolateScale;
         };
     }
 } // namespace AzToolsFramework


### PR DESCRIPTION
## Add local scale net interpolation

### Description

This one amused me a little bit, I found this comment in TransformComponent while implementing scale interpolation: "no interpolation of scale by design, very unlikely somebody needs it". We actually needed it! Since we needed it almost immediately, there is a good chance that someone else might too. We added it as we needed server authoritative scaling of our end zone feature. 