### PR TITLE
37) Fix for network stall ticker thread disconnection problems

### DIFF
--- a/dev/Code/CryEngine/CryAction/CryAction.h
+++ b/dev/Code/CryEngine/CryAction/CryAction.h
@@ -526,7 +526,10 @@ private:
     //-- Network Stall ticker thread
 #ifdef USE_NETWORK_STALL_TICKER_THREAD
     CNetworkStallTickerThread* m_pNetworkStallTickerThread;
-    uint32                                              m_networkStallTickerReferences;
+    uint32 m_networkStallTickerReferences;
+    
+#else   ///< When the network stall ticker thread is disabled, tick GridMate from the main thread during level loading.
+    uint32 m_networkStallTickerReferences;
 #endif // #ifdef USE_NETWORK_STALL_TICKER_THREAD
 
     // Console Variables with some CryAction as owner

--- a/dev/Code/CryEngine/CryCommon/ISystem.h
+++ b/dev/Code/CryEngine/CryCommon/ISystem.h
@@ -1291,8 +1291,14 @@ struct ISystem
     //   Ends rendering frame and swap back buffer.
     virtual void    RenderEnd(bool bRenderStats = true, bool bMainWindow = true) = 0;
 
-    //! Update screen and call some important tick functions during loading.
-    virtual void SynchronousLoadingTick(const char* pFunc, int line) = 0;
+	//! Update screen and call some important tick functions during loading.
+    /*
+        SynchronousTick is now also used to update GridMate when level is loading.
+        Added a flag to indicate that only GridMate should be updated.
+        This is needed because the loading screen cannot be updated when waiting for the textures to precache.
+    */
+    virtual void SynchronousLoadingTick(const char* pFunc, int line, bool drawLoadingScreen = true) = 0; 
+
 
     // Description:
     //   Renders the statistics; this is called from RenderEnd, but if the

--- a/dev/Code/CryEngine/CryCommon/ProjectDefines.h
+++ b/dev/Code/CryEngine/CryCommon/ProjectDefines.h
@@ -278,7 +278,13 @@ typedef uint32 vtx_idx;
 // #define PARTICLE_MOTION_BLUR
 
 // a special ticker thread to run during load and unload of levels
+/* 
+    Disabled network stall ticker thread, as it's causing crashes during level loading. 
+    For example, some entities in the level are networked, and call RPCs from Lua OnActivate() function. 
+    These RPCs would then be processed by the net stall ticker thread, effectively running Lua
+    from the main and net ticker thread simultaneously, leading to data corruption and crashes.
 #define USE_NETWORK_STALL_TICKER_THREAD
+*/
 
 #if !defined(MOBILE)
 //---------------------------------------------------------------------

--- a/dev/Code/CryEngine/CrySystem/System.h
+++ b/dev/Code/CryEngine/CrySystem/System.h
@@ -448,7 +448,12 @@ public:
     void UpdateLoadingScreen();
 
     //! Update screen and call some important tick functions during loading.
-    void SynchronousLoadingTick(const char* pFunc, int line);
+    /*
+        SynchronousTick is now also used to update GridMate when level is loading. 
+        Added a flag to indicate that only GridMate should be updated. 
+        This is needed because the loading screen cannot be updated when waiting for the textures to precache. 
+    */
+    void SynchronousLoadingTick(const char* pFunc, int line, bool drawLoadingScreen = true); 
 
     //! Renders the statistics; this is called from RenderEnd, but if the
     //! Host application (Editor) doesn't employ the Render cycle in ISystem,

--- a/dev/Code/CryEngine/RenderDll/Common/RenderThread.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/RenderThread.cpp
@@ -116,6 +116,7 @@ SRenderThread::SRenderThread()
     m_nRenderThreadLoading = 0;
     m_pThreadLoading = 0;
     m_pLoadtimeCallback = 0;
+    m_pWaitFlushFinishedCallback = 0;
     m_bEndFrameCalled = false;
     m_bBeginFrameCalled = false;
     m_bQuitLoading = false;
@@ -3525,6 +3526,11 @@ void SRenderThread::WaitFlushFinishedCond()
             // We should not attempt to wait for the render thread to signal us -
             // we force signal the flush condition to exit out of this wait loop.
             m_nFlush = 0;
+        }
+
+        if (m_pWaitFlushFinishedCallback)
+        {
+            m_pWaitFlushFinishedCallback->LoadtimeUpdate(iTimer->GetFrameTime());
         }
 #else
         m_FlushFinishedCondition.Wait(m_LockFlushNotify);

--- a/dev/Code/CryEngine/RenderDll/Common/RenderThread.h
+++ b/dev/Code/CryEngine/RenderDll/Common/RenderThread.h
@@ -220,6 +220,13 @@ struct SRenderThread
     CRenderThread* m_pThread;
     CRenderThreadLoading* m_pThreadLoading;
     ILoadtimeCallback* m_pLoadtimeCallback;
+
+    /* 
+        Optional callback to be called periodically while waiting for the flush to finish. 
+        It is used to update GridMate while waiting for the render thread to precache textures. 
+    */
+    ILoadtimeCallback* m_pWaitFlushFinishedCallback; 
+        
     CryMutex m_rdldLock;
     AZStd::mutex m_CommandsMutex;
     bool m_bQuit;


### PR DESCRIPTION
### Description

Disabled Network Stall Ticker Thread, as it is a root cause of a few different crashes. The most recent one seen was caused by running Lua RPC handler from that thread during level loading, causing data corruption.

The Lumberyard team believes it can be safely disabled, as it is a relic that was used by the old CryNetwork system before the GridMate replaced it.
See the related forum ticket: https://gamedev.amazon.com/forums/questions/61765/networkstallticker-thread-unsafe-causing-crashes.html

When the thread is disabled, update GridMate from the main thread during level loading. That ensures that loadLevel request is sent from the server to clients in a timely manner and that the network heartbeat is continuously updated, preventing disconnections during level load.

