### PR TITLE
46) Add particle physics component, 47) Add ability to disable collision with player

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Physics/PhysicsComponentBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Physics/PhysicsComponentBus.h
@@ -301,6 +301,9 @@ namespace AzFramework
         //! Indicates whether this component can interact with proximity triggers
         bool m_interactsWithTriggers = true;
 
+        //! Indicates whether this component collides with character capsules (if set to false, the component will collide with the physics proxy instead)
+        bool m_collideWithCharacterCapsule = true;
+
         //! Damping value applied while in water.
         float m_buoyancyDamping = 0.f;
 

--- a/dev/Gems/LmbrCentral/Code/Source/LmbrCentral.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/LmbrCentral.cpp
@@ -50,6 +50,7 @@
 #include "Physics/PhysicsSystemComponent.h"
 #include "Physics/CharacterPhysicsComponent.h"
 #include "Physics/RagdollComponent.h"
+#include "Physics/ParticlePhysicsComponent.h"
 #include "Physics/RigidPhysicsComponent.h"
 #include "Physics/StaticPhysicsComponent.h"
 #include "Physics/WindVolumeComponent.h"
@@ -175,6 +176,7 @@ namespace LmbrCentral
             PhysicsSystemComponent::CreateDescriptor(),
             CharacterPhysicsComponent::CreateDescriptor(),
             RagdollComponent::CreateDescriptor(),
+            ParticlePhysicsComponent::CreateDescriptor(),
             RigidPhysicsComponent::CreateDescriptor(),
             SimpleAnimationComponent::CreateDescriptor(),
             SimpleStateComponent::CreateDescriptor(),

--- a/dev/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/LmbrCentralEditor.cpp
@@ -28,6 +28,7 @@
 #include "Audio/EditorAudioSwitchComponent.h"
 #include "Audio/EditorAudioTriggerComponent.h"
 #include "Physics/EditorConstraintComponent.h"
+#include "Physics/EditorParticlePhysicsComponent.h"
 #include "Physics/EditorRigidPhysicsComponent.h"
 #include "Physics/EditorStaticPhysicsComponent.h"
 #include "Physics/EditorWindVolumeComponent.h"
@@ -101,6 +102,7 @@ namespace LmbrCentral
             EditorMannequinScopeComponent::CreateDescriptor(),
             EditorMannequinComponent::CreateDescriptor(),
             EditorSphereShapeComponent::CreateDescriptor(),
