### PR TITLE
52) Fix for particles rotating horribly when they die on collision.

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/Particle.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/Particle.cpp
@@ -1515,9 +1515,6 @@ void CParticle::Update(SParticleUpdateContext const& context, float fFrameTime, 
                     stateNew.m_Loc.t = hit.pt;
 
                     fStepTime = max(fStepTime * hit.dist, context.fMinStepTime);
-
-                    // Rotate to surface normal.
-                    RotateToUpVector(stateNew.m_Loc.q, hit.n);
                     stateNew.Collide(fStepTime);
 
                     if (collNew.CanCollide() && params.eFinalCollision != params.eFinalCollision.Bounce)


### PR DESCRIPTION
### Description 

Bug fix for particles rotating horribly when they die on collision.
- Don't rotate the particle to face the normal of the hit surface.