### PR TITLE
24) Fix for final Boot->FE->Exit memory leak.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/CryNameR.h
+++ b/dev/Code/CryEngine/RenderDll/Common/CryNameR.h
@@ -220,17 +220,8 @@ private:
 
     ENGINE_API static CNameTableR* GetNameTable()
     {
-        static CNameTableR* ms_table;
-        ScopedSwitchToGlobalHeap globalHeapScope;
-        // Note: can not use a 'static CNameTable sTable' here, because that
-        // implies a static destruction order dependency - the name table is
-        // accessed from static destructor calls.
-
-        if (ms_table == NULL)
-        {
-            ms_table = new CNameTableR();
-        }
-        return ms_table;
+        static CNameTableR ms_table;
+        return &ms_table;
     }
 
     SNameEntry* _entry(const char* pBuffer) const


### PR DESCRIPTION
### Description

Made CryNameR use a static allocated nametable instead of allocating one on first use. This seems to be okay, despite the previous comment saying not to do it this way. I suspect that CryNameR is not used as much these days, as the only breakpoints to hit it seemed to be in shaders.