### PR TITLE
2) Add "Instant" Carrier Thread Response.

### DIFF
--- a/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
+++ b/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
@@ -538,6 +538,8 @@ namespace GridMate
         CTM_DISCONNECT,
         CTM_DELETE_CONNECTION,
         CTM_HANDSHAKE_COMPLETE,
+        CTM_INSTANT_THREAD_RESPONSE_ENABLE,
+        CTM_INSTANT_THREAD_RESPONSE_DISABLE,
     };
 
     enum MainThreadMsg
@@ -830,6 +832,7 @@ namespace GridMate
         void            DebugDeleteConnection(ConnectionID id) override;
         void            DebugEnableDisconnectDetection(bool isEnabled) override;
         bool            DebugIsEnableDisconnectDetection() const override;
+        void            DebugEnableThreadInstantResponse(bool isEnabled) override;
 
         //////////////////////////////////////////////////////////////////////////
         // Synchronized clock in milliseconds. It will wrap around ~49.7 days.
@@ -1943,6 +1946,14 @@ CarrierThread::ThreadPump()
                     {
                         m_trafficControl->OnHandshakeComplete(tc);
                     }
+                } break;
+                case CTM_INSTANT_THREAD_RESPONSE_ENABLE:
+                {
+                    m_threadInstantResponse = true;
+                } break;
+                case CTM_INSTANT_THREAD_RESPONSE_DISABLE:
+                {
+                    m_threadInstantResponse = false;
                 } break;
                 }
                 ;
@@ -4413,6 +4424,27 @@ CarrierImpl::DebugIsEnableDisconnectDetection() const
     // This is not thread safe, but this should not be a problem. If we need to be
     // we can add a new CTM_XXX (Carrier Thread Message)
     return m_thread->m_enableDisconnectDetection;
+}
+
+//=========================================================================
+// DebugEnableThreadInstantResponse
+//=========================================================================
+void
+CarrierImpl::DebugEnableThreadInstantResponse(bool isEnabled)
+{
+    ThreadMessage* ctm = nullptr;
+    if (isEnabled)
+    {
+        ctm = aznew ThreadMessage(CTM_INSTANT_THREAD_RESPONSE_ENABLE);
+    }
+    else
+    {
+        ctm = aznew ThreadMessage(CTM_INSTANT_THREAD_RESPONSE_DISABLE);
+    }
+
+    ctm->m_connection = nullptr;
+    ctm->m_threadConnection = nullptr;
+    m_thread->PushCarrierThreadMessage(ctm);
 }
 
 //=========================================================================

--- a/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.h
+++ b/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.h
@@ -184,6 +184,13 @@ namespace GridMate
         virtual bool            DebugIsEnableDisconnectDetection() const                        { return false; }
         // @}
 
