### PR TITLE
76) Eliminate benign game rules related errors and warnings

### DIFF
--- a/dev/Code/CryEngine/CryAction/GameRulesSystem.cpp
+++ b/dev/Code/CryEngine/CryAction/GameRulesSystem.cpp
@@ -46,7 +46,14 @@ bool CGameRulesSystem::RegisterGameRules(const char* rulesName, const char* exte
     IEntityClassRegistry::SEntityClassDesc ruleClass;
 
     char scriptName[1024];
-    sprintf_s(scriptName, "Scripts/GameRules/%s.lua", rulesName);
+    if (extensionName && strcmp(extensionName, "NoCryLuaScript") == 0)
+    {
+        scriptName[0] = '\0';
+    }
+    else
+    {
+        sprintf_s(scriptName, "Scripts/GameRules/%s.lua", rulesName);
+    }
 
     ruleClass.sName = rulesName;
     ruleClass.sScriptFile = scriptName;


### PR DESCRIPTION
### Description 

Added "NoCryLuaScript" option to `GameRulesSystem::RegisterGameRules()`.

We use the AZ Lua scripting yet `GameRulesSystem` will try to load the script using Cry script system, resulting in benign, but potentially confusing, error spam in TTY such as:

```
[Warning] [Lua Error] Failed to load script file Scripts/GameRules/DummyRules.lua
```

This change uses the `extensionName` argument for passing a hint to not use a Lua script for this game rules. For example:

``` c++ 
bool MyGame::Init(IGameFramework* framework)
{
    ...
    // Register game rules wrapper.
    pGameRulesSystem->RegisterGameRules("DummyRules", "NoCryLuaScript");
}
```

