### PR TITLE
68) Fix for not being able to connect to the MultiplayerEvents bus from Lua

### DIFF
--- a/dev/Gems/Multiplayer/Code/Source/MultiplayerEventsComponent.cpp
+++ b/dev/Gems/Multiplayer/Code/Source/MultiplayerEventsComponent.cpp
@@ -157,6 +157,13 @@ namespace Multiplayer
                 ->Method("IsLeaderboardServiceStarted", &GridMate::IGridMate::IsLeaderboardServiceStarted)
                 ->Method("IsAchievementServiceStarted", &GridMate::IGridMate::IsAchievementServiceStarted)
                 ->Method("IsStorageServiceStarted", &GridMate::IGridMate::IsStorageServiceStarted)
+                ->Method("GetHandle", []() -> GridMate::IGridMate* {
+                    if (gEnv && gEnv->pNetwork)
+                    {
+                        return gEnv->pNetwork->GetGridMate();
+                    }
+                    return nullptr;
+                });
                 ;
 
             behaviorContext->Class<GridMate::GridSession>()


### PR DESCRIPTION
### Description 
	
Fix for not being able to connect to the MultiplayerEvents bus from Lua. The bus requires you to pass a pointer to GridMate as the bus address in order to connect, prior to this change there was no way to achieve this from Lua. It looks like the bus intended the user to be able to pass a null pointer as the id when connecting, however, there is no way to specify a nullptr from Lua, and additionally, it is not possible to call Connect without an address if you are connecting to an addressed bus.

``` lua
    local gridMate = GridMate_IGridMate.GetHandle();
    ebus:AddHandler(gridMate, MultiplayerEvents, self)
```