### PR TITLE
20) Add camera rig update order override

### DIFF
--- a/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.cpp
+++ b/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.cpp
@@ -61,6 +61,8 @@ namespace Camera
 
         m_initialTransform = AZ::Transform::CreateIdentity();
         EBUS_EVENT_ID_RESULT(m_initialTransform, GetEntityId(), AZ::TransformBus, GetWorldTM);
+
+        AZ::TickBus::Handler::m_tickOrder = AZ::TICK_DEFAULT + m_tickOrderOffset;
         AZ::TickBus::Handler::BusConnect();
     }
 
@@ -96,6 +98,7 @@ namespace Camera
 
             serializeContext->Class<CameraRigComponent, AZ::Component>()
                 ->Version(1)
+                ->Field("Tick Order Offset", &CameraRigComponent::m_tickOrderOffset)
                 ->Field("Target Acquirers", &CameraRigComponent::m_targetAcquirers)
                 ->Field("Look-at Behaviors", &CameraRigComponent::m_lookAtBehaviors)
                 ->Field("Camera Transform Behaviors", &CameraRigComponent::m_transformBehaviors);
@@ -114,6 +117,8 @@ namespace Camera
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Editor/Icons/Components/Viewport/CameraRig.png")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game", 0x232b318c))
                         ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://docs.aws.amazon.com/lumberyard/latest/userguide/component-camera-rig.html")
+                    ->DataElement(0, &CameraRigComponent::m_tickOrderOffset, "Tick order offset",
+                        "By default camera rig uses TICK_DEFAULT tick order, which is shared with Lua scripts (and most of the other components). The offset will be added to TICK_DEFAULT, so offset=1 will make the rig tick after scripts, offset=-1 - before scripts")
                     ->DataElement(0, &CameraRigComponent::m_targetAcquirers, "Target acquirers",
                     "A list of behaviors that define how a camera will select a target.  They are executed in order until one succeeds")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)

--- a/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.h
+++ b/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.h
@@ -56,5 +56,6 @@ namespace Camera
         AZStd::vector<ICameraLookAtBehavior*> m_lookAtBehaviors;
         AZStd::vector<ICameraTransformBehavior*> m_transformBehaviors;
         AZ::Transform m_initialTransform;
+        int m_tickOrderOffset = 0;///< Allows overriding the default tick order, which may be before or after Lua scripts
     };
 } // Camera


### PR DESCRIPTION
## Description 

By default, TickBus uses TICK_DEFAULT order. Pretty much everything in Lumberyard uses this default order.

If the camera rig listens for events or queries properties of other entities, then it may be ticked:
1) Before all dependent entities, and so it will be behind 1 frame
2) After all dependent entities (usually the desired behaviour)
3) Somewhere in the middle - some dependencies still hold values from the previous frame, others have already been updated.

I said (2) is only usually the desired behaviour, because there are situations where it gets even more complicated, like when the rig depends on entities that use physics or animation. Physics and animation are updated on worker threads, meaning that any update requested in this frame will be applied in the next frame.

For example, if the rig is following a character that uses physics, the character's position/orientation change calculated from this frame's input will be applied in the next frame, but the look direction (calculated from mouse input) is ready in the current frame; if the rig uses it for orientation updates, it will be applied 1 frame too early.

By adding the ability to more tightly control this tick order it is possible to mitigate some of these effects where best suited for the particular game. This was essential for smoothing out aiming and control issues in DRG.