### PR TITLE
67) Added option to raycast to specify the collision class to interact with.

### DIFF
--- a/dev/Code/CryEngine/CryCommon/physinterface.h
+++ b/dev/Code/CryEngine/CryCommon/physinterface.h
@@ -3874,6 +3874,7 @@ struct IPhysicalWorld
     virtual int GetEntitiesInBox(Vec3 ptmin, Vec3 ptmax, IPhysicalEntity**& pList, int objtypes, int szListPrealloc = 0) = 0;
 
     virtual int GetMaxThreads() = 0;
+    virtual void RayWorldIntersection_IgnoreCollisionClassesByDefault(uint32 collisionClasses, bool ignore) = 0;
     virtual int RayWorldIntersection(const SRWIParams& rp, const char* pNameTag = RWI_NAME_TAG, int iCaller = GetMaxPhysThreads()) = 0;
     // Traces ray requests (rwi calls with rwi_queue set); logs and calls EventPhysRWIResult for each
     // returns the number of rays traced

--- a/dev/Code/CryEngine/CryPhysics/physicalworld.cpp
+++ b/dev/Code/CryEngine/CryPhysics/physicalworld.cpp
@@ -375,6 +375,9 @@ CPhysicalWorld::CPhysicalWorld(ILog* pLog)
     m_pFirstEventChunk = m_pCurEventChunk = (EventChunk*)(new char[sizeof(EventChunk) + EVENT_CHUNK_SZ]);
     m_pRwiHitsTail = (m_pRwiHitsHead = (m_pRwiHitsPool = new ray_hit[257]) + 1) + 255;
 
+    // Initially we ignore no collision classes
+    m_rayWorldIntersectionDefaultCollisionClassesToIgnore = 0;
+
     Init();
 }
 

--- a/dev/Code/CryEngine/CryPhysics/physicalworld.h
+++ b/dev/Code/CryEngine/CryPhysics/physicalworld.h
@@ -405,6 +405,7 @@ public:
         m_timeSnapshot[iType] = itime_snapshot * m_vars.timeGranularity;
     }
 
+    virtual void RayWorldIntersection_IgnoreCollisionClassesByDefault(uint32 collisionClasses, bool ignore) override;
     // *important* if request RWIs queued iForeignData should be a EPhysicsForeignIds
     virtual int RayWorldIntersection(const Vec3& org, const Vec3& dir, int objtypes, unsigned int flags, ray_hit* hits, int nmaxhits,
         IPhysicalEntity** pSkipEnts = 0, int nSkipEnts = 0, PhysicsForeignData pForeignData = 0, int iForeignData = 0,
@@ -1077,6 +1078,8 @@ public:
     volatile int m_lockBreakQueue;
     volatile int m_lockAuxStepEnt;
     volatile int m_lockWaterMan;
+
+    uint32 m_rayWorldIntersectionDefaultCollisionClassesToIgnore; ///<  Mask of collision classes to ignore by default
 };
 
 const int PHYS_FOREIGN_ID_PHYS_AREA = 12;

--- a/dev/Code/CryEngine/CryPhysics/rwi.cpp
+++ b/dev/Code/CryEngine/CryPhysics/rwi.cpp
@@ -537,6 +537,18 @@ nowater:;
     }
 }
 
