### PR TITLE
40) Add debug rendering modes to display missing LODs and objects with too few LODs

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/3DEngineRender.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/3DEngineRender.cpp
@@ -1244,6 +1244,12 @@ void C3DEngine::PrintDebugInfo(const SRenderingPassInfo& passInfo)
         case 22:
             szMode = "object's current LOD vertex count";
             break;
+        case 24:
+            szMode = "Objects without LODs.\n    name - (triangle count)\n    draw calls - zpass/general/transparent/shadows/misc";
+            break;
+        case 25:
+            szMode = "Objects without LODs (Red). Objects that need more LODs (Blue)\n    name - (triangle count)\n    draw calls - zpass/general/transparent/shadows/misc";
+            break;
 
         default:
             assert(0);

--- a/dev/Code/CryEngine/Cry3DEngine/StatObjRend.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/StatObjRend.cpp
@@ -539,10 +539,14 @@ bool CStatObj::RenderDebugInfo(CRenderObject* pObj, const SRenderingPassInfo& pa
                 pObj->m_ObjFlags |= FOB_SELECTED;
             }
 
-            if (pObj && nNumLods > 1 && !bNoText)
+            // Don't skip objects with single lod (as they should flash)
+            if (pObj && !bNoText)
             {
-                const int nLod0 = GetMinUsableLod();
-                const int maxLod = GetMaxUsableLod();
+                const int nLod0 = nNumLods > 1 ? GetMinUsableLod() : 0;     // Always 0 if one lod
+                const int maxLod = nNumLods > 1 ? GetMaxUsableLod() : 0;    // Always 0 if one lod
+
+                clr.toFloat4(color);    // Actually use the colours calculated already to indicate lod
+
                 const bool bRenderNodeValid(pObj && pObj->m_pRenderNode && ((UINT_PTR)(void*)(pObj->m_pRenderNode) > 0));
                 IRenderNode* pRN = (IRenderNode*)pObj->m_pRenderNode;
                 pRend->DrawLabelEx(pos, 1.3f, color, true, true, "%d [%d;%d] (%d/%.1f)",
@@ -812,6 +816,52 @@ bool CStatObj::RenderDebugInfo(CRenderObject* pObj, const SRenderingPassInfo& pa
             }
             return false;
         }
+        case 24:
+        case 25:
+        {
+            int minTriangleCount = GetCVars()->e_DebugDrawLodMinTriangles;
+            if (m_nLoadedTrisCount >= minTriangleCount)
+            {
+                IRenderNode* pRN = (IRenderNode*)pObj->m_pRenderNode;
+                const char* shortName = "";
+
+                if (!m_szGeomName.empty())
+                {
+                    shortName = m_szGeomName.c_str();
+                }
+                else
+                {
+                    shortName = PathUtil::GetFile(m_szFileName.c_str());
+                }
+
+                if (nNumLods == 1)
+                {
+                    color[1] = color[2] = 0.0f;
+
+                    IRenderer::RNDrawcallsMapNode& drawCallsPerNode = pRend->GetDrawCallsInfoPerNodePreviousFrame();
+                    auto iter = drawCallsPerNode.find(pRN);
+                    if (iter != drawCallsPerNode.end())
+                    {
+                        pRend->DrawLabelEx(pos, 1.3f, color, true, true, "%s (%d)\n%d/%d/%d/%d/%d", shortName, m_nLoadedTrisCount, iter->second.nZpass, iter->second.nGeneral, iter->second.nTransparent, iter->second.nShadows, iter->second.nMisc);
+                    }
+                    else
+                    {
+                        pRend->DrawLabelEx(pos, 1.3f, color, true, true, "%s (%d)", shortName, m_nLoadedTrisCount);
+                    }
+                }
+                else if (e_DebugDraw == 25 && nNumLods < MAX_STATOBJ_LODS_NUM)   // 25 adds in drawing of objects that should be at a lower lod than exists
+                {
+                    float lodDistance = sqrt(m_fGeometricMeanFaceArea);
+                    float nextLodDistance = lodDistance * (nNumLods) / (pRN->GetLodRatioNormalized() * gEnv->p3DEngine->GetFrameLodInfo().fTargetSize);
+                    if (pObj->m_fDistance > nextLodDistance)
+                    {
+                        color[0] = color[1] = 0.0f;
+                        pRend->DrawLabelEx(pos, 1.3f, color, true, true, "%s (%d)", shortName, m_nLoadedTrisCount);
+                    }
+                }
+            }
+        }
+        break;
         }
     }
 

