### PR TITLE
76) Fix for CRenderMesh assert due to mismatched lock/unlock

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/StatObjPhys.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/StatObjPhys.cpp
@@ -1918,8 +1918,8 @@ IStatObj* CStatObj::UpdateVertices(strided_pointer<Vec3> pVtx, strided_pointer<V
                 mesh->UnlockStream(VSF_TANGENTS);
             }
             mesh->UnlockStream(VSF_GENERAL);
-            mesh->UnLockForThreadAccess();
         }
+		mesh->UnLockForThreadAccess();
     }
     return pObj;
 }


### PR DESCRIPTION
### Description 

There appears to be a lock/unlock mismatch for threaded data in the Cloth code. This could occasionally cause an assert during the `CRenderMesh` destruction as `m_nThreadAccessCounter > 0` when quitting a map with cloth in it. The fix is to match up the lock/unlock correctly.