### PR TITLE
48) Fix physics components not reporting state change

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Physics/PhysicsComponentBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Physics/PhysicsComponentBus.h
@@ -321,6 +321,9 @@ namespace AzFramework
 
         //! Maximum number of collisions to be recorded per frame.
         int m_maxRecordedCollisions = 1;
+
+        //! Make physics components report state changes, so when they are moved by a transform modification, they trigger physics update events.
+        bool m_reportStateUpdates = false;
     };
 
     /*!

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/EditorRigidPhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/EditorRigidPhysicsComponent.cpp
@@ -68,6 +68,9 @@ namespace LmbrCentral
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzFramework::RigidPhysicsConfig::m_recordCollisions)
                         ->Attribute(AZ::Edit::Attributes::Min, 0)
 
+                    ->DataElement(0, &AzFramework::RigidPhysicsConfig::m_reportStateUpdates,
+                        "Report state updates", "Indicates whether or not this entity should report external state changes, such as when the transform is modified directly.")
+
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Simulation")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
 

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/RigidPhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/RigidPhysicsComponent.cpp
@@ -37,6 +37,7 @@ namespace AzFramework
                 ->Field("BuoyancyDamping", &AzFramework::RigidPhysicsConfig::m_buoyancyDamping)
                 ->Field("BuoyancyDensity", &AzFramework::RigidPhysicsConfig::m_buoyancyDensity)
                 ->Field("BuoyancyResistance", &AzFramework::RigidPhysicsConfig::m_buoyancyResistance)
+                ->Field("Report state updates", &AzFramework::RigidPhysicsConfig::m_reportStateUpdates)
                 ;
         }
 
@@ -229,6 +230,12 @@ namespace LmbrCentral
         pe_params_flags flagParameters;
         flagParameters.flagsOR  = pef_log_poststep // enable event when entity is moved by physics system
             | pef_log_collisions;                     // enable collision event
+
+        if (m_configuration.m_reportStateUpdates)
+        {
+            flagParameters.flagsOR |= pef_log_state_changes | pef_monitor_state_changes;
+        }
+
         m_physicalEntity->SetParams(&flagParameters);
     }
 

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/StaticPhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/StaticPhysicsComponent.cpp
@@ -77,6 +77,9 @@ namespace LmbrCentral
 
     void StaticPhysicsComponent::ConfigurePhysicalEntity()
     {
+        pe_params_flags flagsParams;
+        flagsParams.flagsOR = pef_log_state_changes | pef_monitor_state_changes;
+        m_physicalEntity->SetParams(&flagsParams);
     }
 
 } // namespace LmbrCentral


### PR DESCRIPTION
### Description 

Fix for Component Entities not reporting physics state changes when they are updated via setting the transform. 

A rigid body component property has been added for enabling external state change monitoring, so that physics events are generated when rigid bodies are moved externally, for example, due to a direct transform modification. This property defaults to off. Setting the new property to true allows external systems, in our particular case Kythera, to listen to physics updates. In the case of Kythera, this was used to mark the navmesh as dirty and regenerate it when doors open or objects move.