### PR TITLE
80) Fix for crash due to missing physics foreign data

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/geoman.h
+++ b/dev/Code/CryEngine/CryPhysics/geoman.h
@@ -74,6 +74,11 @@ public:
     virtual phys_geometry* RegisterGeometry(IGeometry* pGeom, int defSurfaceIdx = 0, int* pMatMapping = 0, int nMats = 0);
     virtual int AddRefGeometry(phys_geometry* pgeom);
     virtual int UnregisterGeometry(phys_geometry* pgeom);
+
+private:
+	int UnregisterGeometryLocked(phys_geometry* pgeom);
+public:
+
     virtual void SetGeomMatMapping(phys_geometry* pgeom, int* pMatMapping, int nMats);
 
     virtual void SaveGeometry(CMemStream& stm, IGeometry* pGeom);

--- a/dev/Code/CryEngine/CryPhysics/geometry.h
+++ b/dev/Code/CryEngine/CryPhysics/geometry.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "overlapchecks.h"
+#include "utils.h"
 
 struct tritem
 {
@@ -348,7 +349,12 @@ public:
     virtual Vec3 GetCenter() { return Vec3(ZERO); }
     virtual PhysicsForeignData GetForeignData(int iForeignData = 0) { return iForeignData == m_iForeignData ? m_pForeignData : PhysicsForeignData(0); }
     virtual int GetiForeignData() { return m_iForeignData; }
-    virtual void SetForeignData(PhysicsForeignData pForeignData, int iForeignData) { m_pForeignData = pForeignData; m_iForeignData = iForeignData; }
+	virtual void SetForeignData(PhysicsForeignData pForeignData, int iForeignData)
+	{
+		AZ_Assert(m_iForeignData != DATA_UNSCALED_GEOM, "Overriding foreign data that is reference counted, will leak geometry");
+		m_pForeignData = pForeignData;
+		m_iForeignData = iForeignData;
+	}
 
     virtual float BuildOcclusionCubemap(geom_world_data* pgwd, int iMode, SOcclusionCubeMap* grid0, SOcclusionCubeMap* grid1, int nGrow);
     virtual int DrawToOcclusionCubemap(const geom_world_data* pgwd, int iStartPrim, int nPrims, int iPass, SOcclusionCubeMap* cubeMap) { return 0; }

--- a/dev/Code/CryEngine/CryPhysics/utils.cpp
+++ b/dev/Code/CryEngine/CryPhysics/utils.cpp
@@ -623,6 +623,8 @@ int BakeScaleIntoGeometry(phys_geometry*& pgeom, IGeomManager* pGeoman, const Ve
             pGeoman->UnregisterGeometry(pgeom);
         }
         pGeomScaled->SetForeignData(pgeom, DATA_UNSCALED_GEOM);
+		pGeoman->AddRefGeometry(pgeom); ///< Add a reference to the unscaled geometry stored in foreign data or it may be released whilst stored
+
         int* pMatMapping = 0;
         if (pgeom->nMats)
         {


### PR DESCRIPTION
### Description

Fix for a crash seen in BakeScaleIntoGeometry.

A better fix for geometry being stored as unscaled geom in physics foreign data. The code which earlies out in utils.cpp BakeScaleIntoGeometry is just a workaround for this issue and could potentially be removed now:
``` c++
    if (!pgeom->pGeom)
    {
        return 0;
    }
```

Add reference counting to the foreign physics data to ensure that unscaled geometry is not released too early. 
The fix is not quite as robust as it should be; it only works for unscaled geometry and the lifetime is only valid if the foreign data of the scaled geometry is not modified after creation. However, the data is not designed for this problem so I've added an assert to catch it and it doesn't fire.