### PR TITLE
57) Fix for random @devassets@ folders appearing in dev folder

### DIFF
--- a/dev/Code/Sandbox/Editor/Objects/ObjectLayerManager.cpp
+++ b/dev/Code/Sandbox/Editor/Objects/ObjectLayerManager.cpp
@@ -645,6 +645,7 @@ bool CObjectLayerManager::SaveExternalLayer(CObjectArchive* pArchive, CObjectLay
 {
     // Form file name from layer name.
     QString path = Path::AddPathSlash(GetIEditor()->GetGameEngine()->GetLevelPath()) + m_layersPath;
+    path = Path::GamePathToFullPath(path); 
     QString file = pLayer->GetExternalLayerPath();
 
     if (CFileUtil::OverwriteFile(file))


### PR DESCRIPTION
### Description 

When adding an external layer via the layers tab of the rollup bar, on saving a @devassets@ folder will appear in the root dev folder. This change correctly resolves the path to save into the correct project and level folder.

GetGameEngine()->GetLevelPath() uses an aliased path (like "@devassets@/foo/bar") instead of an absolute one. CFileUtil is a bit inconsistent, some methods work with aliased paths (i.e. CFileUtil::OverwriteFile()) some don't (CFileUtil::CreateDirectory()). Because CreateDirectory() is used in this code, we need to resolve the path first using ::GamePathToFullPath()