+            EditorParticlePhysicsComponent::CreateDescriptor(),
             EditorRigidPhysicsComponent::CreateDescriptor(),
             EditorStaticPhysicsComponent::CreateDescriptor(),
             EditorWindVolumeComponent::CreateDescriptor(),

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/EditorParticlePhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/EditorParticlePhysicsComponent.cpp
@@ -1,0 +1,181 @@
+/*
+* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+* its licensors.
+*
+* For complete copyright and license terms please see the LICENSE at the root of this
+* distribution (the "License"). All use of this software is governed by the License,
+* or, if provided, by the license below or the license accompanying this file. Do not
+* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+*/
+#include "LmbrCentral_precompiled.h"
+#include "EditorParticlePhysicsComponent.h"
+#include <AzCore/Serialization/EditContext.h>
+
+namespace LmbrCentral
+{
+    void EditorParticlePhysicsConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<EditorParticlePhysicsConfiguration, ParticlePhysicsConfiguration>()
+                ->Version(1)
+                ;
+
+            AZ::EditContext* editContext = serializeContext->GetEditContext();
+            if (editContext)
+            {
+                editContext->Class<ParticlePhysicsConfiguration>(
+                    "Particle Physics Configuration", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::Category, "Physics")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+
+                    ->DataElement(0, &ParticlePhysicsConfiguration::m_enabledInitially,
+                        "Enabled initially", "Whether the entity is initially enabled in the physics simulation.")
+
+                    ->DataElement(0, &ParticlePhysicsConfiguration::m_mass,
+                        "Total mass", "Total mass of entity")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " kg")
+
+                    ->DataElement(0, &ParticlePhysicsConfiguration::m_radius,
+                        "Radius", "Radius of entity")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " m")
+
+                    ->DataElement(0, &ParticlePhysicsConfiguration::m_thicknessWhenLying,
+                        "Thickness when lying", "The thickness of the entity, to use when it is lying on something or sliding.")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " m")
+
+                    ->DataElement(0, &ParticlePhysicsConfiguration::m_interactsWithTriggers,
+                        "Interacts with triggers", "Indicates whether or not this entity can interact with proximity triggers.")
+
+                    ->DataElement(0, &ParticlePhysicsConfiguration::m_collideWithCharacterCapsule,
+                        "Collide with character capsule", "Indicates whether or not this entity can collide with character capsule (when disabled, entity collides with character's physical skeleton instead).")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_stopOnFirstContact, 
+                        "Stop on first contact", "Stop dead on first contact with another entity")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_orientToTrajectory,
+                        "Orient to trajectory", "Continuously align the particle along the current trajectory")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_allowSpin,
+                        "Allow spin", "Allow the particle to incur spin when it collides with things")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_bounceSpeedThreshold,
+                        "Bounce speed threshold", "Minimum speed below which the particle will stop bouncing")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " m/s")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_sleepSpeedThreshold,
+                        "Sleep speed threshold", "Minimum speed below which the particle will come to rest")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " m/s")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_allowRolling,
+                        "Allow rolling", "Whether the particle is allowed to roll. Otherwise it will only slide.")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_alignRollAxis,
+                        "Align roll axis", "Whether to align the particle along the roll axis when it is rolling, or just let it rotate freely.")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Vector3, &ParticlePhysicsConfiguration::m_rollAxis,
+                        "Roll axis", "Local axis to align with the roll axis when rolling")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ParticlePhysicsConfiguration::m_alignRollAxis)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_applyHitImpulse,
+                        "Apply hit impulse", "Apply an impulse to anything the particle hits. Impulse is proportional to speed and mass.")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_airResistance,
+                        "Air resistance", "Resistance to movement when in air")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_waterResistance,
+                        "Water resistance", "Resistance to movement when in water")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_surfaceIndex,
+                        "Surface index", "The physics surface index to use")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_useCustomGravity,
+                        "Use custom gravity", "Use a custom gravity vector instead of the global world gravity")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Vector3, &ParticlePhysicsConfiguration::m_customGravity,
+                        "Custom gravity", "The custom gravity vector to use")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ParticlePhysicsConfiguration::m_useCustomGravity)
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " m/s^2")
+
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Collides with types:")
+                        ->Attribute("AutoExpand", false)
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_collideWithTerrain,
+                        "Terrain", "Collide with terrain")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_collideWithStatic,
+                        "Static", "Collide with static entities")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_collideWithRigid,
+                        "Rigid body (active)", "Collide with active rigid bodies")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_collideWithSleepingRigid,
+                        "Rigid body (sleeping)", "Collide with sleeping rigid bodies")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_collideWithLiving,
+                        "Living", "Collide with living entities")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_collideWithIndependent,
+                        "Independent", "Collide with independent entities")
+
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ParticlePhysicsConfiguration::m_collideWithParticles,
+                        "Particle", "Collide with particles")
+                    ;
+            }
+        }
+    }
+
+    void EditorParticlePhysicsComponent::Reflect(AZ::ReflectContext* context)
+    {
+        EditorParticlePhysicsConfiguration::Reflect(context);
+
+        auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<EditorParticlePhysicsComponent, EditorPhysicsComponent>()
+                ->Field("Configuration", &EditorParticlePhysicsComponent::m_configuration)
+                ->Version(1)
+                ;
+
+            AZ::EditContext* editContext = serializeContext->GetEditContext();
+            if (editContext)
+            {
+                editContext->Class<EditorParticlePhysicsComponent>(
+                    "Particle Physics", "The entity behaves as a particle object in the physics simulation.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "Physics")
+                    ->Attribute(AZ::Edit::Attributes::Icon, "Editor/Icons/Components/RigidPhysics.png")
+                    ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Editor/Icons/Components/Viewport/RigidPhysics.png")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game", 0x232b318c))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(0, &EditorParticlePhysicsComponent::m_configuration, "Configuration", "Configuration for particle physics.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ;
+            }
+        }
+    }
+
+    EditorParticlePhysicsComponent::EditorParticlePhysicsComponent(const EditorParticlePhysicsConfiguration& configuration)
+        : m_configuration(configuration)
+    {
+    }
+
+    void EditorParticlePhysicsComponent::BuildGameEntity(AZ::Entity* gameEntity)
+    {
+        gameEntity->CreateComponent<ParticlePhysicsComponent>(m_configuration);
+    }
+} // namespace LmbrCentral

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/EditorParticlePhysicsComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/EditorParticlePhysicsComponent.h
@@ -1,0 +1,56 @@
+/*
+* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+* its licensors.
+*
+* For complete copyright and license terms please see the LICENSE at the root of this
+* distribution (the "License"). All use of this software is governed by the License,
+* or, if provided, by the license below or the license accompanying this file. Do not
+* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+*/
+#pragma once
+
+#include "EditorPhysicsComponent.h"
+#include "ParticlePhysicsComponent.h"
+
+namespace LmbrCentral
+{
+    /**
+     * Configuration data for EditorParticlePhysicsComponent.
+     */
+    struct EditorParticlePhysicsConfiguration
+        : public ParticlePhysicsConfiguration
+    {
+        AZ_CLASS_ALLOCATOR(EditorParticlePhysicsConfiguration, AZ::SystemAllocator, 0);
+        AZ_TYPE_INFO(EditorParticlePhysicsConfiguration, "{99DB247A-9F25-4753-BF82-EAC383FD248D}", ParticlePhysicsConfiguration);
+        static void Reflect(AZ::ReflectContext* context);
+    };
+
+    /**
+     * In-editor physics component for a Particle movable object.
+     */
+    class EditorParticlePhysicsComponent
+        : public EditorPhysicsComponent
+    {
+    public:
+        AZ_EDITOR_COMPONENT(EditorParticlePhysicsComponent, "{B693BBE6-AA46-41DF-964B-C75300378992}", EditorPhysicsComponent);
+        static void Reflect(AZ::ReflectContext* context);
+
+        EditorParticlePhysicsComponent() = default;
+        explicit EditorParticlePhysicsComponent(const EditorParticlePhysicsConfiguration& configuration);
+        ~EditorParticlePhysicsComponent() override = default;
+
+        ////////////////////////////////////////////////////////////////////////
+        // EditorComponentBase
+        void BuildGameEntity(AZ::Entity* gameEntity) override;
+        ////////////////////////////////////////////////////////////////////////
+
+        const EditorParticlePhysicsConfiguration& GetConfiguration() const { return m_configuration; }
+
+    private:
+
+        EditorParticlePhysicsConfiguration m_configuration;
+    };
+
+} // namespace LmbrCentral

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/EditorRigidPhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/EditorRigidPhysicsComponent.cpp
@@ -61,6 +61,9 @@ namespace LmbrCentral
                     ->DataElement(0, &AzFramework::RigidPhysicsConfig::m_interactsWithTriggers,
                         "Interacts with triggers", "Indicates whether or not this entity can interact with proximity triggers.")
 
