### PR TITLE
29) Fix renderer crash

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DevBuffer.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DevBuffer.cpp
@@ -3425,16 +3425,19 @@ namespace AzRHI
             hr = gcpRendD3D->m_DevMan.CreateD3D11Buffer(&bd, NULL, &m_buffer, "ConstantBuffer");
             CHECK_HRESULT(hr);
 
-            m_used = 1;
+            m_used = (hr == S_OK);
         }
         if (m_dynamic)
         {
-            AZ_Assert(m_base_ptr == nullptr, "Already mapped when mapping");
-            D3D11_MAPPED_SUBRESOURCE mappedResource;
-            HRESULT hr = gcpRendD3D->GetDeviceContext().Map(m_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource);
-            AZ_Assert(hr == S_OK, "Map buffer failed");
-            m_base_ptr = mappedResource.pData;
-            return mappedResource.pData;
+            if (m_used && m_buffer)
+            {
+                AZ_Assert(m_base_ptr == nullptr, "Already mapped when mapping");
+                D3D11_MAPPED_SUBRESOURCE mappedResource;
+                HRESULT hr = gcpRendD3D->GetDeviceContext().Map(m_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mappedResource);
+                AZ_Assert(hr == S_OK, "Map buffer failed");
+                m_base_ptr = mappedResource.pData;
+                return mappedResource.pData;
+            }
         }
         else
         {

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DeviceManager/ConstantBufferCache.h
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DeviceManager/ConstantBufferCache.h
@@ -64,7 +64,10 @@ namespace AzRHI
 #endif
 
             Vec4* mappedData = reinterpret_cast<Vec4*>(MapConstantBuffer(shaderClass, shaderSlot, registerCountMax));
-            SIMDCopy(&mappedData[registerOffset], constants, registerCount);
+            if (mappedData)
+            {
+                SIMDCopy(&mappedData[registerOffset], constants, registerCount);
+            }
         }
 
         inline void WriteConstants(


### PR DESCRIPTION
### Description

Fix for a very elusive renderer crash:
- Add return value safety checks so we don't call D3D functions with a null pointer (should stop the crash). 
- Add protection for MapConstantBuffer returning nullptr.