--- a/dev/Code/CryEngine/Cry3DEngine/cvars.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/cvars.cpp
@@ -90,6 +90,24 @@ void OnVegetationVisibleChange(ICVar* pArgs)
     }
 }
 
+void OnDebugDrawChange(ICVar* pArgs)
+{
+    static bool collectingDrawCalls = false;
+
+    int e_debugDraw = pArgs->GetIVal();
+    if (e_debugDraw >= 24 && e_debugDraw <= 25)
+    {
+        gEnv->pRenderer->CollectDrawCallsInfo(true);
+        gEnv->pRenderer->CollectDrawCallsInfoPerNode(true);
+        collectingDrawCalls = true;
+    }
+    else if (collectingDrawCalls)
+    {
+        gEnv->pRenderer->CollectDrawCallsInfo(false);
+        gEnv->pRenderer->CollectDrawCallsInfoPerNode(false);
+        collectingDrawCalls = false;
+    }
+}
 
 void CVars::Init()
 {
@@ -127,7 +145,7 @@ void CVars::Init()
     DefineConstIntCVar(e_DebugDrawShowOnlyLod, -1, VF_NULL,
         "e_DebugDraw shows only objects showing lod X");
 
-    DefineConstIntCVar(e_DebugDraw, 0, VF_CHEAT | VF_CHEAT_ALWAYS_CHECK,
+    REGISTER_CVAR_CB(e_DebugDraw, 0, VF_CHEAT | VF_CHEAT_ALWAYS_CHECK | CONST_CVAR_FLAGS,
         "Draw helpers with information for each object (same number negative hides the text)\n"
         " 1: Name of the used cgf, polycount, used LOD\n"
         " 2: Color coded polygon count\n"
@@ -151,12 +169,18 @@ void CVars::Init()
         "21: Display animated object distance to camera\n"
         "22: Display object's current LOD vertex count\n"
         "23: Display shadow casters in red\n"
+        "24: Display meshes with no LODs\n"
+        "25: Display meshes with no LODs, meshes with not enough LODs\n"
         "----------------debug draw list values. Any of them enable 2d on-screen listing type info debug. Specific values define the list sorting-----------\n"
         " 100: tri count\n"
         " 101: verts count\n"
         " 102: draw calls\n"
         " 103: texture memory\n"
-        " 104: mesh memory");
+        " 104: mesh memory",
+        OnDebugDrawChange);
+
+    REGISTER_CVAR(e_DebugDrawLodMinTriangles, 200, VF_CHEAT | VF_CHEAT_ALWAYS_CHECK | CONST_CVAR_FLAGS,
+        "Minimum number of triangles (lod 0) to show in LOD debug draw");
 
 #ifndef _RELEASE
     DefineConstIntCVar(e_DebugDrawListSize, 24, VF_DEV_ONLY,    "num objects in the list for e_DebugDraw list infodebug");

--- a/dev/Code/CryEngine/Cry3DEngine/cvars.h
+++ b/dev/Code/CryEngine/Cry3DEngine/cvars.h
@@ -188,6 +188,7 @@ struct CVars
     DeclareConstIntCVar(e_ObjFastRegister, 1);
     float e_ViewDistRatioLights;
     DeclareConstIntCVar(e_DebugDraw, 0);
+    int e_DebugDrawLodMinTriangles;		// cvar for min number of triangles in object before displaying lod warnings
     ICVar* e_DebugDrawFilter;
     DeclareConstIntCVar(e_DebugDrawListSize, 16);
     DeclareConstIntCVar(e_DebugDrawListBBoxIndex, 0);

--- a/dev/Code/CryEngine/CryCommon/Cry_Color.h
+++ b/dev/Code/CryEngine/CryCommon/Cry_Color.h
@@ -240,6 +240,7 @@ struct Color_tpl
     ILINE unsigned int pack_argb8888() const;
     inline Vec4 toVec4() const { return Vec4(r, g, b, a); }
     inline Vec3 toVec3() const { return Vec3(r, g, b); }
+    inline void toFloat4(f32* out) const;
 
     inline void toHSV(f32& h, f32& s, f32& v) const;
     inline void fromHSV(f32 h, f32 s, f32 v);
@@ -501,6 +502,23 @@ ILINE Color_tpl<uint8>::Color_tpl(const Vec3& c, float fAlpha)
     a = (uint8)(fAlpha * 255);
 }
 