+                    ->DataElement(0, &AzFramework::RigidPhysicsConfig::m_collideWithCharacterCapsule,
+                        "Collide with character capsule", "Indicates whether or not this entity can collide with character capsule (when disabled, entity collides with character's physical skeleton instead).")
+
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::RigidPhysicsConfig::m_recordCollisions, "Record collisions", "Whether or not to record and report collisions with this entity")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
 

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/ParticlePhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/ParticlePhysicsComponent.cpp
@@ -1,0 +1,165 @@
+/*
+* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+* its licensors.
+*
+* For complete copyright and license terms please see the LICENSE at the root of this
+* distribution (the "License"). All use of this software is governed by the License,
+* or, if provided, by the license below or the license accompanying this file. Do not
+* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+*/
+#include "LmbrCentral_precompiled.h"
+#include "ParticlePhysicsComponent.h"
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <MathConversion.h>
+
+namespace LmbrCentral
+{
+    void ParticlePhysicsConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<ParticlePhysicsConfiguration>()
+                ->Version(1)
+                ->Field("EnabledInitially", &ParticlePhysicsConfiguration::m_enabledInitially)
+                ->Field("Mass", &ParticlePhysicsConfiguration::m_mass)
+                ->Field("Radius", &ParticlePhysicsConfiguration::m_radius)
+                ->Field("ThicknessWhenLying", &ParticlePhysicsConfiguration::m_thicknessWhenLying)
+                ->Field("InteractsWithTriggers", &ParticlePhysicsConfiguration::m_interactsWithTriggers)
+                ->Field("CollideWithCharacterCapsule", &ParticlePhysicsConfiguration::m_collideWithCharacterCapsule)
+                ->Field("Collide With Terrain", &ParticlePhysicsConfiguration::m_collideWithTerrain)
+                ->Field("Collide With Static", &ParticlePhysicsConfiguration::m_collideWithStatic)
+                ->Field("Collide With Rigid", &ParticlePhysicsConfiguration::m_collideWithRigid)
+                ->Field("Collide With Sleeping Rigid", &ParticlePhysicsConfiguration::m_collideWithSleepingRigid)
+                ->Field("Collide With Living", &ParticlePhysicsConfiguration::m_collideWithLiving)
+                ->Field("Collide With Independent", &ParticlePhysicsConfiguration::m_collideWithIndependent)
+                ->Field("Collide With Particles", &ParticlePhysicsConfiguration::m_collideWithParticles)
+                ->Field("StopOnFirstContact", &ParticlePhysicsConfiguration::m_stopOnFirstContact)
+                ->Field("OrientToTrajectory", &ParticlePhysicsConfiguration::m_orientToTrajectory)
+                ->Field("AllowSpin", &ParticlePhysicsConfiguration::m_allowSpin)
+                ->Field("BounceSpeedThreshold", &ParticlePhysicsConfiguration::m_bounceSpeedThreshold)
+                ->Field("SleepSpeedThreshold", &ParticlePhysicsConfiguration::m_sleepSpeedThreshold)
+                ->Field("AllowRolling", &ParticlePhysicsConfiguration::m_allowRolling)
+                ->Field("AlignRollAxis", &ParticlePhysicsConfiguration::m_alignRollAxis)
+                ->Field("RollAxis", &ParticlePhysicsConfiguration::m_rollAxis)
+                ->Field("ApplyHitImpulse", &ParticlePhysicsConfiguration::m_applyHitImpulse)
+                ->Field("AirResistance", &ParticlePhysicsConfiguration::m_airResistance)
+                ->Field("WaterResistance", &ParticlePhysicsConfiguration::m_waterResistance)
+                ->Field("SurfaceIndex", &ParticlePhysicsConfiguration::m_surfaceIndex)
+                ->Field("UseCustomGravity", &ParticlePhysicsConfiguration::m_useCustomGravity)
+                ->Field("CustomGravity", &ParticlePhysicsConfiguration::m_customGravity)
+                ;
+        }
+    }
+
+    void ParticlePhysicsComponent::Reflect(AZ::ReflectContext* context)
+    {
+        ParticlePhysicsConfiguration::Reflect(context);
+
+        AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<ParticlePhysicsComponent, PhysicsComponent>()
+                ->Version(1)
+                ->Field("Configuration", &ParticlePhysicsComponent::m_configuration)
+                ;
+        }
+    }
+
+    ParticlePhysicsComponent::ParticlePhysicsComponent(const ParticlePhysicsConfiguration& configuration)
+        : m_configuration(configuration)
+    {
+    }
+
+    void ParticlePhysicsComponent::ConfigureCollisionGeometry()
+    {
+        // Particle entities do not have colliders as they model a moving sphere
+    }
+
+    void ParticlePhysicsComponent::ConfigurePhysicalEntity()
+    {
+        // Particle parameters
+        pe_params_particle particleParams;
+        particleParams.flags =
+            pef_never_affect_triggers     // don't generate events when moving through triggers
+            | particle_traceable          // entity is registered in the entity grid
+            | pef_log_collisions          // entity will log collision events
+            | pef_log_poststep            // entity will log EventPhysPostStep events
+            ;
+
+        if (m_configuration.m_stopOnFirstContact)
+        {
+            particleParams.flags |= particle_single_contact; // full stop after first contact
+        }
+
+        if (!m_configuration.m_allowRolling)
+        {
+            particleParams.flags |= particle_no_roll; // 'sliding' mode; entity's 'normal' vector axis will be alinged with the ground normal
+        }
+
+        if (!m_configuration.m_orientToTrajectory)
+        {
+            particleParams.flags |= particle_no_path_alignment; // unless set, entity's y axis will be aligned along the movement trajectory
+        }
+
+        if (!m_configuration.m_allowSpin)
+        {
+            particleParams.flags |= particle_no_spin; // disables spinning while flying
+        }
+
+        if (!m_configuration.m_collideWithParticles)
+        {
+            particleParams.flags |= particle_no_self_collisions; // disables collisions with other particles
+        }
+
+        if (!m_configuration.m_applyHitImpulse)
+        {
+            particleParams.flags |= particle_no_impulse; // particle will not add hit impulse (expecting that some other system will)
+        }
+
+        particleParams.mass = m_configuration.m_mass;
+        particleParams.size = m_configuration.m_radius;
+        particleParams.thickness = m_configuration.m_thicknessWhenLying;
+        particleParams.collTypes = m_configuration.GetColTypes();
+
+        AZ::Transform transform = GetEntity()->GetTransform()->GetWorldTM();
+        particleParams.q0 = AZQuaternionToLYQuaternion(AZ::Quaternion::CreateFromTransform(transform).GetNormalized());
+        particleParams.heading = AZVec3ToLYVec3(transform.GetBasisY().GetNormalizedSafe());
+
+        particleParams.velocity = 0.0f;
+        particleParams.normal = Vec3(0.0f, 0.0f, 1.0f);
+
+        particleParams.kAirResistance = m_configuration.m_airResistance;
+        particleParams.kWaterResistance = m_configuration.m_waterResistance;
+        particleParams.surface_idx = m_configuration.m_surfaceIndex;
+
+        if (m_configuration.m_alignRollAxis)
+        {
+            particleParams.rollAxis = AZVec3ToLYVec3(m_configuration.m_rollAxis);
+        }
+
+        if (m_configuration.m_useCustomGravity)
+        {
+            particleParams.gravity = AZVec3ToLYVec3(m_configuration.m_customGravity);
+        }
+
+        particleParams.minBounceVel = m_configuration.m_bounceSpeedThreshold;
+        particleParams.minVel = m_configuration.m_sleepSpeedThreshold;
+
+        m_physicalEntity->SetParams(&particleParams, 1);
+    }
+
+    int ParticlePhysicsConfiguration::GetColTypes() const
+    {
+        return (m_collideWithTerrain ? ent_terrain : 0)
+            | (m_collideWithStatic ? ent_static : 0)
+            | (m_collideWithRigid ? ent_rigid : 0)
+            | (m_collideWithSleepingRigid ? ent_sleeping_rigid : 0)
+            | (m_collideWithLiving ? ent_living : 0)
+            | (m_collideWithIndependent ? ent_independent : 0)
+            ;
+    }
+} // namespace LmbrCentral

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/ParticlePhysicsComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/ParticlePhysicsComponent.h
@@ -1,0 +1,131 @@
+/*
+* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+* its licensors.
+*
+* For complete copyright and license terms please see the LICENSE at the root of this
+* distribution (the "License"). All use of this software is governed by the License,
+* or, if provided, by the license below or the license accompanying this file. Do not
+* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+*/
+#pragma once
+
+#include "PhysicsComponent.h"
+
+namespace LmbrCentral
+{
+    /**
+     * Configuration data for ParticlePhysicsComponent.
+     */
+    struct ParticlePhysicsConfiguration
+    {
+        AZ_CLASS_ALLOCATOR(ParticlePhysicsConfiguration, AZ::SystemAllocator, 0);
+        AZ_TYPE_INFO(ParticlePhysicsConfiguration, "{FA5938D3-BD8F-4106-8177-C17F944D8B31}");
+        static void Reflect(AZ::ReflectContext* context);
+
+		//	Collider types
+		int GetColTypes() const;
+
+        //! Whether the entity is initially enabled in the physics simulation.
+        //! Entities can be enabled later via PhysicsComponentRequests::Enable(true).
+        bool m_enabledInitially = true;
+
+        //! Total mass of entity, in kg
+        float m_mass = 1.f;
+
+        //! Radius of the particle, in m
+        float m_radius = 0.05f;
+
+        //! The thickness to use when sliding or lying flat
+        float m_thicknessWhenLying = 0.05f;
+
+        //! Indicates whether this component can interact with proximity triggers
+        bool m_interactsWithTriggers = true;
+
+        //! Indicates whether this component collides with character capsules (if set to false, the component will collide with the physics proxy instead)
+        bool m_collideWithCharacterCapsule = true;
+
+        // Entity types to collide with
+        bool m_collideWithTerrain = true;
+        bool m_collideWithStatic = true;
+        bool m_collideWithRigid = true;
+        bool m_collideWithSleepingRigid = true;
+        bool m_collideWithLiving = true;
+        bool m_collideWithIndependent = true;
+        bool m_collideWithParticles = true;
+
+        //! Stop moving as soon as it hits something
+        bool m_stopOnFirstContact = false;
+
+        //! Align the particle's forward vector with the current trajectory
+        bool m_orientToTrajectory = true;
+
+        //! Allow the particle to spin
+        bool m_allowSpin = true;
+
+        //! Minimum speed below which the particle will stop bouncing
+        float m_bounceSpeedThreshold = 1.0f;
+
+        //! Minimum speed below which the particle will come to rest
+        float m_sleepSpeedThreshold = 0.02f;
+
+        //! If the particle is allowed to roll (otherwise it will only slide)
+        bool m_allowRolling = true;
+
+        //! Aligns the entity with the roll axis when rolling
+        bool m_alignRollAxis = false;
+
+        //! The local axis to align with the roll axis
+        AZ::Vector3 m_rollAxis = AZ::Vector3(0, 0, 0);
+
+        //! Apply an impulse to anything it collides with
+        bool m_applyHitImpulse = true;
+
+        //! Resistance applied when in air
+        float m_airResistance = 0.0f;
+        
+        //! Resistance applied when in water
+        float m_waterResistance = 0.5f;
+
+        //! Surface index to use for collisions
+        int m_surfaceIndex = 0;
+
+        //! Enable custom gravity. Otherwise uses the world gravity
+        bool m_useCustomGravity = false;
+
+        //! Custom gravity direction and magnitude
+        AZ::Vector3 m_customGravity = AZ::Vector3(0, 0, 0);
+    };
+
+    /*!
+     * Physics component for a Particle movable object.
+     */
+    class ParticlePhysicsComponent
+        : public PhysicsComponent
+    {
+    public:
+        AZ_COMPONENT(ParticlePhysicsComponent, "{84658098-1AB2-4317-8391-1D3024325F96}", PhysicsComponent);
+        static void Reflect(AZ::ReflectContext* context);
+
+        ParticlePhysicsComponent() = default;
+        explicit ParticlePhysicsComponent(const ParticlePhysicsConfiguration& configuration);
+        ~ParticlePhysicsComponent() override = default;
+
+        ////////////////////////////////////////////////////////////////////////
+        // PhysicsComponent
+        void ConfigurePhysicalEntity() override;
+        void ConfigureCollisionGeometry() override;
+        pe_type GetPhysicsType() const override { return PE_PARTICLE; }
+        bool CanInteractWithProximityTriggers() const override { return m_configuration.m_interactsWithTriggers; }
+        bool CanCollideWithCharacterCapsule() const override { return m_configuration.m_collideWithCharacterCapsule; }
+        bool IsEnabledInitially() const override { return m_configuration.m_enabledInitially; }
+        ////////////////////////////////////////////////////////////////////////
+
+        const ParticlePhysicsConfiguration& GetConfiguration() const { return m_configuration; }
+
+    protected:
+
+        ParticlePhysicsConfiguration m_configuration;
+    };
+} // namespace LmbrCentral

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsComponent.cpp
@@ -631,9 +631,22 @@ namespace LmbrCentral
         int finalPartId = AzFramework::ColliderComponentRequests::NoPartsAdded;
         EBUS_EVENT_ID_RESULT(finalPartId, entityId, ColliderComponentRequestBus, AddColliderToPhysicalEntity, *m_physicalEntity, m_nextPartId);
 
