### PR TITLE
83) Add CloneGameEntity() request support to GameEntityContext 

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextBus.h
@@ -92,7 +92,7 @@ namespace AzFramework
 		* Clones an existing entity in the game context.
 		* @param entity A pointer to the entity to clone.
 		* @param activate Optional parameter to skip activation.
-		* @param name
+		* @param name A name for the cloned entity.
 		*/		
 		virtual AZ::Entity* CloneGameEntity(AZ::Entity* /*entity*/, bool /* activate = true*/, const char* /* name = nullptr*/) { return nullptr; }
 

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextBus.h
@@ -88,6 +88,14 @@ namespace AzFramework
          */
         virtual void AddGameEntity(AZ::Entity* /*entity*/) = 0;
 
+		/**
+		* Clones an existing entity in the game context.
+		* @param entity A pointer to the entity to clone.
+		* @param activate Optional parameter to skip activation.
+		* @param name
+		*/		
+		virtual AZ::Entity* CloneGameEntity(AZ::Entity* /*entity*/, bool /* activate = true*/, const char* /* name = nullptr*/) { return nullptr; }
+
         /**
          * Destroys an entity. 
          * The entity is immediately deactivated and will be destroyed on the next tick.

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -146,10 +146,33 @@ namespace AzFramework
         AddEntity(entity);
     }
 
+	//=========================================================================
+	// CloneGameEntity
+	//=========================================================================
+	AZ::Entity* GameEntityContextComponent::CloneGameEntity(AZ::Entity* entity, bool activate, const char* name)
+	{
+		AZ::Entity* clonedEntity = nullptr;
+		if (entity)
+		{
+			if (!activate)
+			{
+				m_activationDisabledForCloning = true;
+			}
 
-    //=========================================================================
-    // CreateEntity
-    //=========================================================================
+			clonedEntity = CloneEntity(*entity);
+			if (clonedEntity && name)
+			{
+				clonedEntity->SetName(name);
+			}
+
+			if (!activate)
+			{
+				m_activationDisabledForCloning = false;
+			}
+		}
+		return clonedEntity;
+	}
+
     AZ::Entity* GameEntityContextComponent::CreateEntity(const char* name)
     {
         auto entity = aznew AZ::Entity(name);
@@ -195,16 +218,19 @@ namespace AzFramework
             }
         }
 
-        for (AZ::Entity* entity : entities)
-        {
-            if (entity->GetState() == AZ::Entity::ES_INIT)
-            {
-                if (entity->IsRuntimeActiveByDefault())
-                {
-                    entity->Activate();
-                }
-            }
-        }
+		if (!m_activationDisabledForCloning)
+		{
+			for (AZ::Entity* entity : entities)
+			{
+				if (entity->GetState() == AZ::Entity::ES_INIT)
+				{
+					if (entity->IsRuntimeActiveByDefault())
+					{
+						entity->Activate();
+					}
+				}
+			}
+		}
     }
 
     //=========================================================================

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -147,7 +147,7 @@ namespace AzFramework
     }
 
 	//=========================================================================
-	// CloneGameEntity
+	// GameEntityContextComponent::CloneGameEntity
 	//=========================================================================
 	AZ::Entity* GameEntityContextComponent::CloneGameEntity(AZ::Entity* entity, bool activate, const char* name)
 	{
@@ -173,6 +173,9 @@ namespace AzFramework
 		return clonedEntity;
 	}
 
+	//=========================================================================
+	// GameEntityContextComponent::CreateEntity
+	//=========================================================================
     AZ::Entity* GameEntityContextComponent::CreateEntity(const char* name)
     {
         auto entity = aznew AZ::Entity(name);

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.h
@@ -55,6 +55,7 @@ namespace AzFramework
         AZ::Entity* CreateGameEntity(const char* name) override;
         BehaviorEntity CreateGameEntityForBehaviorContext(const char* name) override;
         void AddGameEntity(AZ::Entity* entity) override;
+		AZ::Entity* CloneGameEntity(AZ::Entity* entity, bool activate = true, const char* name = nullptr) override;
         void DestroyGameEntity(const AZ::EntityId&) override;
         void DestroyGameEntityAndDescendants(const AZ::EntityId&) override;
         bool DestroyDynamicSliceByEntity(const AZ::EntityId&) override;
@@ -110,6 +111,9 @@ namespace AzFramework
         };
 
         AZStd::unordered_map<SliceInstantiationTicket, InstantiatingDynamicSliceInfo> m_instantiatingDynamicSlices;
+
+	private:
+		bool m_activationDisabledForCloning = false;
     };
 } // namespace AzFramework
 


### PR DESCRIPTION
### Description

Add CloneGameEntity() request support to GameEntityContext. 
The use case for us was cloning existing consumable inventory items, such as grenades. This allowed us to clone N grenades, store them, then activate and launch them when requested by the player.