### PR TITLE
54) Fix for stall on Windows

### DIFF
--- a/dev/Code/CryEngine/CryCommon/CryThread.h
+++ b/dev/Code/CryEngine/CryCommon/CryThread.h
@@ -653,6 +653,8 @@ namespace CryMT
 
         m_arrBuffer = alias_cast<T*>(CryModuleMemalign(nSize * sizeof(T), 16));
         m_nBufferSize = nSize;
+
+        CryMT::detail::ProducerConsumerQueueBase::Init(nSize);  ///< Set up the queue
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -746,6 +748,8 @@ namespace CryMT
         m_arrStates = alias_cast<uint32*>(CryModuleMemalign(nSize * sizeof(uint32), 16));
         memset((void*)m_arrStates, 0, sizeof(uint32) * nSize);
         m_nBufferSize = nSize;
+
+        CryMT::detail::ProducerConsumerQueueBase::Init(nSize); ///< Set up the queue
     }
 
     ///////////////////////////////////////////////////////////////////////////////
@@ -758,6 +762,7 @@ namespace CryMT
             __debugbreak();
         }
 #endif
+        CryMT::detail::ProducerConsumerQueueBase::Reset(); ///< Reset the queue for the next frame
         m_nRunning = 1;
         m_nProducerCount = 1;
     }
@@ -794,6 +799,7 @@ namespace CryMT
         if (CryInterlockedDecrement((volatile int*)&m_nProducerCount) == 0)
         {
             m_nRunning = 0;
+            CryMT::detail::ProducerConsumerQueueBase::Done(1);  ///< We're done, make sure the consumer is not waiting
         }
     }
 

--- a/dev/Code/CryEngine/CryCommon/CryThread_pthreads.h
+++ b/dev/Code/CryEngine/CryCommon/CryThread_pthreads.h
@@ -1147,9 +1147,28 @@ public:
     // are implemeted in CryThead_platform.h
     namespace CryMT {
         namespace detail {
+
+            ///////////////////////////////////////////////////////////////////////////////
+            //  Dummy base class to match windows impl
+            class ProducerConsumerQueueBase
+            {
+            public:
+                inline void Done(size_t)
+                {
+                }
+
+                inline void Init(size_t)
+                {
+                }
+
+                inline void Reset()
+                {
+                }
+            };
+
             ///////////////////////////////////////////////////////////////////////////////
             ///////////////////////////////////////////////////////////////////////////////
-            class SingleProducerSingleConsumerQueueBase
+            class SingleProducerSingleConsumerQueueBase : public ProducerConsumerQueueBase  ///< Matches windows interface but uses dummy base class
             {
             public:
                 SingleProducerSingleConsumerQueueBase()
@@ -1203,7 +1222,7 @@ public:
 
             ///////////////////////////////////////////////////////////////////////////////
             ///////////////////////////////////////////////////////////////////////////////
-            class N_ProducerSingleConsumerQueueBase
+            class N_ProducerSingleConsumerQueueBase : public ProducerConsumerQueueBase  ///< Matches windows interface but uses dummy base class
             {
             public:
                 N_ProducerSingleConsumerQueueBase()


### PR DESCRIPTION
### Description

This change switches sleeps to semaphores in the CryThread_Windows impl plus adds better profiling markers.

In CryThread_windows.h the ProducerConsumerQueueBase is implemented to use semaphores rather than sleeping. The problem here was that the use of CryLowLatencySleep could take up to a whole schedule quantum (16ms) to wake up causing a stall across the entire game.

In CryThread_pthreads.h a ProducerConsumerQueueBase class has been added which is used as a base for SingleProducerSingleConsumerQueueBase and N_ProducerSingleConsumerQueueBase, this is simply a dummy base class used to match the windows interface.