### PR TITLE
66) Fix for the scan lines post process GFX using "texture not found"

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/PostProcess/PostProcess.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/PostProcess/PostProcess.cpp
@@ -583,7 +583,7 @@ int CPostEffectsMgr::SortEffectsByID(const CPostEffect* p1, const CPostEffect* p
 
 int CParamTexture::Create(const char* pszFileName)
 {
-    if (!pszFileName)
+    if (!pszFileName || pszFileName[0] == '\0')
     {
         return 0;
     }


### PR DESCRIPTION
### Description 

A fix for the scan lines post-process GFX using "texture not found" placeholder texture in Release.

VisualArtifacts post process FX does not use any mask texture by default. This is a valid, handled case, yet the effect was using "Texture not found" texture in release builds.