### PR TITLE
10) Add SetSkinnedMaterial function to the SkinnedMeshComponentBus

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/EditorSkinnedMeshComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/EditorSkinnedMeshComponent.cpp
@@ -339,6 +339,11 @@ namespace LmbrCentral
         return m_mesh.GetEntityCharacter();
     }
 
+    void EditorSkinnedMeshComponent::SetSkinMaterial(const AZStd::string& materialOverride)
+    {
+        m_mesh.SetSkinMaterial(materialOverride);
+    }
+
     bool EditorSkinnedMeshComponent::GetVisibility()
     {
         return m_mesh.GetVisible();

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/EditorSkinnedMeshComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/EditorSkinnedMeshComponent.h
@@ -62,6 +62,7 @@ namespace LmbrCentral
         //////////////////////////////////////////////////////////////////////////
         // SkinnedMeshComponentRequestBus interface implementation
         ICharacterInstance* GetCharacterInstance() override;
+        void SetSkinMaterial(const AZStd::string& materialOverride) override;
         ///////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/SkinnedMeshComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/SkinnedMeshComponent.h
@@ -129,6 +129,8 @@ namespace LmbrCentral
         //! has changed.
         void RefreshRenderState();
 
+        void SetSkinMaterial(AZStd::string const&);
+
         //! Set/get auxiliary render flags.
         void SetAuxiliaryRenderFlags(uint32 flags);
         uint32 GetAuxiliaryRenderFlags() const { return m_auxiliaryRenderFlags; }
@@ -307,6 +309,7 @@ namespace LmbrCentral
         //////////////////////////////////////////////////////////////////////////
         // SkinnedMeshComponentRequestBus interface implementation
         ICharacterInstance* GetCharacterInstance() override;
+        void SetSkinMaterial(const AZStd::string&) override;
         ///////////////////////////////////
     protected:
 

--- a/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshComponentBus.h
+++ b/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshComponentBus.h
@@ -107,6 +107,7 @@ namespace LmbrCentral
     {
     public:
         virtual ICharacterInstance* GetCharacterInstance() = 0;
+        virtual void SetSkinMaterial(const AZStd::string&) = 0;
     };
 
     using SkinnedMeshComponentRequestBus = AZ::EBus<SkinnedMeshComponentRequests>;


### PR DESCRIPTION
### Description 

Added SetSkinnedMaterial function to the SkinnedMeshComponentBus. 
This is a simple addition to find the skin attachment for a skinned mesh and set a replacement material for all of the skin LODs. This is what we are using for setting different skins materials for different team colours in an online game.