-        if (finalPartId == AzFramework::ColliderComponentRequests::NoPartsAdded)
+        if (GetPhysicsType() != PE_PARTICLE && finalPartId == AzFramework::ColliderComponentRequests::NoPartsAdded)
         {
             return;
+        }
+
+        /*
+            Disable collisions with player (meaning - player/character capsule).
+            Collisions with individual parts (physical skeleton) will still be enabled,
+            so this essentially makes the collisions more accurate.
+        */
+        if (!CanCollideWithCharacterCapsule() && finalPartId != AzFramework::ColliderComponentRequests::NoPartsAdded)
+        {
+            pe_params_part pp;
+            pp.ipart = finalPartId;
+            pp.flagsAND = ~geom_colltype_player;
+            m_physicalEntity->SetParams(&pp);
         }
 
         m_nextPartId = finalPartId + 1;

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsComponent.h
@@ -169,6 +169,7 @@ namespace LmbrCentral
 
         virtual pe_type GetPhysicsType() const = 0;
         virtual bool CanInteractWithProximityTriggers() const = 0;
+        virtual bool CanCollideWithCharacterCapsule() const = 0; ///< When flase, character physical skeleton is used instead.
         virtual bool IsEnabledInitially() const = 0;
         ////////////////////////////////////////////////////////////////////////
 

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/RigidPhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/RigidPhysicsComponent.cpp
@@ -30,6 +30,7 @@ namespace AzFramework
                 ->Field("AtRestInitially", &AzFramework::RigidPhysicsConfig::m_atRestInitially)
                 ->Field("EnableCollisionResponse", &AzFramework::RigidPhysicsConfig::m_enableCollisionResponse)
                 ->Field("InteractsWithTriggers", &AzFramework::RigidPhysicsConfig::m_interactsWithTriggers)
