### PR TITLE
27) Fix for a crash in RenderMesh

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/RenderMesh.h
+++ b/dev/Code/CryEngine/RenderDll/Common/RenderMesh.h
@@ -21,6 +21,7 @@
 #include <GeomQuery.h>
 #include "Shaders/Vertex.h"
 #include <AzCore/Jobs/LegacyJobExecutor.h>
+#include <AzCore/std/parallel/atomic.h>
 
 // Enable the below to get fatal error is some holds a rendermesh buffer lock for longer than 1 second
 //#define RM_CATCH_EXCESSIVE_LOCKS
@@ -155,6 +156,7 @@ private:
     int   m_nFrameRequestCachePos;
 
     std::vector<Vec2*> m_UVCache;         // float UVs (cached)
+    AZStd::atomic<size_t> m_UVCacheSize;  // Thread-safe UVCache resizing
     int   m_nFrameRequestCacheUVs;
 
     CRenderMesh* m_pVertexContainer;


### PR DESCRIPTION
### Description

Speculative fix  for a crash in RenderMesh::CreateUVCache() caused by multiple threads resizing a std::vector (speculative as I wasn't able to reproduce the crash locally, so I can't verify if it's fixed. I was, however, able to prove that CreateUVCache() is called from multiple threads, and m_UVCache vector is not protected by any synchronisation primitives, so that's a very likely cause of the crash).