+        /**
+         * Debug function which will allow the gm_carrierThreadInstantResponse to be changed at runtime for testing.
+         * \param isEnabled Specifies whether IO events should wake the carrier thread instantly
+        */
+        virtual void            DebugEnableThreadInstantResponse(bool isEnabled) { (void)isEnabled; }
+
+
         //////////////////////////////////////////////////////////////////////////
         // Synchronized clock in milliseconds. It will wrap around ~49.7 days.
         /**

--- a/dev/Code/Framework/GridMate/GridMate/Session/Session.cpp
+++ b/dev/Code/Framework/GridMate/GridMate/Session/Session.cpp
@@ -1440,6 +1440,33 @@ GridSession::DebugIsEnableDisconnectDetection() const
     return m_state->m_isDisconnectDetection.Get();
 }
 
+//=========================================================================
+// DebugEnableThreadInstantResponse
+//=========================================================================
+void 
+GridSession::DebugEnableThreadInstantResponse(bool isEnable)
+{
+    AZ_Assert(m_state, "Invalid session state replica. Session is not initialized.");
+
+    if (IsHost())
+    {
+        //  This will be called on the Client via the "m_isThreadInstantResponse" callback on the dataset change
+        DebugEnableThreadInstantResponseOnCarrier(isEnable);
+    }
+
+    m_state->m_isThreadInstantResponse.Set(isEnable);
+}
+
+//=========================================================================
+// DebugEnableThreadInstantResponseOnCarrier
+//=========================================================================
+void 
+GridSession::DebugEnableThreadInstantResponseOnCarrier(bool isEnable)
+{
+    AZ_Assert(m_carrier, "Invalid carrier.");
+    m_carrier->DebugEnableThreadInstantResponse(isEnable);
+}
+
 //////////////////////////////////////////////////////////////////////////
 // State machine
 //////////////////////////////////////////////////////////////////////////

--- a/dev/Code/Framework/GridMate/GridMate/Session/Session.h
+++ b/dev/Code/Framework/GridMate/GridMate/Session/Session.h
@@ -502,6 +502,11 @@ namespace GridMate
         bool DebugIsEnableDisconnectDetection() const;
         /// @}
 
+        /// @{ Debug: Functions for setting carrier instant response on host and client
+        void DebugEnableThreadInstantResponse(bool isEnable);
+        void DebugEnableThreadInstantResponseOnCarrier(bool isEnable);
+        /// @}
+
     protected:
         // Currently we support ONLY one carrier per session, since when we received messages from the carrier we don't prefix them with session ID
         // we we do so, we can share a carrier between sessions. TODO: If you enable it make sure to add function to check if you own that carrier or NOT
@@ -839,11 +844,13 @@ namespace GridMate
                 , m_topology("Topology", ST_INVALID)
                 , m_params("Params")
                 , m_isDisconnectDetection("DisconnectDetection", true)
+                , m_isThreadInstantResponse("ThreadInstantResponse", false)
                 , m_session(session)
             {
                 if (m_session)
                 {
                     m_isDisconnectDetection.Set(m_session->GetCarrierDesc().m_enableDisconnectDetection);
+                    m_isThreadInstantResponse.Set(m_session->GetCarrierDesc().m_threadInstantResponse);
                 }
                 SetPriority(k_replicaPriorityRealTime);
             }
@@ -886,6 +893,13 @@ namespace GridMate
             };
             DataSet<ParamContainer, ContainerMarshaler<ParamContainer, ParamMarshaler> > m_params; ///< Session params.
             DataSet<bool> m_isDisconnectDetection; ///< Allows to control disconnect detection states in the entire session.
+
+            void OnThreadInstantResponseChanged(const bool& isEnabled, const GridMate::TimeContext& timeContext)
+            {
+                (timeContext);
+                m_session->DebugEnableThreadInstantResponseOnCarrier(isEnabled);
+            }
+            DataSet<bool>::BindInterface<GridSessionReplica, &GridSessionReplica::OnThreadInstantResponseChanged> m_isThreadInstantResponse; ///< Allows control over instant carrier thread response on IO events
 
         protected:
             GridSession* m_session;

--- a/dev/Gems/Multiplayer/Code/Source/MultiplayerCVars.cpp
+++ b/dev/Gems/Multiplayer/Code/Source/MultiplayerCVars.cpp
@@ -393,6 +393,19 @@ namespace Multiplayer
         session->GetReplicaMgr()->SetSendLimitBurstRange(cvar->GetFVal());
     }
 
+    static void OnInstantResponseChanged(ICVar* cvar)
+    {
+        GridMate::GridSession* session = nullptr;
+        EBUS_EVENT_RESULT(session, Multiplayer::MultiplayerRequestBus, GetSession);
+
+        if (!session)
+        {
+            return;
+        }
+
+        session->DebugEnableThreadInstantResponse(cvar->GetIVal() != 0);
+    }
+
     //-----------------------------------------------------------------------------
     MultiplayerCVars* MultiplayerCVars::s_instance = nullptr;
 
@@ -449,7 +462,7 @@ namespace Multiplayer
             REGISTER_INT_CB("gm_replicasSendTime", 0, VF_NULL, "Time interval between replicas sends (in milliseconds), 0 will bound sends to GridMate tick rate", OnReplicasSendTimeChanged);
             REGISTER_INT_CB("gm_replicasSendLimit", 0, VF_DEV_ONLY, "Replica data send limit in bytes per second. 0 - limiter turned off. (Dev build only)", OnReplicasSendLimitChanged);
             REGISTER_FLOAT_CB("gm_burstTimeLimit", 10.f, VF_DEV_ONLY, "Burst in bandwidth will be allowed for the given amount of time(in seconds). Burst will only be allowed if bandwidth is not capped at the time of burst. (Dev build only)", OnReplicasBurstRangeChanged);
-
+            REGISTER_INT_CB("gm_carrierThreadInstantResponse", 0, VF_NULL, "Specifies that IO events should wake the carrier thread instantly.", OnInstantResponseChanged);
 
 #if !defined(BUILD_GAMELIFT_SERVER) && defined(BUILD_GAMELIFT_CLIENT)
             REGISTER_STRING("gamelift_fleet_id", "", VF_DUMPTODISK, "Id of GameLift Fleet to use with this client.");
@@ -501,7 +514,7 @@ namespace Multiplayer
 #endif
 
 
-
+            UNREGISTER_CVAR("gm_carrierThreadInstantResponse");
             UNREGISTER_CVAR("gm_burstTimeLimit");
             UNREGISTER_CVAR("gm_replicasSendLimit");
             UNREGISTER_CVAR("gm_replicasSendTime");


### PR DESCRIPTION
### Description 

Added "Instant" Carrier Thread Response

By default, GridMate's messaging API (Carrier) is updated every 30ms. This change implements a method and corresponding CVar to enable an instant response to IO events which will wake up the Carrier thread immediately. 

The CVar ("gm_carrierThreadInstantResponse") when used on the Host will update and propagate to all Clients. By default this is turned off.

CVar can be used in AutoExec.cfg

With this turned off, the RTT of MP games will never be lower than 30ms (even on localhost). Turning this on will reduce the minimum RTT to ~1ms (fluctuates), however, will use more bandwidth (not currently measured).