### PR TITLE
44) Fixes for 3DEngineLight

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/3dEngine.h
+++ b/dev/Code/CryEngine/Cry3DEngine/3dEngine.h
@@ -509,6 +509,7 @@ private:
     SLightCell m_pWorldLightCells[LV_LIGHTS_WORLD_BUCKET_SIZE];     // 2D World cell buckets for light sources ids
     uint16 m_nWorldCells[LV_WORLD_BUCKET_SIZE];                     // World cell buckets for light volumes
     bool m_bUpdateLightVolumes : 1;
+	CryMutex m_dataMutex; // Added mutex to make sure all light interactions are thread-safe
 };
 
 // onscreen infodebug for e_debugDraw >= 100


### PR DESCRIPTION
### Description

Fix for two crashes seen in 3DEngineLight:

1) Fix for referencing out of bounds light id
2) Fix thread safety of light interactions to fix collision between reset and update on level unload