+                ->Field("CollideWithCharacterCapsule", &AzFramework::RigidPhysicsConfig::m_collideWithCharacterCapsule)
                 ->Field("RecordCollisions", &AzFramework::RigidPhysicsConfig::m_recordCollisions)
                 ->Field("MaxRecordedCollisions", &AzFramework::RigidPhysicsConfig::m_maxRecordedCollisions)
                 ->Field("SimulationDamping", &AzFramework::RigidPhysicsConfig::m_simulationDamping)

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/RigidPhysicsComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/RigidPhysicsComponent.h
@@ -36,6 +36,7 @@ namespace LmbrCentral
         void ConfigureCollisionGeometry() override;
         pe_type GetPhysicsType() const override { return PE_RIGID; }
         bool CanInteractWithProximityTriggers() const override { return m_configuration.m_interactsWithTriggers; }
+        bool CanCollideWithCharacterCapsule() const override { return m_configuration.m_collideWithCharacterCapsule; } ///< When false, character physical skeleton is used instead
         bool IsEnabledInitially() const override { return m_configuration.m_enabledInitially; }
         ////////////////////////////////////////////////////////////////////////
 

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/StaticPhysicsComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/StaticPhysicsComponent.h
@@ -34,6 +34,7 @@ namespace LmbrCentral
         void ConfigureCollisionGeometry() override {};
         pe_type GetPhysicsType() const override { return PE_STATIC; }
         bool CanInteractWithProximityTriggers() const override { return false; }
