### PR TITLE
81) Trivial addition to allow limb IK to be enabled/disabled if necessary.

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Animation/CharacterAnimationManagerComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Animation/CharacterAnimationManagerComponent.cpp
@@ -55,6 +55,7 @@ namespace LmbrCentral
         , m_previousWorldTransform(AZ::Transform::Identity())
         , m_useAnimDrivenMotion(false)
         , m_appliedAnimDrivenMotion(false)
+		, m_limbIkEnabled(true)
     {
     }
 
@@ -68,7 +69,7 @@ namespace LmbrCentral
         AZ::TransformNotificationBus::Handler::BusConnect(m_entityId);
         CharacterAnimationRequestBus::Handler::BusConnect(m_entityId);
         AimIKComponentRequestBus::Handler::BusConnect(m_entityId);
-
+		LimbIKComponentRequestBus::Handler::BusConnect(m_entityId);
         PhysicsSystemEventBus::Handler::BusConnect();
 
         EBUS_EVENT_ID_RESULT(m_currentWorldTransform, m_entityId, AZ::TransformBus, GetWorldTM);
@@ -97,6 +98,7 @@ namespace LmbrCentral
 
         PhysicsSystemEventBus::Handler::BusDisconnect();
 
+		LimbIKComponentRequestBus::Handler::BusDisconnect();
         AimIKComponentRequestBus::Handler::BusDisconnect();
         CharacterAnimationRequestBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect();
@@ -112,7 +114,7 @@ namespace LmbrCentral
         if (m_characterInstance && m_characterInstance->GetISkeletonAnim())
         {
             // Tick limb IK.
-            if (m_limbIK)
+            if (m_limbIK && m_limbIkEnabled)
             {
                 m_limbIK->Update(AZTransformToLYQuatT(m_currentWorldTransform), deltaTime);
             }
@@ -382,6 +384,10 @@ namespace LmbrCentral
                 ->Event("SetAimIKPolarCoordinatesMaxRadiansPerSecond", &AimIKComponentRequestBus::Events::SetAimIKPolarCoordinatesMaxRadiansPerSecond)
                 ->Event("GetAimIKBlend", &AimIKComponentRequestBus::Events::GetAimIKBlend)
                 ;
+
+			behaviorContext->EBus<LimbIKComponentRequestBus>("LimbIKComponentRequestBus")
+				->Event("EnableLimbIK", &LimbIKComponentRequestBus::Events::EnableLimbIK)
+				;
         }
     }
 
@@ -568,6 +574,11 @@ namespace LmbrCentral
         }
         return 0.f;
     }
+
+	void CharacterAnimationManagerComponent::CharacterInstanceEntry::EnableLimbIK(bool enable)
+	{
+		m_limbIkEnabled = enable;
+	}
     //////////////////////////////////////////////////////////////////////////
 
 } // namespace LmbrCentral

--- a/dev/Gems/LmbrCentral/Code/Source/Animation/CharacterAnimationManagerComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Animation/CharacterAnimationManagerComponent.h
@@ -82,6 +82,7 @@ namespace LmbrCentral
             , private CharacterAnimationRequestBus::Handler
             , private AzFramework::PhysicsSystemEventBus::Handler
             , private AimIKComponentRequestBus::Handler
+			, private LimbIKComponentRequestBus::Handler
         {
         public:
 
@@ -131,6 +132,11 @@ namespace LmbrCentral
             float GetAimIKBlend() override;
             //////////////////////////////////////////////////////////////////////////
 
+			//////////////////////////////////////////////////////////////////////////
+			// LimbIKComponentRequestBus handler
+			void EnableLimbIK(bool enable) override;
+			//////////////////////////////////////////////////////////////////////////
+
         private:
 
             void UpdateParametricBlendParameters(float deltaTime, const AZ::Transform& frameMotionDelta);
@@ -148,6 +154,7 @@ namespace LmbrCentral
             Animation::MotionParameterSmoothingSettings m_motionParamsSmoothingSettings;    ///< Parameter smoothing settings currently set this character instance.
 
             IAnimationPoseAlignerPtr m_limbIK;  ///< Limb IK instance.
+			bool m_limbIkEnabled;   ///< Are limb IK requests enabled/disabled
         };
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Animation/CharacterAnimationBus.h
+++ b/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Animation/CharacterAnimationBus.h
@@ -117,6 +117,21 @@ namespace LmbrCentral
 
     using AimIKComponentRequestBus = AZ::EBus<AimIKComponentRequests>;
 
+	/**
+	 * Limb IK component request bus
+	 */
+	class LimbIKComponentRequests
+		: public AZ::ComponentBus
+	{
+	public:
+
+		/// Enable/disable limb IK
+		/// \param enable - true to enable, false to disable.
+		virtual void EnableLimbIK(bool enable) = 0;
+	};
+
+	using LimbIKComponentRequestBus = AZ::EBus<LimbIKComponentRequests>;
+
     /**
      * Represents a timed event/annotation dispatched during animation playback.
      */


### PR DESCRIPTION
### Description 

A trivial addition which we used for ensuring limb IK was correctly enabled/disabled in various situations. For example, when the player is dead we no longer want the IK to be aligning the feet with the ground.

### Usage
``` lua
function character_animation:OnDead(entityId, attackerEntityId)
    if(self.entityId == entityId) then
        self:RequestBaseState(EBaseState.Death)
        LimbIKComponentRequestBus.Event.EnableLimbIK(self.entityId, false)
    end
end
```