### PR TITLE
35) Fix for net binding crash

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.cpp
@@ -607,8 +607,11 @@ namespace AzFramework
                 }
 
                 NetBindingHandlerInterface* binding = GetNetBindingHandler(entity);
-                AZ_Assert(binding, "Can't find NetBindingHandlerInterface!");
-                binding->BindToNetwork(bindTo);
+                AZ_Assert(binding, "Can't find NetBindingComponent on entity %llu (%s)!", static_cast<AZ::u64>(entity->GetId()), entity->GetName().c_str());
+                if (binding)
+                {
+                    binding->BindToNetwork(bindTo);
+                }
 
                 entity->Activate();
                 success = true;


### PR DESCRIPTION
### Description 

- Fix for the net binding system causing the game to crash in release when a netbinding component is not found.
- Improved the assert logging in debug builds.