### PR TITLE
79) Add ignored entities to trigger area component

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Scripting/EditorTriggerAreaComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Scripting/EditorTriggerAreaComponent.cpp
@@ -46,10 +46,15 @@ namespace LmbrCentral
                     ->DataElement(AZ::Edit::UIHandlers::ComboBox, &TriggerAreaComponent::m_activationEntityType, "Activated by", "The types of entities capable of interacting with the area trigger.")
                         ->EnumAttribute(TriggerAreaComponent::ActivationEntityType::AllEntities, "All entities")
                         ->EnumAttribute(TriggerAreaComponent::ActivationEntityType::SpecificEntities, "Specific entities")
+						->EnumAttribute(TriggerAreaComponent::ActivationEntityType::IgnoreEntities, "Ignore entities")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &TriggerAreaComponent::OnActivatedByComboBoxChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &TriggerAreaComponent::m_specificInteractEntities, "Specific entities", "List of entities that can interact with the trigger.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &TriggerAreaComponent::UseSpecificEntityList)
-                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+					->DataElement(AZ::Edit::UIHandlers::Default, &TriggerAreaComponent::m_ignoredEntities, "Ignore entities", "List of entities which will not interact with the trigger.")
+						->Attribute(AZ::Edit::Attributes::Visibility, &TriggerAreaComponent::UseIgnoredEntityList)
+						->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+					;
 
                 edit->Class<EditorTriggerAreaComponent>("Trigger Area", "The Trigger Area component provides generic triggering services by using Shape components as its bounds")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")

--- a/dev/Gems/LmbrCentral/Code/Source/Scripting/TriggerAreaComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Scripting/TriggerAreaComponent.cpp
@@ -186,6 +186,7 @@ namespace LmbrCentral
                 ->Field("TriggerOnce", &TriggerAreaComponent::m_triggerOnce)
                 ->Field("ActivatedBy", &TriggerAreaComponent::m_activationEntityType)
                 ->Field("SpecificInteractEntities", &TriggerAreaComponent::m_specificInteractEntities)
+				->Field("IgnoreInteractEntities", &TriggerAreaComponent::m_ignoredEntities)
                 ->Field("RequiredTags", &TriggerAreaComponent::m_requiredTags)
                 ->Field("ExcludedTags", &TriggerAreaComponent::m_excludedTags);
         }
@@ -198,6 +199,8 @@ namespace LmbrCentral
                 ->Event("RemoveRequiredTag", &TriggerAreaRequestsBus::Events::RemoveRequiredTag)
                 ->Event("AddExcludedTag", &TriggerAreaRequestsBus::Events::AddExcludedTag)
                 ->Event("RemoveExcludedTag", &TriggerAreaRequestsBus::Events::RemoveExcludedTag)
+				->Event("AddIgnoredEntity", &TriggerAreaRequestsBus::Events::AddIgnoredEntity)
+				->Event("RemoveIgnoredEntity", &TriggerAreaRequestsBus::Events::RemoveIgnoredEntity)
                 ;
 
             behaviorContext->EBus<TriggerAreaNotificationBus>("TriggerAreaNotificationBus")
@@ -353,6 +356,30 @@ namespace LmbrCentral
         }
     }
 
