### PR TITLE
69) Flag to disable streaming on a material

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/MatMan.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/MatMan.cpp
@@ -427,6 +427,24 @@ _smart_ptr<IMaterial> CMatMan::LoadMaterialInternal(const char* sMtlName, bool b
     {
         pMtl = CreateMaterialPlaceholder(name.c_str(), nLoadingFlags, szDefaultSolid);
     }
+    
+    if (pMtl)
+    {
+        if (pMtl->GetFlags() & MTL_FLAG_DO_NOT_STREAM)
+        {
+            pMtl->DisableTextureStreaming();
+        }
+
+        int nSubMtlCount = pMtl->GetSubMtlCount();
+        for (int i = 0; i < nSubMtlCount; i++)
+        {
+            _smart_ptr<IMaterial> pSubMtl = pMtl->GetSubMtl(i);
+            if (pSubMtl->GetFlags() & MTL_FLAG_DO_NOT_STREAM)
+            {
+                pSubMtl->DisableTextureStreaming();
+            }
+        }
+    }
 
     return pMtl;
 }

--- a/dev/Code/CryEngine/CryCommon/IMaterial.h
+++ b/dev/Code/CryEngine/CryCommon/IMaterial.h
@@ -92,11 +92,13 @@ enum EMaterialFlags
     MTL_FLAG_DELETE_PENDING             = 0x800000, // Internal use only
     MTL_FLAG_BLEND_TERRAIN              = 0x1000000,
     MTL_FLAG_IS_TERRAIN                 = 0x2000000,// indication to the loader - Terrain type
-    MTL_FLAG_IS_SKY                     = 0x4000000 // indication to the loader - Sky type
+    MTL_FLAG_IS_SKY                     = 0x4000000, // indication to the loader - Sky type
+    MTL_FLAG_DO_NOT_STREAM              = 0x40000000 // Do not stream this material
 };
 
 #define MTL_FLAGS_SAVE_MASK (MTL_FLAG_WIRE | MTL_FLAG_2SIDED | MTL_FLAG_ADDITIVE |  MTL_FLAG_LIGHTING | \
-                             MTL_FLAG_NOSHADOW | MTL_FLAG_MULTI_SUBMTL | MTL_FLAG_SCATTER | MTL_FLAG_REQUIRE_FORWARD_RENDERING | MTL_FLAG_HIDEONBREAK | MTL_FLAG_UIMATERIAL | MTL_64BIT_SHADERGENMASK | MTL_FLAG_REQUIRE_NEAREST_CUBEMAP | MTL_FLAG_CONSOLE_MAT | MTL_FLAG_BLEND_TERRAIN)
+                             MTL_FLAG_NOSHADOW | MTL_FLAG_MULTI_SUBMTL | MTL_FLAG_SCATTER | MTL_FLAG_REQUIRE_FORWARD_RENDERING | MTL_FLAG_HIDEONBREAK | MTL_FLAG_UIMATERIAL | MTL_64BIT_SHADERGENMASK | MTL_FLAG_REQUIRE_NEAREST_CUBEMAP | MTL_FLAG_CONSOLE_MAT | MTL_FLAG_BLEND_TERRAIN | \
+                             MTL_FLAG_DO_NOT_STREAM) 
 
 // Post effects flags
 enum EPostEffectFlags

--- a/dev/Code/Sandbox/Editor/Material/MaterialDialog.cpp
+++ b/dev/Code/Sandbox/Editor/Material/MaterialDialog.cpp
@@ -202,6 +202,7 @@ public:
     CSmartVariable<bool> bHideAfterBreaking;
     CSmartVariable<bool> bBlendTerrainColor;
     //CSmartVariable<bool> bTranslucenseLayer;
+    CSmartVariable<bool> bDoNotStream;
     CSmartVariableEnum<QString> surfaceType;
 
     CSmartVariable<bool> allowLayerActivation;
@@ -525,6 +526,7 @@ public:
         AddVariable(tableAdvanced, bPropagateShaderParams, "Propagate Shader Params", "");
         AddVariable(tableAdvanced, bPropagateShaderGenParams, "Propagate Shader Generation", "");
         AddVariable(tableAdvanced, bPropagateVertexDef, "Propagate Vertex Deformation", "");
+        AddVariable(tableAdvanced, bDoNotStream, "Do Not Stream (Use Sparingly)", "");
 
         //////////////////////////////////////////////////////////////////////////
         // Init Vertex Deformation.
@@ -1146,6 +1148,7 @@ void CMaterialUI::SetFromMaterial(CMaterial* mtlIn)
     bScatter = (mtlFlags & MTL_FLAG_SCATTER);
     bHideAfterBreaking = (mtlFlags & MTL_FLAG_HIDEONBREAK);
     bBlendTerrainColor = (mtlFlags & MTL_FLAG_BLEND_TERRAIN);
+    bDoNotStream = (mtlFlags & MTL_FLAG_DO_NOT_STREAM);
     texUsageMask = mtlIn->GetTexmapUsageMask();
 
     allowLayerActivation = mtlIn->LayerActivationAllowed();
@@ -1247,6 +1250,15 @@ void CMaterialUI::SetToMaterial(CMaterial* mtl, int propagationFlags)
         else
         {
             mtlFlags &= ~MTL_FLAG_BLEND_TERRAIN;
+        }
+
+        if (bDoNotStream)
+        {
+            mtlFlags |= MTL_FLAG_DO_NOT_STREAM;
+        }
+        else
+        {
+            mtlFlags &= ~MTL_FLAG_DO_NOT_STREAM;
         }
     }
 


### PR DESCRIPTION
### Description 

Added a MTL_FLAG_DO_NOT_STREAM flag which, post material load, will disable texture streaming if set on the material or a sub-material.