### PR TITLE
14) Added AlphaChannelEnabled attribute support for colour picker

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/dev/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -126,6 +126,9 @@ namespace AZ
 
             // Attribute for providing a custom UI Handler - can be used with Attribute() (or with ElementAttribute() for containers such as vectors, to specify the handler for container elements (i.e. vectors))
             const static AZ::Crc32 Handler = AZ_CRC("Handler", 0x939715cd);
+
+			// Color picker attributes, allow to pick alpha if the AlphaChannelEnabled attribute is present
+			const static AZ::Crc32 AlphaChannelEnabled = AZ_CRC("AlphaChannelEnabled", 0xce653f5f); 
         }
 
 

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.cpp
@@ -105,9 +105,17 @@ namespace AzToolsFramework
                 m_pColorDialog->setCurrentColor(m_color);
             }
 
-            int R, G, B;
-            m_color.getRgb(&R, &G, &B);
-            m_colorEdit->setText(QStringLiteral("%1,%2,%3").arg(R).arg(G).arg(B));
+			int R, G, B, A;
+			m_color.getRgb(&R, &G, &B, &A);
+
+			if (m_showAlpha)
+			{
+				m_colorEdit->setText(QStringLiteral("R: %1 G: %2 B: %3 A: %4").arg(R).arg(G).arg(B).arg(A));
+			}
+			else
+			{
+				m_colorEdit->setText(QStringLiteral("R: %1 G: %2 B: %3").arg(R).arg(G).arg(B));
+			}
         }
     }
 
@@ -136,8 +144,15 @@ namespace AzToolsFramework
         }
 
         m_pColorDialog = new QColorDialog(m_color, this);
-        m_pColorDialog->setOption(QColorDialog::NoButtons);
-        connect(m_pColorDialog, SIGNAL(currentColorChanged(QColor)), this, SLOT(onSelected(QColor)));
+		if (m_showAlpha)
+		{
+			m_pColorDialog->setOptions(QColorDialog::NoButtons | QColorDialog::ShowAlphaChannel);
+		}
+		else
+		{
+			m_pColorDialog->setOption(QColorDialog::NoButtons);
+		}
+		connect(m_pColorDialog, SIGNAL(currentColorChanged(QColor)), this, SLOT(onSelected(QColor)));
 
         // Position the picker around cursor.
         QLayout* layout = m_pColorDialog->layout();
@@ -220,8 +235,16 @@ namespace AzToolsFramework
         }
     }
 
-    void AZColorPropertyHandler::ConsumeAttribute(PropertyColorCtrl* /*GUI*/, AZ::u32 /*attrib*/, PropertyAttributeReader* /*attrValue*/, const char* /*debugName*/)
+    void AZColorPropertyHandler::ConsumeAttribute(PropertyColorCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* /*debugName*/)
     {
+		if (attrib == AZ::Edit::Attributes::AlphaChannelEnabled)
+		{
+			bool value = false;
+			if (attrValue->Read<bool>(value))
+			{
+				GUI->SetShowAlpha(value);
+			}
+		}
     }
 
     void AZColorPropertyHandler::WriteGUIValuesIntoProperty(size_t index, PropertyColorCtrl* GUI, property_t& instance, InstanceDataNode* node)

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.hxx
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyColorCtrl.hxx
@@ -46,6 +46,7 @@ namespace AzToolsFramework
         QWidget* GetFirstInTabOrder();
         QWidget* GetLastInTabOrder();
         void UpdateTabOrder();
+		void SetShowAlpha(bool showAlpha) { m_showAlpha = showAlpha; }
 
     signals:
         void valueChanged(QColor newValue);
@@ -72,6 +73,7 @@ namespace AzToolsFramework
 
         QLineEdit* m_colorEdit;
         QColor m_color;
+		bool m_showAlpha = false;
     };
 
     template <class ValueType>


### PR DESCRIPTION
### Description 

Added AlphaChannelEnabled attribute support for EditContext & colour values, and updated PropertyColorCtrl to consume it. When used, the colour picker will allow the user to select an alpha value as well as RGB. This makes sense for components which do not want to define and maintain a separate alpha value and slider.

### Usage

``` c++
->DataElement(AZ::Edit::UIHandlers::Color, &TrajectoryVisualiserComponent::m_colour, "Colour", "")
	->Attribute(AZ::Edit::Attributes::AlphaChannelEnabled, true)
```