### PR TITLE
63) Bug fix for physics entities failing to create.

### DIFF
--- a/dev/Code/CryEngine/CryAnimation/SkeletonPhysics.cpp
+++ b/dev/Code/CryEngine/CryAnimation/SkeletonPhysics.cpp
@@ -913,7 +913,15 @@ IPhysicalEntity* CSkeletonPhysics::CreateCharacterPhysics(
 
         pe_params_pos pp;
         pp.iSimClass = 6;
-        m_pCharPhysics = g_pIPhysicalWorld->CreatePhysicalEntity(PE_ARTICULATED, 5.0f, &pp, pfd.pForeignData, pfd.iForeignData);
+
+        // Set the position of the physics entity on creation as supplied.
+        Matrix34 transform(mtxloc);
+        pp.pMtx3x4 = &transform;
+
+        //  The foreign data has to be 0x5AFE on creation otherwise the position will not 
+        //  get set until later by a deferred job, resulting in character dimensions failing to create.
+        m_pCharPhysics = g_pIPhysicalWorld->CreatePhysicalEntity(PE_ARTICULATED, 5.0f, &pp, 0, 0x5AFE);
+        m_pCharPhysics->SetParams(&pfd);
 
 #   if !defined(_RELEASE)
         pe_params_flags pf;

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/CharacterPhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/CharacterPhysicsComponent.cpp
@@ -464,11 +464,16 @@ namespace LmbrCentral
         m_physicalEntity = gEnv->pPhysicalWorld->CreatePhysicalEntity(
             PE_LIVING, // type
             &positionParameters, // params
-            static_cast<uint64>(GetEntityId()), // pForeignData
-            PHYS_FOREIGN_ID_COMPONENT_ENTITY, // iForeignData
+            0,
+            0x5AFE,
             -1, // id
             nullptr // IGeneralMemoryHeap
         );
+
+        pe_params_foreign_data foreignDataParams;
+        foreignDataParams.iForeignData = PHYS_FOREIGN_ID_COMPONENT_ENTITY;
+        foreignDataParams.pForeignData = static_cast<uint64>(GetEntityId());
+        m_physicalEntity->SetParams(&foreignDataParams);
 
         pe_simulation_params simParams;
         m_physicalEntity->GetParams(&simParams);

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsComponent.cpp
@@ -486,8 +486,8 @@ namespace LmbrCentral
         IPhysicalEntity* rawPhysicalEntityPtr = gEnv->pPhysicalWorld->CreatePhysicalEntity(
                 GetPhysicsType(), // type
                 &positionParameters, // params
-                static_cast<uint64>(GetEntityId()), // pForeignData
-                PHYS_FOREIGN_ID_COMPONENT_ENTITY, // iForeignData
+                0,
+                0x5AFE,
                 -1, // id
                 nullptr); // IGeneralMemoryHeap
 
@@ -496,6 +496,11 @@ namespace LmbrCentral
             AZ_Assert(false, "Failed to create physical entity.");
             return;
         }
+
+        pe_params_foreign_data foreignDataParams;
+        foreignDataParams.iForeignData = PHYS_FOREIGN_ID_COMPONENT_ENTITY;
+        foreignDataParams.pForeignData = static_cast<uint64>(GetEntityId());
+        m_physicalEntity->SetParams(&foreignDataParams);
 
         // IPhysicalEntity is owned by IPhysicalWorld and will not be destroyed until both:
         // - IPhysicalEntity's internal refcount has dropped to zero.

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/RagdollComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/RagdollComponent.cpp
@@ -337,10 +337,18 @@ namespace LmbrCentral
         positionParameters.q = AZQuaternionToLYQuaternion(AZ::Quaternion::CreateFromTransform(transform));
 
         // create the ragdoll physics entity
-        m_physicalEntity = gEnv->pPhysicalWorld->CreatePhysicalEntity(PE_ARTICULATED, &positionParameters, static_cast<uint64>(GetEntityId()), PHYS_FOREIGN_ID_COMPONENT_ENTITY);
+        m_physicalEntity = gEnv->pPhysicalWorld->CreatePhysicalEntity(
+            PE_ARTICULATED, 
+            &positionParameters, 
+            0,
+            0x5AFE);
         AZ_Assert(m_physicalEntity, "new failed to create a physical entity for the ragdoll component.");
         m_physicalEntity->AddRef();
 
+        pe_params_foreign_data foreignDataParams;
+        foreignDataParams.iForeignData = PHYS_FOREIGN_ID_COMPONENT_ENTITY;
+        foreignDataParams.pForeignData = static_cast<uint64>(GetEntityId());
+        m_physicalEntity->SetParams(&foreignDataParams);
 
         ICharacterInstance* character = nullptr;
         EBUS_EVENT_ID_RESULT(character, GetEntityId(), SkinnedMeshComponentRequestBus, GetCharacterInstance);


### PR DESCRIPTION
### Description 

Bug fix for physics entities failing to create due to their initial position being set on a thread rather than at creation time. In our case, this was resulting in floating rockets and characters that could not move.

- At creation, specify 0x5AFE as the foreign data, which causes the Cry physics system to set the initial parameters immediately rather than putting them on to the job queue.
- Added the pe_params_foreign_data SetParams call after creation, to put the component-entity data into the foreign data (by this point, the 0x5AFE has been used and is no longer needed).