+void CPhysicalWorld::RayWorldIntersection_IgnoreCollisionClassesByDefault(uint32 collisionClasses, bool ignore)
+{
+    if (ignore)
+    {
+        m_rayWorldIntersectionDefaultCollisionClassesToIgnore |= collisionClasses;
+    }
+    else
+    {
+        m_rayWorldIntersectionDefaultCollisionClassesToIgnore &= ~collisionClasses;
+    }
+}
+
 int CPhysicalWorld::RayWorldIntersection(const IPhysicalWorld::SRWIParams& rp, const char* pNameTag, int iCaller)
 {
     ray_hit* hits = rp.hits;
@@ -670,6 +682,13 @@ int CPhysicalWorld::RayWorldIntersection(const IPhysicalWorld::SRWIParams& rp, c
             egc.flagsColliderAny = geom_collides;
         }
         egc.collclass = rp.collclass;
+
+        // If no collision class info was specified, use the default ignore list
+        if (egc.collclass.type == 0 && egc.collclass.ignore == 0)
+        {
+            egc.collclass.ignore = m_rayWorldIntersectionDefaultCollisionClassesToIgnore;
+        }
+
         egc.bUsePhysOnDemand = iszero((objtypes & (ent_static | ent_no_ondemand_activation)) - ent_static);
         egc.nMaxHits = rp.nMaxHits;
         egc.pSkipForeignData = (rp.nSkipEnts > 0 && rp.pSkipEnts[0]) ?

--- a/dev/Code/Framework/AzFramework/AzFramework/Physics/PhysicsSystemComponentBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Physics/PhysicsSystemComponentBus.h
@@ -73,6 +73,12 @@ namespace AzFramework
             AZ::Vector3 m_position;  ///< The position of the hit in world space
             AZ::Vector3 m_normal;    ///< The normal of the surface hit
             AZ::EntityId m_entityId; ///< The id of the AZ::Entity hit, or AZ::InvalidEntityId if hit object is not an AZ::Entity
+
+            AZ_INLINE AZStd::string ToString() const
+            {
+                return IsValid() ? 
+                    AZStd::string::format("Hit: %s, Pos: {%f,%f,%f}, Dist: %f", m_entityId.ToString().c_str(), (float)m_position.GetX(), (float)m_position.GetY(), (float)m_position.GetZ(), m_distance) : "";
+            }
         };
 
         /**
@@ -113,6 +119,9 @@ namespace AzFramework
 
             /// \ref PhysicalEntityTypes that the ray can hit.
             int m_physicalEntityTypes = PhysicalEntityTypes::All;
+
+            /// Mask for the collision classes to check for, 0 is default (all)
+            int m_collisionClass = 0;
         };
 
         /**

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsSystemComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsSystemComponent.cpp
@@ -177,6 +177,8 @@ namespace LmbrCentral
                 ->Property("normal", BehaviorValueGetter(&RayCastHit::m_normal), nullptr)
                 ->Property("entityId", BehaviorValueGetter(&RayCastHit::m_entityId), nullptr)
                 ->Method("IsValid", &RayCastHit::IsValid)
+                ->Method("ToString", &RayCastHit::ToString)
+                    ->Attribute(AZ::Script::Attributes::Operator, AZ::Script::Attributes::OperatorType::ToString)
                 ;
 
             // RayCastConfiguration
@@ -418,6 +420,13 @@ namespace LmbrCentral
         cryParams.hits = cryHits.data();
         cryParams.nMaxHits = cryHits.size();
         cryParams.flags = rwi_pierceability(AZ::GetClamp<decltype(configuration.m_piercesSurfacesGreaterThan)>(configuration.m_piercesSurfacesGreaterThan, 0, sf_max_pierceable));
+
+        // If the user specified a collision class then we want to match the type and ignore all others
+        if (configuration.m_collisionClass)
+        {
+            cryParams.collclass.type = configuration.m_collisionClass;
+            cryParams.collclass.ignore = ~configuration.m_collisionClass;
+        }
 
         // Set ignored entities
         AZStd::vector<IPhysicalEntity*> ignorePhysicalEntities;


### PR DESCRIPTION
### Description

Added an option to allow raycasts to not interact with specific collision classes by default. 
- In our game, we had two distinct physical worlds and a whole host of classes which should not be returned from our raycast queries. 
- By adding the option to specify default classes to ignore by default, and to change these at runtime, we were able to remove a lot of noise from our raycast results.

Added ToString for debugging RayCastHits.

### Example
``` c++
pe_collision_class m_collisionClass = collision_class_living;

void RaycastMaskComponent::Activate()
{
	IPhysicalEntity* physicalEntity = nullptr;
	EBUS_EVENT_ID_RESULT(physicalEntity, GetEntityId(), LmbrCentral::CryPhysicsComponentRequestBus, GetPhysicalEntity);
	if (physicalEntity)
	{
                pe_params_collision_class paramsCollisionClass;
		paramsCollisionClass.collisionClassAND.type = paramsCollisionClass.collisionClassOR.type = m_collisionClass;
		physicalEntity->SetParams(&paramsCollisionClass, true);
	}

	if (m_initiallyActive)
	{
		EnableRaycastMask();
	}
}

void RaycastMaskComponent::EnableRaycastMask()
{
	if (gEnv && gEnv->pPhysicalWorld)
	{
		gEnv->pPhysicalWorld->RayWorldIntersection_IgnoreCollisionClassesByDefault(m_collisionClass, true);
	}
}

void RaycastMaskComponent::DisableRaycastMask()
{
	if (gEnv && gEnv->pPhysicalWorld)
	{
		gEnv->pPhysicalWorld->RayWorldIntersection_IgnoreCollisionClassesByDefault(m_collisionClass, false);
	}
}
```