+	void TriggerAreaComponent::AddIgnoredEntity(const AZ::EntityId& ignoredEntityId)
+	{
+		const auto& ignoredEntityIter = AZStd::find(m_ignoredEntities.begin(), m_ignoredEntities.end(), ignoredEntityId);
+		bool isEntityIgnored = (m_ignoredEntities.end() != ignoredEntityIter);
+		if (!isEntityIgnored)
+		{
+			m_ignoredEntities.push_back(ignoredEntityId);
+			ReevaluateAllIgnoredEntities();
+		}
+	}
+
+	void TriggerAreaComponent::RemoveIgnoredEntity(const AZ::EntityId& ignoredEntityId)
+	{
+		const auto& ignoredEntityIter = AZStd::find(m_ignoredEntities.begin(), m_ignoredEntities.end(), ignoredEntityId);
+		bool isEntityIgnored = (m_ignoredEntities.end() != ignoredEntityIter);
+		AZ_Warning("TriggerAreaComponent", isEntityIgnored, "No such entity is ignored %s", ignoredEntityId.ToString().c_str());
+
+		if (isEntityIgnored)
+		{
+			m_ignoredEntities.erase(ignoredEntityIter);
+			ReevaluateAllIgnoredEntities();
+		}
+	}
+
     void TriggerAreaComponent::OnTick(float deltaTime, AZ::ScriptTimePoint)
     {
         TriggerAreaReplicaChunk* triggerAreaReplicaChunk = static_cast<TriggerAreaReplicaChunk*>(m_replicaChunk.get());
@@ -470,6 +497,12 @@ namespace LmbrCentral
             m_entitiesInsideExcludedByTags.erase(excludedEntityIter);
         }
 
+		auto ignoredEntityIter = AZStd::find(m_entitiesInsideExcludedByIgnoreList.begin(), m_entitiesInsideExcludedByIgnoreList.end(), entityId);
+		if (ignoredEntityIter != m_entitiesInsideExcludedByIgnoreList.end())
+		{
+			m_entitiesInsideExcludedByIgnoreList.erase(ignoredEntityIter);
+		}
+		
         TagComponentNotificationsBus::MultiHandler::BusDisconnect(entityId);
 
         return retVal;
@@ -517,6 +550,12 @@ namespace LmbrCentral
                 result = foundIter != m_specificInteractEntities.end();
                 break;
             }
+			case ActivationEntityType::IgnoreEntities:
+			{
+				auto foundIter = AZStd::find(m_ignoredEntities.begin(), m_ignoredEntities.end(), id);
+				result = foundIter == m_ignoredEntities.end();
+				break;
+			}
         }
         
         if (!result)
@@ -697,6 +736,19 @@ namespace LmbrCentral
         }
     }
 
+	void TriggerAreaComponent::ReevaluateAllIgnoredEntities()
+	{
+		for (const AZ::EntityId& entityInside : m_entitiesInside)
+		{
+			HandleIgnoredEntitiesChange(entityInside);
+		}
+
+		for (const AZ::EntityId& entityInside : m_entitiesInsideExcludedByIgnoreList)
+		{
+			HandleIgnoredEntitiesChange(entityInside);
+		}
+	}
+
     void TriggerAreaComponent::HandleTagChange(const AZ::EntityId& entityId)
     {
         FilteringResult result = EntityPassesFilters(entityId);
@@ -719,6 +771,28 @@ namespace LmbrCentral
             }
         }
     }
