### PR TITLE
78) Fix for endless loop of Lua script reloading bug

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Script/ScriptSystemComponent.h
+++ b/dev/Code/Framework/AzCore/AzCore/Script/ScriptSystemComponent.h
@@ -165,7 +165,7 @@ namespace AZ
         // Used to avoid cascading reloads
         bool m_isReloadQueued = false;
         // Used to store scripts needing reloading
-        AZStd::unordered_set<Data::AssetId> m_assetsAlreadyReloaded;
+        AZStd::unordered_set<Data::AssetId> m_queuedReloads;
         // Used for being alerted when a require()'d script has finished reloading
         void OnAssetReloaded(Data::Asset<Data::AssetData> asset) override;
 


### PR DESCRIPTION
### Description 

Fix for a bug where Lua scripts would endlessly reload.

It was possible, in a large project with a significant number of scripts to reload, to get into a situation where endless Lua script reloading would happen. 

**The reason for this was that:**
- The old algorithm cleared the `m_assetsAlreadyReloaded` map once all assets were requested to reload without waiting for them to be handled. 
- When there are a significant number of scripts to reload, it may happen that some of the scripts are not fully reloaded by the time `reloadFn` is finished. 
- When they were processed after `reloadFn`, their `OnAssetReloaded` callback would call `reloadFn` again, triggering a vicious circle of endless reloading.

**To fix this:**
- Instead of tracking already reloaded assets, track all reload requests and remove them from the map one by one as they are handled. 
- Once all queued reloads are handled, another full reload can be triggered. 