### PR TITLE
77) Debug camera additions.

### DIFF
--- a/dev/Code/CryEngine/CryAction/DebugCamera/DebugCamera.h
+++ b/dev/Code/CryEngine/CryAction/DebugCamera/DebugCamera.h
@@ -42,11 +42,14 @@ public:
     void OnEnable();
     void OnDisable();
     void OnInvertY();
-    void OnNextMode();
+	void OnToggleFixedMode();
     void UpdatePitch(float amount);
     void UpdateYaw(float amount);
     void UpdatePosition(const Vec3& amount);
     void MovePosition(const Vec3& offset);
+	inline Vec3 GetPosition() const { return m_position; }
+	inline float GetPitch() const { return m_cameraPitch; }
+	inline float GetYaw() const { return m_cameraYaw; }
 
 protected:
     int m_mouseMoveMode;
@@ -60,7 +63,9 @@ protected:
 
     float m_moveScale;
     float m_oldMoveScale;
-    Vec3 m_position;
+	bool m_goFaster = false;
+	bool m_goSlower = false;
+	Vec3 m_position;
     Matrix33 m_view;
 };
 

--- a/dev/Code/CryEngine/CryCommon/IInput.h
+++ b/dev/Code/CryEngine/CryCommon/IInput.h
@@ -1358,6 +1358,9 @@ struct IInput
     virtual void PostInputEvent(const SInputEvent& event, bool bForce = false) = 0;
     virtual void PostMotionSensorEvent(const SMotionSensorEvent& event, bool bForce = false) = 0;
     virtual void PostUnicodeEvent(const SUnicodeEvent& event, bool bForce = false) = 0;
+	virtual bool WasLastPostedInputEventHandled() const = 0;	// Check if the last posted input event was handled and does not need to be propagated further 
+																// (done via a separate call as this requires fewer changes than adding "wasHandled" ref parameter 
+																// to PostInputEvent(), PostMotionSensorEvent(), and PostUnicodeEvent())
 
     // Description:
     //   For direct key processing (e.g. win proc functions)

--- a/dev/Code/CryEngine/CrySystem/NullImplementation/NullInput.h
+++ b/dev/Code/CryEngine/CrySystem/NullImplementation/NullInput.h
@@ -52,6 +52,7 @@ public:
     virtual void PostInputEvent(const SInputEvent& event, bool bForce = false) {}
     virtual void PostMotionSensorEvent(const SMotionSensorEvent& event, bool bForce = false) {}
     virtual void PostUnicodeEvent(const SUnicodeEvent& event, bool bForce = false) {}
+	virtual bool WasLastPostedInputEventHandled() const { return false; }
 
     virtual void ForceFeedbackEvent(const SFFOutputEvent& event) {}
     virtual void ForceFeedbackSetDeviceIndex(int index) {};

