### PR TITLE
Fix for game crash on r_WaterReflections=0

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DFXPipeline.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DFXPipeline.cpp
@@ -285,7 +285,6 @@ void CD3D9Renderer::EF_ClearTargetsLater(uint32 nFlags)
     //      uint8(m_pNewTarget[0]->m_pSurfDepth->pTex->GetClearColor().g));
 }
 
-
 void CD3D9Renderer::FX_ClearTargetRegion(const uint32 nAdditionalStates /* = 0*/)
 {
     assert(m_pRT->IsRenderThread());
@@ -5238,7 +5237,7 @@ bool CD3D9Renderer::FX_DrawToRenderTarget(CShader* pShader, CShaderResources* pR
             assert(pEnvTex != NULL);
             if (pEnvTex && pEnvTex->m_pTex && pEnvTex->m_pTex->m_pTexture)
             {
-                FX_ClearTarget(pEnvTex->m_pTex->m_pTexture, Clr_Empty);
+                m_pRT->RC_ClearTarget(pEnvTex->m_pTex->m_pTexture, Clr_Empty);
             }
             return true;
         }


### PR DESCRIPTION
Game crashes if water is present on level and user activates r_WaterReflections=0. Render context is used from Main and Render threads.