+template<>
+inline void Color_tpl<uint8>::toFloat4(f32* out) const
+{
+    out[0] = r / 255.0f;
+    out[1] = g / 255.0f;
+    out[2] = b / 255.0f;
+    out[3] = a / 255.0f;
+}
+
+template<>
+inline void Color_tpl<f32>::toFloat4(f32* out) const
+{
+    out[0] = r;
+    out[1] = g;
+    out[2] = b;
+    out[3] = a;
+}
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // functions implementation

--- a/dev/Code/CryEngine/CryCommon/IRenderer.h
+++ b/dev/Code/CryEngine/CryCommon/IRenderer.h
@@ -2009,6 +2009,8 @@ struct IRenderer
 #if !defined(_RELEASE)
     //Get draw call info for frame
     virtual RNDrawcallsMapMesh& GetDrawCallsInfoPerMesh(bool mainThread = true) = 0;
+    virtual RNDrawcallsMapMesh& GetDrawCallsInfoPerMeshPreviousFrame(bool mainThread = true) = 0;
+    virtual RNDrawcallsMapNode& GetDrawCallsInfoPerNodePreviousFrame(bool mainThread = true) = 0;
     virtual int GetDrawCallsPerNode(IRenderNode* pRenderNode) = 0;
     virtual void ForceRemoveNodeFromDrawCallsMap(IRenderNode* pNode) = 0;
 #endif

--- a/dev/Code/CryEngine/RenderDll/Common/RenderPipeline.h
+++ b/dev/Code/CryEngine/RenderDll/Common/RenderPipeline.h
@@ -959,10 +959,13 @@ struct SRenderPipeline
     //===================================================================
     // Drawcall count debug view - per Node - r_stats 6
     std::map< struct IRenderNode*, IRenderer::SDrawCallCountInfo > m_pRNDrawCallsInfoPerNode[RT_COMMAND_BUF_COUNT];
+    std::map< struct IRenderNode*, IRenderer::SDrawCallCountInfo > m_pRNDrawCallsInfoPerNodePreviousFrame[RT_COMMAND_BUF_COUNT];	// Functionality for retrieving previous frames stats to use this frame
 
     //===================================================================
     // Drawcall count debug view - per mesh - perf hud renderBatchStats
     std::map< struct IRenderMesh*, IRenderer::SDrawCallCountInfo > m_pRNDrawCallsInfoPerMesh[RT_COMMAND_BUF_COUNT];
+    std::map< struct IRenderMesh*, IRenderer::SDrawCallCountInfo > m_pRNDrawCallsInfoPerMeshPreviousFrame[RT_COMMAND_BUF_COUNT];	// Functionality for retrieving previous frames stats to use this frame
+
 #endif
 
     //================================================================

