### PR TITLE
82) Add a callback define to allow sys_affinity to be set after launch

### DIFF
--- a/dev/Code/CryEngine/CrySystem/SystemWin32.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemWin32.cpp
@@ -104,6 +104,13 @@ const char* g_szModuleGroups[][2] = {
 };
 
 //////////////////////////////////////////////////////////////////////////
+// Allow the affinity to be set after launch
+void AffinityChangedCallback(ICVar*)
+{
+	((CSystem*)GetISystem())->SetAffinity();
+}
+
+//////////////////////////////////////////////////////////////////////////
 void CSystem::SetAffinity()
 {
     // the following code is only for Windows
@@ -112,7 +119,7 @@ void CSystem::SetAffinity()
     ICVar* pcvAffinityMask = GetIConsole()->GetCVar("sys_affinity");
     if (!pcvAffinityMask)
     {
-        pcvAffinityMask = REGISTER_INT("sys_affinity", 0, VF_NULL, "");
+        pcvAffinityMask = REGISTER_INT("sys_affinity", 0, VF_NULL, "", AffinityChangedCallback);
     }
 
     if (pcvAffinityMask)


### PR DESCRIPTION
### Description 

A simple addition. As the title suggests we have changed the registration of the "sys_affinity" CVar to use `REGISTER_INT_CB` so that we can hook it up an `AffinityChangedCallback`.