### PR TITLE
28) Fix transform spawning inaccuracy

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Scripting/SpawnerComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Scripting/SpawnerComponent.h
@@ -89,6 +89,7 @@ namespace LmbrCentral
 
         //////////////////////////////////////////////////////////////////////////
         // Private helpers
+        AzFramework::SliceInstantiationTicket SpawnSliceInternalAbsolute(const AZ::Data::Asset<AZ::Data::AssetData>& slice, const AZ::Transform& world);
         AzFramework::SliceInstantiationTicket SpawnSliceInternal(const AZ::Data::Asset<AZ::Data::AssetData>& slice, const AZ::Transform& relative);
         //////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
### Description

Fix for entities being spawned at an inaccurate position. 
The inaccuracy was caused by an unnecessary world->local->world transform round trip.

Test by using the SpawnerComponent to spawn an entity at a known transform and log out its transform from OnActivate. There will be a small but significant difference before and after the fix. This was particularly obvious for us when spawning bullet hit decals. The character would aim at a particular spot, raycast to a known position, then the decal would spawn off centre.

