### PR TITLE
1) Fix for D3D exception

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Textures/TextureStreaming.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Textures/TextureStreaming.cpp
@@ -275,25 +275,26 @@ void STexStreamInState::StreamAsyncOnComplete(IReadStream* pStream, unsigned nEr
         {
 
 #if defined(TEXSTRM_DEFERRED_UPLOAD)
-
-            ID3D11CommandList* pCmdList = tp->StreamCreateDeferred(m_nHigherUploadedMip, m_nLowerUploadedMip, m_pNewPoolItem, tp->m_pFileTexMips->m_pPoolItem);
-
-            if (pCmdList)
+            if (tp->m_pFileTexMips->m_pPoolItem)    ///< Don't upload if the source is nullptr it'll just cause an exception
             {
-                m_pCmdList = pCmdList;
-                m_bValidLowMips = true;
+                ID3D11CommandList* pCmdList = tp->StreamCreateDeferred(m_nHigherUploadedMip, m_nLowerUploadedMip, m_pNewPoolItem, tp->m_pFileTexMips->m_pPoolItem);
 
-                for (int i = 0, c = m_nLowerUploadedMip - m_nHigherUploadedMip + 1; i != c; ++i)
+                if (pCmdList)
                 {
-                    m_mips[i].m_bExpanded = false;
-                }
+                    m_pCmdList = pCmdList;
+                    m_bValidLowMips = true;
 
-                if (CTexture::s_bStreamDontKeepSystem)
-                {
-                    tp->StreamReleaseMipsData(m_nHigherUploadedMip, m_nLowerUploadedMip);
+                    for (int i = 0, c = m_nLowerUploadedMip - m_nHigherUploadedMip + 1; i != c; ++i)
+                    {
+                        m_mips[i].m_bExpanded = false;
+                    }
+
+                    if (CTexture::s_bStreamDontKeepSystem)
+                    {
+                        tp->StreamReleaseMipsData(m_nHigherUploadedMip, m_nLowerUploadedMip);
+                    }
                 }
             }
-
 #endif
 
 #if defined(TEXSTRM_ASYNC_TEXCOPY)


### PR DESCRIPTION
### Description 

Added nullptr protection in d3d11 deferred texture streaming. This became visible in our project due to enabling constant texture streaming in the level.

The diff looks a bit funny for me but all that has been added is:

```c++
if (tp->m_pFileTexMips->m_pPoolItem)    ///< Don't upload if the source is nullptr it'll just cause an exception
{
    ...
}
```