### PR TITLE
55) Add pre-render step to render interface.

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/ObjManDrawEntity.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/ObjManDrawEntity.cpp
@@ -128,6 +128,8 @@ void CObjManager::RenderDecalAndRoad(IRenderNode* pEnt,
     DrawParams.nMaterialLayers = pEnt->GetMaterialLayers();
     DrawParams.rendItemSorter = rendItemSorter.GetValue();
 
+    pEnt->PreRender(DrawParams, passInfo);
+
     pEnt->Render(DrawParams, passInfo);
 }
 

--- a/dev/Code/CryEngine/CryCommon/IEntityRenderState.h
+++ b/dev/Code/CryEngine/CryCommon/IEntityRenderState.h
@@ -255,6 +255,10 @@ struct IRenderNode
     virtual bool IsReady() const { return true; }
 
     // Summary:
+    //   Called prior to calling Render
+    virtual void PreRender(struct SRendParams& EntDrawParams, const SRenderingPassInfo& passInfo) {}
+
+    // Summary:
     //   Renders node geometry
     virtual void Render(const struct SRendParams& EntDrawParams, const SRenderingPassInfo& passInfo) = 0;
 

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.cpp
@@ -643,6 +643,11 @@ namespace LmbrCentral
         return aabb;
     }
 
+    /*IRenderNode*/ void MeshComponentRenderNode::PreRender(struct SRendParams& inOutRenderParams, const struct SRenderingPassInfo& passInfo)
+    {
+        EBUS_EVENT_ID(m_renderOptions.m_attachedToEntityId, MeshComponentNotificationBus, OnMeshPreRender, inOutRenderParams, passInfo);
+    }
+
     /*IRenderNode*/ void MeshComponentRenderNode::Render(const struct SRendParams& inRenderParams, const struct SRenderingPassInfo& passInfo)
     {
         if (!HasMesh())

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.h
@@ -105,6 +105,7 @@ namespace LmbrCentral
 
         //////////////////////////////////////////////////////////////////////////
         // IRenderNode interface implementation
+        void PreRender(struct SRendParams& inOutRenderParams, const struct SRenderingPassInfo& passInfo) override;
         void Render(const struct SRendParams& inRenderParams, const struct SRenderingPassInfo& passInfo) override;
         bool GetLodDistances(const SFrameLodInfo& frameLodInfo, float* distances) const override;
         float GetFirstLodDistance() const override { return m_lodDistance; }

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/SkinnedMeshComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/SkinnedMeshComponent.cpp
@@ -613,6 +613,11 @@ namespace LmbrCentral
         return aabb;
     }
 
+    /*IRenderNode*/ void SkinnedMeshComponentRenderNode::PreRender(struct SRendParams& inOutRenderParams, const struct SRenderingPassInfo& passInfo)
+    {
+        EBUS_EVENT_ID(m_attachedToEntityId, MeshComponentNotificationBus, OnMeshPreRender, inOutRenderParams, passInfo);
+    }
+
     /*IRenderNode*/ void SkinnedMeshComponentRenderNode::Render(const struct SRendParams& inRenderParams, const struct SRenderingPassInfo& passInfo)
     {
         SRendParams rParams(inRenderParams);

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/SkinnedMeshComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/SkinnedMeshComponent.h
@@ -102,6 +102,7 @@ namespace LmbrCentral
         
         //////////////////////////////////////////////////////////////////////////
         // IRenderNode interface implementation
+        void PreRender(struct SRendParams& inOutRenderParams, const struct SRenderingPassInfo& passInfo) override;
         void Render(const struct SRendParams& inRenderParams, const struct SRenderingPassInfo& passInfo) override;
         bool GetLodDistances(const SFrameLodInfo& frameLodInfo, float* distances) const override;
         float GetFirstLodDistance() const override { return m_lodDistance; }

--- a/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshComponentBus.h
+++ b/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshComponentBus.h
@@ -18,6 +18,8 @@
 
 struct IStatObj;
 struct ICharacterInstance;
+struct SRenderingPassInfo;
+struct SRendParams;
 
 namespace LmbrCentral
 {
@@ -145,6 +147,11 @@ namespace LmbrCentral
         virtual void OnMeshDestroyed() {}
 
         virtual void OnBoundsReset() {};
+
+        /*
+         * Notifies liteners prior to making the render call 
+         */
+        virtual void OnMeshPreRender(struct SRendParams& inOutRenderParams, const SRenderingPassInfo& passInfo) {};
 
         /**
          * When connecting to this bus if the asset is ready you will immediately get an OnMeshCreated event


### PR DESCRIPTION
### Description

Added support for a PreRender step when rendering mesh or skinned mesh components. This is useful in a variety of situations; our use case was for implementing a silhouette component which will fill out SRenderParams::nHUDSilhouettesParams in OnMeshPreRender.