--- a/dev/Gems/CryLegacy/Code/Source/Input/AzToLyInputDevice.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/Input/AzToLyInputDevice.cpp
@@ -109,12 +109,12 @@ void AzToLyInputDevice::OnInputChannelEvent(const InputChannel& inputChannel, bo
     SInputSymbol* inputSymbol = DevSpecIdToSymbol(inputChannel.GetInputChannelId().GetNameCrc32());
     if (inputSymbol)
     {
-        PostCryInputEvent(inputChannel, *inputSymbol);
+		PostCryInputEvent(inputChannel, *inputSymbol, o_hasBeenConsumed); ///< passing in o_hasBeenConsumed, so that systems that use CryInput can filter input events too.
     }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-void AzToLyInputDevice::PostCryInputEvent(const InputChannel& inputChannel, SInputSymbol& inputSymbol)
+void AzToLyInputDevice::PostCryInputEvent(const InputChannel& inputChannel, SInputSymbol& inputSymbol, bool& o_hasBeenConsumed)
 {
     // Value
     inputSymbol.value = inputChannel.GetValue();
@@ -168,11 +168,14 @@ void AzToLyInputDevice::PostCryInputEvent(const InputChannel& inputChannel, SInp
     inputSymbol.AssignTo(inputEvent, GetIInput().GetModifiers());
     GetIInput().PostInputEvent(inputEvent);
 
+	o_hasBeenConsumed = GetIInput().WasLastPostedInputEventHandled(); ///< Check if CryInput handled this event, pass the result up
+
     // CryInput dispatched 'changed' events for touch inputs, in addition to the regular pressed/held/released
     if (inputSymbol.deviceType == eIDT_TouchScreen &&
         inputSymbol.state == eIS_Down)
     {
         inputEvent.state = eIS_Changed;
         GetIInput().PostInputEvent(inputEvent);
+		o_hasBeenConsumed = o_hasBeenConsumed || GetIInput().WasLastPostedInputEventHandled();
     }
 }

--- a/dev/Gems/CryLegacy/Code/Source/Input/AzToLyInputDevice.h
+++ b/dev/Gems/CryLegacy/Code/Source/Input/AzToLyInputDevice.h
@@ -44,7 +44,7 @@ protected:
     void OnInputChannelEvent(const AzFramework::InputChannel& inputChannel,
                              bool& o_hasBeenConsumed) override;
 
-    void PostCryInputEvent(const AzFramework::InputChannel& inputChannel, SInputSymbol& inputSymbol);
+    void PostCryInputEvent(const AzFramework::InputChannel& inputChannel, SInputSymbol& inputSymbol, bool& o_hasBeenConsumed);
 
 protected:
     const AzFramework::InputDeviceId m_azFrameworkInputDeviceId;

--- a/dev/Gems/CryLegacy/Code/Source/Input/AzToLyInputDeviceGamepad.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/Input/AzToLyInputDeviceGamepad.cpp
@@ -70,16 +70,16 @@ void AzToLyInputDeviceGamepad::OnInputChannelEvent(const InputChannel& inputChan
         SInputSymbol* inputSymbol = DevSpecIdToSymbol(AZ::Crc32("gamepad_button_l2_digital"));
         if (inputSymbol)
         {
-            PostCryInputEvent(inputChannel, *inputSymbol);
-        }
+			PostCryInputEvent(inputChannel, *inputSymbol, o_hasBeenConsumed);
+		}
     }
     else if (inputChannel.GetInputChannelId() == InputDeviceGamepad::Trigger::R2)
     {
         SInputSymbol* inputSymbol = DevSpecIdToSymbol(AZ::Crc32("gamepad_button_r2_digital"));
         if (inputSymbol)
         {
-            PostCryInputEvent(inputChannel, *inputSymbol);
-        }
+			PostCryInputEvent(inputChannel, *inputSymbol, o_hasBeenConsumed);
+		}
     }
 }
 

--- a/dev/Gems/CryLegacy/Code/Source/Input/AzToLyInputDeviceMouse.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/Input/AzToLyInputDeviceMouse.cpp
@@ -60,7 +60,7 @@ void AzToLyInputDeviceMouse::OnInputChannelEvent(const InputChannel& inputChanne
 
         if (inputSymbol)
         {
-            PostCryInputEvent(inputChannel, *inputSymbol);
+            PostCryInputEvent(inputChannel, *inputSymbol, o_hasBeenConsumed);
         }
     }
 }