+        bool CanCollideWithCharacterCapsule() const override { return true; }
         bool IsEnabledInitially() const override { return m_configuration.m_enabledInitially; }
         ////////////////////////////////////////////////////////////////////////
 

--- a/dev/Gems/LmbrCentral/Code/lmbrcentral.waf_files
+++ b/dev/Gems/LmbrCentral/Code/lmbrcentral.waf_files
@@ -135,6 +135,8 @@
             "Source/Physics/CharacterPhysicsComponent.cpp",
             "Source/Physics/ConstraintComponent.h",
             "Source/Physics/ConstraintComponent.cpp",
+            "source/Physics/ParticlePhysicsComponent.h",
+            "source/Physics/ParticlePhysicsComponent.cpp",
             "Source/Physics/PhysicsComponent.h",
             "Source/Physics/PhysicsComponent.cpp",
             "Source/Physics/PhysicsComponentV1Converter.cpp",

--- a/dev/Gems/LmbrCentral/Code/lmbrcentral_editor.waf_files
+++ b/dev/Gems/LmbrCentral/Code/lmbrcentral_editor.waf_files
@@ -53,6 +53,8 @@
         [
             "Source/Physics/EditorConstraintComponent.h",
             "Source/Physics/EditorConstraintComponent.cpp",
+            "source/Physics/EditorParticlePhysicsComponent.h",
+            "source/Physics/EditorParticlePhysicsComponent.cpp",
             "Source/Physics/EditorPhysicsComponent.h",
             "Source/Physics/EditorPhysicsComponent.cpp",
             "Source/Physics/EditorRigidPhysicsComponent.h",


### PR DESCRIPTION
This is a bit of a two in one push because the two changes implement some of the same interface so I thought I would bundle them to make it a bit easier to integrate.

### 46) Description 
Added a new particle physics component. 
This implements a physics entity of type PE_PARTICLE, which according to the old Cryengine documentation is well suited for small fast moving objects, for example, projectiles. It is lightweight, and uses a ray sweep for collision detection, meaning that it cannot teleport through walls and characters when moving at high speed.

### 47) Description
Added an option to disable collisions between character capsules and RigidPhysicsComponents. Our use case for this was such that a grenade can miss the character closely, for instance through the legs, and that it can be thrown from a closer distance.