### PR TITLE
44) Usability addition: add Ctrl-V support in the console.

### DIFF
--- a/dev/Code/CryEngine/CrySystem/XConsole.cpp
+++ b/dev/Code/CryEngine/CrySystem/XConsole.cpp
@@ -1360,6 +1360,15 @@ bool CXConsole::OnInputChannelEventFiltered(const AzFramework::InputChannel& inp
             // Consume keyboard events if the console is active, which it will be if we get here
             return true;
         }
+
+		if (channelId == AzFramework::InputDeviceKeyboard::Key::AlphanumericV &&
+			modifierKeyStates.IsActive(AzFramework::ModifierKeyMask::CtrlAny))
+		{
+			Paste();
+
+			// Consume keyboard events if the console is active, which it will be if we get here
+			return true;
+		}
     }
 
     if (channelId == AzFramework::InputDeviceKeyboard::Key::PunctuationTilde)
@@ -3471,6 +3480,27 @@ void CXConsole::Copy()
 #endif //WIN32
 }
 
+//////////////////////////////////////////////////////////////////////////
+void CXConsole::Paste()
+{
+#ifdef WIN32
+	if (OpenClipboard(nullptr))
+	{
+		if (HANDLE hUnicodeText = GetClipboardData(CF_UNICODETEXT))
+		{
+			const WCHAR* wchars = static_cast<const WCHAR*>(GlobalLock(hUnicodeText));
+			AZStd::string text;
+			AZStd::to_string(text, wchars);
+			if (text.length() > 0)
+			{
+				AddInputUTF8(text);
+			}
+			GlobalUnlock(hUnicodeText);
+		}
+		CloseClipboard();
+	}
+#endif //WIN32
+}
 
 //////////////////////////////////////////////////////////////////////////
 int CXConsole::GetNumVars()

--- a/dev/Code/CryEngine/CrySystem/XConsole.h
+++ b/dev/Code/CryEngine/CrySystem/XConsole.h
@@ -149,6 +149,7 @@ public:
     void FreeRenderResources();
     //
     void Copy();
+	void Paste();
 
     // interface IConsole ---------------------------------------------------------
     virtual void Release();


### PR DESCRIPTION
### Description

This is a simple one and does what it says on the tin; we have added paste support to the developer console. This was great for us as we heavily utilise the CVar system and prior to this change would need to manually type in long CVars. Now you can use CTRL-V as expected.