--- a/dev/Gems/CryLegacy/Code/Source/Input/BaseInput.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/Input/BaseInput.cpp
@@ -48,6 +48,7 @@ bool compareInputListener(const IInputEventListener* pListenerA, const IInputEve
 CBaseInput::CBaseInput()
     : m_pExclusiveListener(0)
     , m_enableEventPosting(true)
+	, m_wasLastPostedEventHandled(false)
     , m_retriggering(false)
     , m_hasFocus(false)
     , m_modifiers(0)
@@ -451,6 +452,7 @@ void CBaseInput::PostInputEvent(const SInputEvent& event, bool bForce)
 {
     FUNCTION_PROFILER(GetISystem(), PROFILE_INPUT);
     //CryAutoCriticalSection postInputLock(m_postInputEventMutex);
+	m_wasLastPostedEventHandled = false; ///< Store the handled state of the event, so that it can be later retrieved via WasLastPostedInputEventHandled()
 
     if (!bForce && !m_enableEventPosting)
     {
@@ -477,6 +479,7 @@ void CBaseInput::PostInputEvent(const SInputEvent& event, bool bForce)
 
     if (!SendEventToListeners(event))
     {
+		m_wasLastPostedEventHandled = true;
         return;
     }
     AddEventToHoldSymbols(event);
@@ -495,6 +498,8 @@ void CBaseInput::PostUnicodeEvent(const SUnicodeEvent& event, bool bForce)
     FUNCTION_PROFILER(GetISystem(), PROFILE_INPUT);
     assert(event.inputChar != 0 && Unicode::Validate(event.inputChar) && "Attempt to post invalid unicode event");
 
+	m_wasLastPostedEventHandled = false;
+
     if (!bForce && !m_enableEventPosting)
     {
         return;
@@ -509,6 +514,7 @@ void CBaseInput::PostUnicodeEvent(const SUnicodeEvent& event, bool bForce)
 
     if (!SendEventToListeners(event))
     {
+		m_wasLastPostedEventHandled = true;
         return;
     }
 }

--- a/dev/Gems/CryLegacy/Code/Source/Input/BaseInput.h
+++ b/dev/Gems/CryLegacy/Code/Source/Input/BaseInput.h
@@ -81,8 +81,9 @@ public:
     virtual void    EnableEventPosting(bool bEnable);
     virtual bool    IsEventPostingEnabled () const;
     virtual void    PostInputEvent(const SInputEvent& event, bool bForce = false);
-    virtual void    PostMotionSensorEvent(const SMotionSensorEvent& event, bool bForce = false) {}
+	virtual void    PostMotionSensorEvent(const SMotionSensorEvent& event, bool bForce = false) { m_wasLastPostedEventHandled = false; } ///< Motion events are never handled by the base input.
     virtual void    PostUnicodeEvent(const SUnicodeEvent& event, bool bForce = false);
+	virtual bool    WasLastPostedInputEventHandled() const { return m_wasLastPostedEventHandled; } ///< Return the handled state of the last posted input event.
     virtual void    ForceFeedbackEvent(const SFFOutputEvent& event);
     virtual void    ForceFeedbackSetDeviceIndex(int index);
     virtual void    EnableDevice(EInputDeviceType deviceType, bool enable);
@@ -143,6 +144,7 @@ private:
     IInputEventListener*    m_pExclusiveListener;
 
     bool                    m_enableEventPosting;
+	bool                    m_wasLastPostedEventHandled; ///< Variable holds the handled state of the last PostInputEvent()/PostMotionSensorEvent()/PostUnicodeEvent(). Better way would be to add ref bool parameter to the Post*() functions, but that would require a large number of files to be modified.
     bool                    m_retriggering;
     CryCriticalSection      m_postInputEventMutex;
 


### PR DESCRIPTION
### Description 

DebugCamera modifications, fixes and improvements. 

Note: This changes works with the legacy input and debug camera system, ie the CryLegacy Gem is enabled. The debug free-fly camera has not been updated to be controlled with the new input system (same as current 1.13 behaviour).

### Changes
- Do not send inputs to game entities if debug camera is enabled in free-fly mode. This allows for positioning of a debug camera without the player character moving around.
- Mouse wheel scales the linear speed only (and not angular speed). Typically rotational speed is not an issue whereas translation speed is. 
- Press left ctrl to slow down the camera.
- Additions to get debug camera position & orientation (we used this for teleporting the player to the debug camera position).
- Changed key bindings to use slash instead of backslash which doesn't appear to work
- Hook into console event binding to allow handling of events before the game's main loop.
- Use the UI update time so that the debug camera can still be controlled if the game is paused.
- CTRL-Slash toggles debug camera on/off (instead of on/fixed/off).
- CTRL-LSHIFT-Slash toggles fixed camera on/off, this will work when debug camera is off or in free-fly mode
-- The two changes above combine to make the functionality of the debug camera feel more consistent. Pressing CTRL-/ always turns free fly on/off, pressing CTRL-LSHIFT-/ always turns fixed mode on/off