### PR TITLE
39) Fix for unproject not working

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/livingentity.cpp
+++ b/dev/Code/CryEngine/CryPhysics/livingentity.cpp
@@ -340,10 +340,21 @@ got_unproj:
             else if (pentlist[i]->m_parts[0].flags & collider_flags && !IgnoreCollision(m_collisionClass, pentlist[i]->m_collisionClass))
             {
                 CLivingEntity* pent = (CLivingEntity*)pentlist[i];
-                if (fabs_tpl((pos.z + hCollider - hPivot) - (pent->m_pos.z + pent->m_hCyl - pent->m_hPivot)) < newdim.z + pent->m_size.z &&
-                    len2(vector2df(pos) - vector2df(pent->m_pos)) < sqr(newdim.x + pent->m_size.x))
+                float myColliderHalfHeight = newdim.z + (newdim.x * bCapsule);
+                float theirColliderHalfHeight = pent->m_size.z + (pent->m_size.x * pent->m_bUseCapsule);
+                float verticalCenterOfMyCollider = pos.z + hCollider - hPivot;
+                float verticalCenterOfTheirCollider = pent->m_pos.z + pent->m_hCyl - pent->m_hPivot;
+                float distanceBetweenVerticalCentersOfColliders = fabs_tpl(verticalCenterOfMyCollider - verticalCenterOfTheirCollider);
+                Vec2 planarCenterToCenterOfColliders = vector2df(pent->m_pos) - vector2df(pos);
+                float squareDistanceBetweenPlanarCentersOfColliders = len2(planarCenterToCenterOfColliders);
+                if (distanceBetweenVerticalCentersOfColliders < myColliderHalfHeight + theirColliderHalfHeight &&
+                    squareDistanceBetweenPlanarCentersOfColliders < sqr(newdim.x + pent->m_size.x))
                 {
-                    return 1E10;
+                    // Pick the best direction to unproject in the XY plane
+                    Vec2 safeUnprojDir = Vec2(cry_random(-1.0f, 1.0f), cry_random(-1.0f, 1.0f)).GetNormalizedSafe(Vec2(0.0f, 1.0f));
+                    dirUnproj = planarCenterToCenterOfColliders.GetNormalizedSafe(safeUnprojDir);
+                    float unprojAmountNeeded = newdim.x + pent->m_size.x - sqrt(squareDistanceBetweenPlanarCentersOfColliders);
+                    return unprojAmountNeeded;
                 }
             }
         }
@@ -359,7 +370,7 @@ int CLivingEntity::SetParams(const pe_params* _params, int bThreadSafe)
     {
         if (_params->type == pe_player_dimensions::type_id && (unsigned int)m_iSimClass < 7u)
         {
-            int iter = 0, iCaller = get_iCaller();
+            int iter = 30, iCaller = get_iCaller();
             WriteLockCond lockc(m_pWorld->m_lockCaller[iCaller], iCaller == MAX_PHYS_THREADS);
             float hCyl, hPivot;
             Vec3 size, pos;
@@ -378,15 +389,19 @@ int CLivingEntity::SetParams(const pe_params* _params, int bThreadSafe)
             float unproj = 0, step;
             if ((heightCollider != hCyl || sizeCollider.x != size.x || sizeCollider.z != size.z) && m_pWorld && m_bActive)
             {
+                // AZ_TracePrintf("Unproj", "Unprojecting start");
                 do
                 {
                     unproj += (step = UnprojectionNeeded(pos + params->dirUnproj * unproj, qrot, heightCollider,
-                                       hPivot, sizeCollider, m_bUseCapsule, params->dirUnproj, iCaller)) * 1.01f;
-                } while (unproj < params->maxUnproj && ++iter < 8 && step > 0);
-                if (unproj > params->maxUnproj || iter == 8)
+                        hPivot, sizeCollider, m_bUseCapsule, params->dirUnproj, iCaller)) * 1.01f;
+                    // AZ_TracePrintf("Unproj", "Unprojecting res %d, step %f, unproj %f", iter, step, unproj);
+                } while (unproj < params->maxUnproj && --iter > 0 && step > 0);
+                if (unproj > params->maxUnproj || iter == 0)
                 {
+                    // AZ_TracePrintf("Unproj", "Unprojecting fail");
                     return 0;
                 }
+                // AZ_TracePrintf("Unproj", "Unprojecting done");
             }
         }
         return 1;
@@ -471,19 +486,23 @@ int CLivingEntity::SetParams(const pe_params* _params, int bThreadSafe)
         }
 
         float unproj = 0, step;
-        res = 0;
+        res = 30;   ///< Upped the number of allowed iterations, and made the iterator count backwards to avoid repeated magic numbers
         if ((params->heightCollider != m_hCyl || params->heightPivot != m_hPivot || params->sizeCollider.x != m_size.x || params->sizeCollider.z != m_size.z ||
              params->bUseCapsule != m_bUseCapsule) && m_pWorld && m_bActive)
         {
+            // AZ_TracePrintf("Unproj", "Unprojecting start");
             do
             {
                 unproj += (step = UnprojectionNeeded(m_pos + params->dirUnproj * unproj, m_qrot, params->heightCollider,
-                                   params->heightPivot, params->sizeCollider, params->bUseCapsule, params->dirUnproj)) * 1.01f;
-            } while (unproj < params->maxUnproj && ++res < 8 && step > 0);
-            if (unproj > params->maxUnproj || res == 8)
+                    params->heightPivot, params->sizeCollider, params->bUseCapsule, params->dirUnproj)) * 1.01f;
+                // AZ_TracePrintf("Unproj", "Unprojecting res %d, step %f, unproj %f", res, step, unproj);
+            } while (unproj < params->maxUnproj && --res > 0 && step > 0);      
+            if (unproj > params->maxUnproj || res == 0)
             {
+                //AZ_TracePrintf("Unproj", "Unprojecting fail");
                 return 0;
             }
+            AZ_TracePrintf("Unproj", "Unprojecting done");
         }
 
         {


### PR DESCRIPTION
### Description 
Fix for un-projection not working when character capsules are overlapping, resulting in creation failure.

### Test
This is fairly easy to see working. 

**Before the fix:**
I would suggest adding some logging like the commented out logs provided in this change, it makes it easy to see when unprojection starts, ends, and fails.

- Create a new level in the Starter Game
- Add in two versions of the PlayerSlice
- Make sure they are overlapping
- Setup unprojection on them, I set it to about 2.0m and the direction to {0, 0, 0} to allow auto-unproject to work
- Run the game, note that Jack doesn't move, and if you added logs you will see something like:
```
(Unproj) - Unprojecting start
(Unproj) - Unprojecting fail
[Warning] (CharacterPhysicsComponent) - Setting dimensions failed.  The character may not have enough room.
```

**After the fix:**
- Setup the level as before
- Run the game
- Note that Jack moves across and the logs look something like: 

```
(Unproj) - Unprojecting start
(Unproj) - Unprojecting res 30, step 0.578779, unproj 0.584567
(Unproj) - Unprojecting res 29, step 0.436646, unproj 1.025579
(Unproj) - Unprojecting res 28, step 0.000000, unproj 1.025579
(Unproj) - Unprojecting done
```