### PR TITLE
22) Add surface id to raycast hit

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Physics/PhysicsSystemComponentBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Physics/PhysicsSystemComponentBus.h
@@ -70,6 +70,7 @@ namespace AzFramework
             bool IsValid() const { return m_distance >= 0.f; }
 
             float m_distance = -1.0f; ///< The distance from \ref begin to the hit
+			int m_surfaceId;         ///< The surface the ray hit
             AZ::Vector3 m_position;  ///< The position of the hit in world space
             AZ::Vector3 m_normal;    ///< The normal of the surface hit
             AZ::EntityId m_entityId; ///< The id of the AZ::Entity hit, or AZ::InvalidEntityId if hit object is not an AZ::Entity

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsSystemComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/PhysicsSystemComponent.cpp
@@ -173,6 +173,7 @@ namespace LmbrCentral
             behaviorContext->Class<RayCastHit>()
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::Preview)
                 ->Property("distance", BehaviorValueGetter(&RayCastHit::m_distance), nullptr)
+				->Property("surface", BehaviorValueGetter(&RayCastHit::m_surfaceId), nullptr)
                 ->Property("position", BehaviorValueGetter(&RayCastHit::m_position), nullptr)
                 ->Property("normal", BehaviorValueGetter(&RayCastHit::m_normal), nullptr)
                 ->Property("entityId", BehaviorValueGetter(&RayCastHit::m_entityId), nullptr)
@@ -469,6 +470,7 @@ namespace LmbrCentral
             hit.m_distance = cryHit.dist;
             hit.m_position = LYVec3ToAZVec3(cryHit.pt);
             hit.m_normal = LYVec3ToAZVec3(cryHit.n);
+			hit.m_surfaceId = cryHit.surface_idx;
 
             if (cryHit.pCollider && cryHit.pCollider->GetiForeignData() == PHYS_FOREIGN_ID_COMPONENT_ENTITY)
             {


### PR DESCRIPTION
### Description 

Add the surface id to the raycast hit result.
This is a simple but often used addition which allows features such as choosing different hit impact effects per surface type. For example, using a different particle effect when shooting a steel surface as opposed to a concrete one.