### PR TITLE
34) Fix dedicated server shutdown

### DIFF
--- a/dev/Code/CryEngine/CrySystem/WindowsConsole.cpp
+++ b/dev/Code/CryEngine/CrySystem/WindowsConsole.cpp
@@ -770,8 +770,6 @@ void CWindowsConsole::CleanUp()
         m_pCVarSvGameRules = NULL;
         m_inputBufferHandle = INVALID_HANDLE_VALUE;
         m_screenBufferHandle = INVALID_HANDLE_VALUE;
-        FreeConsole();
-
         m_initialized = false;
     }
 


### PR DESCRIPTION
### Description

Closing the dedicated server window with the X button in the top-right of the window does not shut the engine down cleanly. The process will instead be terminated in the middle of shutdown and system components won't be deactivated and destructed correctly.

When the X button is pressed, a CLOSE event is sent to the CtrlHandler() function from a separate thread, this signals the engine to shutdown on the main thread and waits indefinitely as when the CtrlHandler returns the process will be forcefully terminated by Windows.  During shutdown, however, there is a call to FreeConsole() in CWindowsConsole::CleanUp. Calling FreeConsole here causes the CtrlHandler thread to exit and then forcefully terminates the app mid-shutdown. 

The fix is to simply not call FreeConsole, this should be unnecessary as Windows will automatically free the console as soon as the last process exits, and when the X button is pressed we should shut down cleanly and exit normally (or otherwise be forcefully terminated by Windows because we did not shut down in a ~5 second timout).