### PR TITLE
62) Fix for null pointer dereference.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DRendPipeline.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DRendPipeline.cpp
@@ -4703,7 +4703,10 @@ void CD3D9Renderer::FX_ProcessBatchesList(int nums, int nume, uint32 nBatchFilte
             FX_Start(pShader, nTech, pCurRes, pRE);
         }
 
-        pRE->mfPrepare(true);
+        if (pRE)
+        {
+            pRE->mfPrepare(true);
+        }
 
         if (rRP.m_RIs[0].size() == 0)
         {


### PR DESCRIPTION
### Description 

Added a null pointer check for a crash we found in D3DRendPipeline due to a null dereference.