### PR TITLE
9) Fix for GridMate crashes

### DIFF
--- a/dev/Code/Framework/GridMate/GridMate/Session/Session.cpp
+++ b/dev/Code/Framework/GridMate/GridMate/Session/Session.cpp
@@ -2547,19 +2547,22 @@ SessionService::Update()
 void
 SessionService::AddGridSeach(GridSearch* search)
 {
-    AZ_Assert(AZStd::find(m_activeSearches.begin(), m_activeSearches.end(), search) == m_activeSearches.end(), "This search %p is already in the active searches list!", search);
-    AZ_Assert(AZStd::find(m_completedSearches.begin(), m_completedSearches.end(), search) == m_completedSearches.end(), "This search %p is already in the complete searches list!", search);
-
-    if (search->IsDone())
+    if(search != nullptr)
     {
-        m_completedSearches.push_back(search);
-    }
-    else
-    {
-        m_activeSearches.push_back(search);
-    }
+        AZ_Assert(AZStd::find(m_activeSearches.begin(), m_activeSearches.end(), search) == m_activeSearches.end(), "This search %p is already in the active searches list!", search);
+        AZ_Assert(AZStd::find(m_completedSearches.begin(), m_completedSearches.end(), search) == m_completedSearches.end(), "This search %p is already in the complete searches list!", search);
 
-    EBUS_EVENT_ID(m_gridMate, SessionEventBus, OnGridSearchStart, search);
+        if (search->IsDone())
+        {
+            m_completedSearches.push_back(search);
+        }
+        else
+        {
+            m_activeSearches.push_back(search);
+        }
+
+        EBUS_EVENT_ID(m_gridMate, SessionEventBus, OnGridSearchStart, search);
+    }
 }
 
 //=========================================================================
@@ -2568,22 +2571,25 @@ SessionService::AddGridSeach(GridSearch* search)
 void
 SessionService::ReleaseGridSearch(GridSearch* search)
 {
-    EBUS_EVENT_ID(m_gridMate, SessionEventBus, OnGridSearchRelease, search);
-
-    if (search->IsDone())
+    if(search != nullptr)
     {
-        SearchArrayType::iterator it = AZStd::find(m_completedSearches.begin(), m_completedSearches.end(), search);
-        AZ_Assert(it != m_completedSearches.end(), "Completed search %p was NOT found in the complete list!", search);
-        m_completedSearches.erase(it);
-    }
-    else
-    {
-        SearchArrayType::iterator it = AZStd::find(m_activeSearches.begin(), m_activeSearches.end(), search);
-        AZ_Assert(it != m_activeSearches.end(), "Active search %p was NOT found in the active list!", search);
-        m_activeSearches.erase(it);
-    }
+        EBUS_EVENT_ID(m_gridMate, SessionEventBus, OnGridSearchRelease, search);
 
-    delete search;
+        if (search->IsDone() && !m_completedSearches.empty())
+        {
+            SearchArrayType::iterator it = AZStd::find(m_completedSearches.begin(), m_completedSearches.end(), search);
+            AZ_Assert(it != m_completedSearches.end(), "Completed search %p was NOT found in the complete list!", search);
+            m_completedSearches.erase(it);
+        }
+        else if (!m_activeSearches.empty())
+        {
+            SearchArrayType::iterator it = AZStd::find(m_activeSearches.begin(), m_activeSearches.end(), search);
+            AZ_Assert(it != m_activeSearches.end(), "Active search %p was NOT found in the active list!", search);
+            m_activeSearches.erase(it);
+        }
+
+        delete search;
+    }
 }
 
 //=========================================================================


### PR DESCRIPTION
### Description

- nullptr safety checks in AddGridSearch and ReleaseGridSearch. We were seeing some crashes related to nullptr dereference of a null GridSearch* coming through. 
- Don't try and remove a search from an empty list. 
