### PR TITLE
78) Fix for lmbr.exe populate-appdescriptors command generating corrupt files. 

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -893,7 +893,7 @@ namespace AZ
                 }
                 m_xmlNode = next;
 
-                Uuid specializedId;
+                Uuid specializedId = Uuid::CreateNull();
                 // now parse the node
                 rapidxml::xml_attribute<char>* attr = m_xmlNode->first_attribute();
                 while (attr)
@@ -946,8 +946,13 @@ namespace AZ
                         }
 
                     }
-                    element.m_id = specializedId;
-                }
+
+					// Don't overwrite the element type if no specializedId attribute exists.
+					if (!specializedId.IsNull())    
+					{
+						element.m_id = specializedId;
+					}
+				}
  
                 // find the registered class data
                 cd = sc.FindClassData(element.m_id, parent, element.m_nameCrc);
@@ -1065,8 +1070,13 @@ namespace AZ
                                 }
                             }
                         }
-                        element.m_id = specializedId;
-                    }
+
+						// Don't overwrite the element type if no specializedId attribute exists.
+						if (!specializedId.IsNull())
+						{
+							element.m_id = specializedId;
+						}
+					}
                 }
                 valueIt = currentElement->FindMember("version");
                 if (valueIt != currentElement->MemberEnd())
@@ -1166,8 +1176,8 @@ namespace AZ
                 // Version 3 of the ObjectStream serializes the specialized type id directly in the data element id field. The data element old id field value is no longer needed
                 if (m_version == 2)
                 {
-                    Uuid specializedId;
-                    nBytesRead = m_stream->Read(specializedId.end() - specializedId.begin(), specializedId.begin());
+					Uuid specializedId = Uuid::CreateNull();
+					nBytesRead = m_stream->Read(specializedId.end() - specializedId.begin(), specializedId.begin());
                     AZ_Assert(nBytesRead == static_cast<IO::SizeType>(specializedId.end() - specializedId.begin()), "Failed trying to read binary class element uuid");
 
                     // The Asset ClassId is handled directly within the LoadClass function
@@ -1184,8 +1194,13 @@ namespace AZ
                                 }
                             }
                         }
-                        element.m_id = specializedId;
-                    }
+
+						// Don't overwrite the element type if no specializedId attribute exists.
+						if (!specializedId.IsNull())
+						{
+							element.m_id = specializedId;
+						}
+					}
                 }
 
                 element.m_dataType = SerializeContext::DataElement::DT_BINARY_BE;


### PR DESCRIPTION
### Description 

Fix for lmbr.exe `populate-appdescriptors` command generating corrupt files.

Previously `FlavorXml::PopulateModules` would clone the descriptor node from the in-memory v3 object stream to the on-disc v-anything XML. This is not a valid thing to do, as it would leave the SystemEntity and root node on the existing ObjectStream version, leaving us with a v2 XML file that contains a v3 descriptor. Instead, we deserialise and reserialise both the descriptor AND the system entity, and write out a whole new XML file in the latest ObjectStream version.

This has the disadvantage that it will destroy any custom system components that have been added to the SystemEntity, because lmbr.exe does not load the gem dlls and register the system components with the serialiser, so they get stripped on load as they are not recognised.

Until we come up with a better fix, this is preferable to writing out corrupt files, and system components will need to be re-added from the ProjectConfigurator after running a `populate-appdescriptors` step.

In `ObjectStream.cpp`, there are fixes for un-initialised variables overwriting the element type if no specializationTypeId attribute exists.

**Note:** 
This GitHub Pull Request _only_ has the changes for `ObjectStream.cpp`. 
The change for Flavor.cpp has been shared separately to this request.
We do not currently have the 1.13 version of Flavor.cpp as it is not distributed through GitHub so this change is against version 1.12. I have left inline comments in `Flavor.cpp` to help follow the reasoning.