### PR TITLE
36) Fix for detecting application focus issues

### DIFF
--- a/dev/Code/CryEngine/CryCommon/CrySystemBus.h
+++ b/dev/Code/CryEngine/CryCommon/CrySystemBus.h
@@ -60,6 +60,7 @@ class CrySystemRequests
 public:
     //! Get CrySystem
     virtual ISystem* GetCrySystem() = 0;
+    virtual void* GetMainWindowHandle() = 0;
 };
 using CrySystemRequestBus = AZ::EBus<CrySystemRequests>;
 

--- a/dev/Code/CryEngine/CrySystem/System.cpp
+++ b/dev/Code/CryEngine/CrySystem/System.cpp
@@ -287,6 +287,7 @@ CSystem::CSystem(SharedEnvironmentInstance* pSharedEnvironment)
 
 #ifdef WIN32
     m_hInst = NULL;
+    m_hStartupWnd = NULL;
     m_hWnd = NULL;
 #if _MSC_VER < 1000
     int sbh = _set_sbh_threshold(1016);
@@ -958,6 +959,16 @@ void CSystem::SetIProcess(IProcess* process)
 ISystem* CSystem::GetCrySystem()
 {
     return this;
+}
+
+//////////////////////////////////////////////////////////////////////////
+//  Request main window handle.
+//  Normally it's pSystem->pHwnd, but in editor it's different. Using a dedicated method so that it can be used from modules that do not depend on CrySystem.
+//  This is used by GetFocusEx(). The editor creates window and then initialises renderer, which creates a sub-window (in a tab). 
+//  The game launcher will use null initial hwnd, and let the renderer create the window. We need to use the editor window for detecting focus changes in editor game mode, and render hwnd in the game launcher.
+void* CSystem::GetMainWindowHandle()
+{
+    return m_hStartupWnd ? m_hStartupWnd : m_hWnd;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/dev/Code/CryEngine/CrySystem/System.h
+++ b/dev/Code/CryEngine/CrySystem/System.h
@@ -442,6 +442,7 @@ public:
     ////////////////////////////////////////////////////////////////////////
     // CrySystemRequestBus interface implementation
     ISystem* GetCrySystem() override;
+    void* GetMainWindowHandle() override;
     ////////////////////////////////////////////////////////////////////////
 
     //! Update screen during loading.
@@ -1080,6 +1081,10 @@ private: // ------------------------------------------------------
     ILoadConfigurationEntrySink* m_pCVarsWhitelistConfigSink;
 #endif // defined(CVARS_WHITELIST)
 
+    WIN_HWND        m_hStartupWnd; ///< Store the startup hwnd. 
+                                   ///< The editor creates the window and then initialises the renderer. 
+                                   ///< The game launcher lets the renderer create the window (so the startup hwnd is null in this case). 
+                                   ///< We need to use the editor window for detecting focus changes in editor game mode, as the renderer hwnd in this case is just the perspective tab
     WIN_HWND        m_hWnd;
     WIN_HINSTANCE   m_hInst;
 

--- a/dev/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -3469,6 +3469,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
 
     m_hInst = (WIN_HINSTANCE)startupParams.hInstance;
     m_hWnd = (WIN_HWND)startupParams.hWnd;
+    m_hStartupWnd = (WIN_HWND)startupParams.hWnd;   ///< Store the startup window hwnd so that it can be used for focus change detection in editor game mode. 
 
     m_userRootDir = startupParams.userPath;
     m_logsDir = startupParams.logPath;


### PR DESCRIPTION
### Description

Mouse and Keyboard focus detection fixes.

AZ input system uses WinApi ::GetFocus() to detect if the application has focus, but that function only tells which "control" has the keyboard focus. It is possible for an application to be in the background, not receiving input, but the ::GetFocus() call still returning a valid window handle (meaning - when the application becomes active, this control will receive input), which can be easily replicated.

To fix this, an extended version of::GetFocus() WinApi call, GetFocusEx(), was added.

### Detail
::GetFocus() is used to detect if application is active (in the foreground).

What ::GetFocus() really does though is return the window with the KEYBOARD focus for the CURRENT THREAD's message queue.
This basically means that the call returns the current control within the application window that will receive the keyboard events.
Usually, when the main application window is sent to background, the text focus is reset (::GetFocus() returns nullptr), but not always - it is possible for the application to be in the background, yet ::GetFocus() to continue returning a valid window handle.

The MSDN documentation is somewhat brief and vague in this area, making it easy to use this call incorrectly. It does recommend using ::GetForegroundWindow() instead to get the window with which the user is currently working.

GetFocusEx() uses ::GetForegroundWindow() to verify if the handle from::GetFocus() should be used - if ::GetFocus() handle is valid, but the application is not active, ignore it.
