### PR TITLE
72) Fix for Amazon HTTP requestor

### DIFF
--- a/dev/Gems/HttpRequestor/Code/Source/HttpRequestManager.cpp
+++ b/dev/Gems/HttpRequestor/Code/Source/HttpRequestManager.cpp
@@ -80,7 +80,7 @@ namespace HttpRequestor
     {
         // Lock mutex and wait for work to be signalled via the condition variable
         AZStd::unique_lock<AZStd::mutex> lock(m_requestMutex);
-        m_requestConditionVar.wait(lock);
+        m_requestConditionVar.wait(lock, [&] { return !m_runThread || !m_requestsToHandle.empty() || !m_textRequestsToHandle.empty(); });
 
         // Swap queues
         AZStd::queue<Parameters> requestsToHandle;


### PR DESCRIPTION
### Description 

Fix for HTTP requestor dropping requests that are made in quick succession due to incorrect use of a condition variable.
