### PR TITLE
56) Add ref counted character physics

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Physics/CharacterPhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/CharacterPhysicsComponent.cpp
@@ -406,7 +406,7 @@ namespace LmbrCentral
 
     bool CharacterPhysicsComponent::IsPhysicsEnabled()
     {
-        return m_physicalEntity != nullptr;
+        return m_physicalEntity;
     }
 
     bool CharacterPhysicsComponent::ConfigurePhysicalEntity()
@@ -446,9 +446,11 @@ namespace LmbrCentral
 
     }
 
+    extern AZStd::shared_ptr<IPhysicalEntity> CreateIPhysicalEntitySharedPtr(IPhysicalEntity* rawPhysicalEntityPtr);
+    
     void CharacterPhysicsComponent::EnablePhysics()
     {
-        if (m_physicalEntity)
+        if (IsPhysicsEnabled())
         {
             return;
         }
@@ -461,7 +463,7 @@ namespace LmbrCentral
         positionParameters.pMtx3x4 = &cryTransform;
 
         // Create physical entity
-        m_physicalEntity = gEnv->pPhysicalWorld->CreatePhysicalEntity(
+        IPhysicalEntity* rawPhysicalEntityPtr = gEnv->pPhysicalWorld->CreatePhysicalEntity(
             PE_LIVING, // type
             &positionParameters, // params
             static_cast<uint64>(GetEntityId()), // pForeignData
@@ -469,6 +471,14 @@ namespace LmbrCentral
             -1, // id
             nullptr // IGeneralMemoryHeap
         );
+
+        m_physicalEntity = CreateIPhysicalEntitySharedPtr(rawPhysicalEntityPtr);
+        if (!m_physicalEntity)
+        {
+            AZ_Printf("SkinnedCharacterPhysicsComponent", "SkinnedCharacterPhysicsComponent::EnablePhysics no physical entity on entity id %s", GetEntityId().ToString().c_str());
+
+            return;
+        }
 
         pe_simulation_params simParams;
         m_physicalEntity->GetParams(&simParams);
@@ -487,8 +497,7 @@ namespace LmbrCentral
         // If anything goes wrong, destroy m_physicalEntity
         if (!ConfigurePhysicalEntity())
         {
-            gEnv->pPhysicalWorld->DestroyPhysicalEntity(m_physicalEntity);
-            m_physicalEntity = nullptr;
+            m_physicalEntity.reset();
             return;
         }
 
@@ -508,7 +517,7 @@ namespace LmbrCentral
 
     void CharacterPhysicsComponent::DisablePhysics()
     {
-        if (!m_physicalEntity)
+        if (!IsPhysicsEnabled())
         {
             return;
         }
@@ -530,13 +539,12 @@ namespace LmbrCentral
         }
 
 
-        gEnv->pPhysicalWorld->DestroyPhysicalEntity(m_physicalEntity);
-        m_physicalEntity = nullptr;
+        m_physicalEntity.reset();
     }
 
     IPhysicalEntity* CharacterPhysicsComponent::GetPhysicalEntity()
     {
-        return m_physicalEntity;
+        return m_physicalEntity.get();
     }
 
     void CharacterPhysicsComponent::GetPhysicsParameters(pe_params& outParameters)

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/CharacterPhysicsComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/CharacterPhysicsComponent.h
@@ -333,7 +333,7 @@ namespace LmbrCentral
 
         //////////////////////////////////////////////////////////////////////////
         // Non reflected data
-        IPhysicalEntity* m_physicalEntity = nullptr;
+        AZStd::shared_ptr<IPhysicalEntity> m_physicalEntity;
         bool m_isApplyingPhysicsToEntityTransform = false;
         SProximityElement* m_proximityTriggerProxy = nullptr;
         AZ::Transform m_previousEntityTransform = AZ::Transform::CreateIdentity();

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsComponent.cpp
@@ -468,6 +468,31 @@ namespace LmbrCentral
         }
     }
 
+    AZStd::shared_ptr<IPhysicalEntity> CreateIPhysicalEntitySharedPtr(IPhysicalEntity* rawPhysicalEntityPtr)
+    {
+        AZStd::shared_ptr<IPhysicalEntity> result;
+
+        if (rawPhysicalEntityPtr)
+        {
+            // Increment IPhysicalEntity's internal refcount once. We will decrement it once when the shared_ptr's refcount reaches zero.
+            rawPhysicalEntityPtr->AddRef();
+
+            result.reset(rawPhysicalEntityPtr,
+                [](IPhysicalEntity* physicalEntity)
+            {
+                // IPhysicalEntity is owned by IPhysicalWorld and will not be destroyed until both:
+                // - IPhysicalEntity's internal refcount has dropped to zero.
+                // - IPhysicalWorld::DestroyPhysicalEntity() has been called on it.
+                // We store IPhysicalEntity in a ptr whose custom destructor
+                // ensures that these steps are all followed.
+                physicalEntity->Release();
+                gEnv->pPhysicalWorld->DestroyPhysicalEntity(physicalEntity);
+            });
+        }
+
+        return result;
+    }
+
     void PhysicsComponent::EnablePhysics()
     {
         if (m_physicalEntity)
@@ -497,18 +522,7 @@ namespace LmbrCentral
             return;
         }
 
-        // IPhysicalEntity is owned by IPhysicalWorld and will not be destroyed until both:
-        // - IPhysicalEntity's internal refcount has dropped to zero.
-        // - IPhysicalWorld::DestroyPhysicalEntity() has been called on it.
-        // We store IPhysicalEntity in a ptr whose custom destructor
-        // ensures that these steps are all followed.
-        rawPhysicalEntityPtr->AddRef();
-        m_physicalEntity.reset(rawPhysicalEntityPtr,
-            [](IPhysicalEntity* physicalEntity)
-            {
-                physicalEntity->Release();
-                gEnv->pPhysicalWorld->DestroyPhysicalEntity(physicalEntity);
-            });
+        m_physicalEntity = CreateIPhysicalEntitySharedPtr(rawPhysicalEntityPtr);
 
         // Let subclass configure the physical entity.
         ConfigurePhysicalEntity();


### PR DESCRIPTION
### Description

Removed the raw IPhysicalEntity pointer from CharacterPhysicsComponent and switched to using an AZStd::shared_ptr in line with the PhysicsComponent. This fixed some issues we had been experiencing with character physics.