--- a/dev/Code/CryEngine/RenderDll/Common/Renderer.h
+++ b/dev/Code/CryEngine/RenderDll/Common/Renderer.h
@@ -2495,6 +2495,31 @@ public:
             return m_RP.m_pRNDrawCallsInfoPerMesh[m_RP.m_nProcessThreadID];
         }
     }
+    
+    // Added functionality for retrieving previous frames stats to use this frame
+    virtual RNDrawcallsMapMesh& GetDrawCallsInfoPerMeshPreviousFrame(bool mainThread = true)
+    {
+        if (mainThread)
+        {
+            return m_RP.m_pRNDrawCallsInfoPerMeshPreviousFrame[m_RP.m_nFillThreadID];
+        }
+        else
+        {
+            return m_RP.m_pRNDrawCallsInfoPerMeshPreviousFrame[m_RP.m_nProcessThreadID];
+        }
+    }
+    virtual RNDrawcallsMapNode& GetDrawCallsInfoPerNodePreviousFrame(bool mainThread = true)
+    {
+        if (mainThread)
+        {
+            return m_RP.m_pRNDrawCallsInfoPerNodePreviousFrame[m_RP.m_nFillThreadID];
+        }
+        else
+        {
+            return m_RP.m_pRNDrawCallsInfoPerNodePreviousFrame[m_RP.m_nProcessThreadID];
+        }
+    }
+
     virtual int GetDrawCallsPerNode(IRenderNode* pRenderNode);
 
     //Routine to perform an emergency flush of a particular render node from the stats, as not all render node holders are delay-deleted
@@ -2514,8 +2539,10 @@ public:
     {
         for (int i = 0; i < RT_COMMAND_BUF_COUNT; i++)
         {
-            m_RP.m_pRNDrawCallsInfoPerMesh[ i ].clear();
-            m_RP.m_pRNDrawCallsInfoPerNode[ i ].clear();
+            m_RP.m_pRNDrawCallsInfoPerMesh[i].swap(m_RP.m_pRNDrawCallsInfoPerMeshPreviousFrame[i]);
+            m_RP.m_pRNDrawCallsInfoPerMesh[i].clear();
+            m_RP.m_pRNDrawCallsInfoPerNode[i].swap(m_RP.m_pRNDrawCallsInfoPerNodePreviousFrame[i]);
+            m_RP.m_pRNDrawCallsInfoPerNode[i].clear();
         }
     }
 #endif

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DriverD3D.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DriverD3D.cpp
@@ -1496,7 +1496,10 @@ void CD3D9Renderer::RT_BeginFrame()
     }
 
 #if !defined(_RELEASE)
+    m_RP.m_pRNDrawCallsInfoPerNode[m_RP.m_nProcessThreadID].swap(m_RP.m_pRNDrawCallsInfoPerNodePreviousFrame[m_RP.m_nProcessThreadID]);
     m_RP.m_pRNDrawCallsInfoPerNode[m_RP.m_nProcessThreadID].clear();
+
+    m_RP.m_pRNDrawCallsInfoPerMesh[m_RP.m_nProcessThreadID].swap(m_RP.m_pRNDrawCallsInfoPerMeshPreviousFrame[m_RP.m_nProcessThreadID]);
     m_RP.m_pRNDrawCallsInfoPerMesh[m_RP.m_nProcessThreadID].clear();
 #endif
 


### PR DESCRIPTION
### Description 

- Added debug render modes 24 and 25. These will highlight models which have no LODs assigned, and models which should be on a lower LOD but don't have one assigned.
- Added a new e_DebugDrawLodMinTriangles cvar which is used to selectively ignore small objects in the new debug rendering modes.
- Fixed debug render mode 3 which is meant to flash objects with a single LOD.

This change helped us to optimize our scene by easily finding models which had incorrect or non-existent LODs. The debug output for shadows also proved very useful as we found they were a consistent source of problems for us.