+
+	void TriggerAreaComponent::HandleIgnoredEntitiesChange(const AZ::EntityId& entityId)
+	{
+		FilteringResult result = EntityPassesFilters(entityId);
+		if (result != FilteringResult::Pass)
+		{
+			OnTriggerExit(entityId);
+			if (result == FilteringResult::FailWithPossibilityOfChange)
+			{
+				m_entitiesInsideExcludedByIgnoreList.push_back(entityId);
+			}
+		}
+		else
+		{
+			OnTriggerEnter(entityId);
+			auto foundIter = AZStd::find(m_entitiesInsideExcludedByIgnoreList.begin(), m_entitiesInsideExcludedByIgnoreList.end(), entityId);
+			if (foundIter != m_entitiesInsideExcludedByIgnoreList.end())
+			{
+				m_entitiesInsideExcludedByIgnoreList.erase(foundIter);
+			}
+		}
+	}
 
     void TriggerAreaComponent::OnTagAdded(const Tag& tagAdded)
     {

--- a/dev/Gems/LmbrCentral/Code/Source/Scripting/TriggerAreaComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Scripting/TriggerAreaComponent.h
@@ -73,6 +73,9 @@ namespace LmbrCentral
 
         void AddExcludedTag(const Tag& excludedTag) override;
         void RemoveExcludedTag(const Tag& excludedTag) override;
+
+		void AddIgnoredEntity(const AZ::EntityId&) override;
+		void RemoveIgnoredEntity(const AZ::EntityId&) override;
         //////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////
@@ -139,6 +142,7 @@ namespace LmbrCentral
         {
             AllEntities,
             SpecificEntities,
+			IgnoreEntities,
         };
 
         //! Adds a required tag without Reevaluating trigger (used for building game entities)
@@ -171,14 +175,21 @@ namespace LmbrCentral
         /// Reevaluates tags for all entities in the Area
         void ReevaluateTagsAllEntities();
 
+		/// Reevaluates all ignored entities in the Area
+		void ReevaluateAllIgnoredEntities();
+
         /// Handles changes in tags on any entities that are inside the Trigger volume
         void HandleTagChange(const AZ::EntityId& entityId);
+
+		/// Handles change in the list of ignored entities that are inside the Trigger volume
+		void HandleIgnoredEntitiesChange(const AZ::EntityId& entityId);
 
         ActivationEntityType            m_activationEntityType;     ///< The types of entities able to interact with the trigger area.
         bool                            m_triggerOnce;              ///< Only trigger once.
         AZStd::vector<AZ::EntityId>     m_specificInteractEntities; ///< Specific list of entities that can interact with the trigger, if m_activationEntityType is SpecificEntities.
         AZStd::vector<AZ::EntityId>     m_entitiesInside;           ///< Tracking of valid entities currently inside the trigger.
-        AZStd::vector<AZ::EntityId>     m_entitiesInsideExcludedByTags;           ///< Tracking of valid entities currently spatially inside the trigger but are logically evicted
+		AZStd::vector<AZ::EntityId>     m_entitiesInsideExcludedByTags;           ///< Tracking of valid entities currently spatially inside the trigger but are logically evicted
+		AZStd::vector<AZ::EntityId>     m_entitiesInsideExcludedByIgnoreList;	  ///< Tracking of valid entities currently spatially inside the trigger but are logically evicted
         SProximityElement*              m_proximityTrigger;         ///< The proximity trigger instance per the ProximityTriggerSystem.
 
         GridMate::ReplicaChunkPtr       m_replicaChunk;
@@ -189,7 +200,11 @@ namespace LmbrCentral
         //! The tags that exclude an entity from triggering this Area
         AZStd::vector<LmbrCentral::Tag> m_excludedTags;
 
+		//! The entities which will not trigger this Area if m_activationEntityType is IgnoredEntities
+		AZStd::vector<AZ::EntityId> m_ignoredEntities;
+		
         bool UseSpecificEntityList() const { return m_activationEntityType == ActivationEntityType::SpecificEntities; }
+		bool UseIgnoredEntityList() const { return m_activationEntityType == ActivationEntityType::IgnoreEntities; }
 
         //////////////////////////////////////////////////////////////////////////
         // Component descriptor

--- a/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Scripting/TriggerAreaComponentBus.h
+++ b/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Scripting/TriggerAreaComponentBus.h
@@ -34,6 +34,12 @@ namespace LmbrCentral
 
             //! Removes an excluded tag from the Activation filtering criteria of this component
             virtual void RemoveExcludedTag(const Tag& excludedTag) = 0;
+
+			//! Adds an entityId which will fail the Activation filtering criteria of this component
+			virtual void AddIgnoredEntity(const AZ::EntityId&) = 0;
+
+			//! Removes an entityId from the Activation filtering criteria of this component
+			virtual void RemoveIgnoredEntity(const AZ::EntityId&) = 0;
     };
 
     using TriggerAreaRequestsBus = AZ::EBus<TriggerAreaRequests>;


### PR DESCRIPTION
### Description 

Similarly to how TriggerAreaComponents can ignore entities based on tag, functionality has been added to ignore entities based on entityId. This was used extensively from bespoke Lua components for trigger area management in DRG.