### PR TITLE
84) Add support for build version matching.

### DIFF
--- a/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
+++ b/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
@@ -3989,6 +3989,10 @@ CarrierImpl::Update()
                             {
                                 DisconnectRequest(conn, CarrierDisconnectReason::DISCONNECT_VERSION_MISMATCH);
                             }
+							else if (requestError == HandshakeErrorCode::BUILDVERSION_MISMATCH)
+							{
+								DisconnectRequest(conn, CarrierDisconnectReason::DISCONNECT_BUILDVERSION_MISMATCH);
+							}
                             else
                             {
                                 DisconnectRequest(conn, CarrierDisconnectReason::DISCONNECT_HANDSHAKE_REJECTED);
@@ -4465,6 +4469,9 @@ CarrierEventsBase::ReasonToString(CarrierDisconnectReason reason)
     case CarrierDisconnectReason::DISCONNECT_VERSION_MISMATCH:
         reasonStr = "Version mismatch when establishing a connection.";
         break;
+	case CarrierDisconnectReason::DISCONNECT_BUILDVERSION_MISMATCH:
+		reasonStr = "Build version mismatch.";
+		break;
     default:
         reasonStr = "Unknown reason";
     }

--- a/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.h
+++ b/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.h
@@ -241,6 +241,7 @@ namespace GridMate
             , m_driverIsFullPackets(false)
             , m_driverIsCrossPlatform(false)
             , m_version(1)
+			, m_buildVersion(0)
             , m_securityData(nullptr)
             , m_enableDisconnectDetection(true)
             , m_connectionTimeoutMS(5000)
@@ -274,6 +275,7 @@ namespace GridMate
         bool                            m_driverIsCrossPlatform;    ///< True if we will need communicate across platforms (need to make sure we use common platform features).
 
         VersionType                     m_version;                  ///< Carriers with mismatching version numbers are not allowed to connect to each other. Default is 1.
+		VersionType						m_buildVersion;				///< Carriers with mismatching buildVersion numbers are not allowed to connect to each other. Default is 0.
 
         const char*                     m_securityData;             ///< Pointer to string with security data
 
@@ -389,6 +391,7 @@ namespace GridMate
         DISCONNECT_DEBUG_DELETE_CONNECTION,
 
         DISCONNECT_VERSION_MISMATCH,            ///< Attempting to connect to a different application version.
+		DISCONNECT_BUILDVERSION_MISMATCH,		///< Attempting to connect to a build with a different changelist version
 
         DISCONNECT_MAX,                         ///< Must be last for internal reasons
     };

--- a/dev/Code/Framework/GridMate/GridMate/Carrier/Handshake.h
+++ b/dev/Code/Framework/GridMate/GridMate/Carrier/Handshake.h
@@ -24,6 +24,7 @@ namespace GridMate
         REJECTED,
         PENDING,
         VERSION_MISMATCH,
+		BUILDVERSION_MISMATCH,
     };
 
     /**

--- a/dev/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerUtils.h
+++ b/dev/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerUtils.h
@@ -72,6 +72,7 @@ namespace Multiplayer
             carrierDesc.m_securityData = gEnv->pConsole->GetCVar("gm_securityData")->GetString();
             carrierDesc.m_familyType = CVarToFamilyType(gEnv->pConsole->GetCVar("gm_ipversion")->GetString());
             carrierDesc.m_version = gEnv->pConsole->GetCVar("gm_version")->GetIVal();
+			carrierDesc.m_buildVersion = gEnv->pConsole->GetCVar("mp_build_version")->GetIVal();
 
             ApplyDisconnectDetectionSettings(carrierDesc);
 

--- a/dev/Gems/Multiplayer/Code/Source/MultiplayerCVars.cpp
+++ b/dev/Gems/Multiplayer/Code/Source/MultiplayerCVars.cpp
@@ -423,6 +423,9 @@ namespace Multiplayer
             REGISTER_COMMAND("mpsearch", MPJoinLANCmd, 0, "try to find a LAN session");
             REGISTER_COMMAND("mpdisconnect", MPDisconnectCmd, 0, "disconnect from our session");
 
+			REGISTER_INT("mp_build_version", 0, VF_READONLY, "Build version which was synced to make this build.");
+			REGISTER_INT("mp_build_version_matching", 0, VF_READONLY, "Enables/Disables build version matching.");
+
             REGISTER_INT("gm_version", 1, 0, "Set the gridmate version number.");
 
 #ifdef NET_SUPPORT_SECURE_SOCKET_DRIVER
@@ -522,6 +525,9 @@ namespace Multiplayer
             UNREGISTER_CVAR("gm_netsec_private_key");
             UNREGISTER_CVAR("gm_netsec_enable");
 #endif
+			UNREGISTER_CVAR("mp_build_version"); 
+			UNREGISTER_CVAR("mp_build_version_matching");
+
             UNREGISTER_CVAR("gm_version");
 
             if (gEnv->pConsole)


### PR DESCRIPTION
### Description 

Add support for only allowing builds with matching changelists to connect to each other. Currently, the GridMate version is checked but this was not granular enough for our needs. This change was made to allow us much more control over how our games connected.

This change requires the Multiplayer Gem for:
- Registration of the new CVars.
- Setting `m_buildVersion` on the `GridMate::CarrierDesc` struct.
- Loading the new `.buildmeta` file

If `LOAD_BUILD_METADATA` is defined then build version matching will be enabled. 
At TKG, we augmented the DRG `.wscript` to define `LOAD_BUILD_METADATA` if the build had been created via our continuous integration system, Teamcity. This allowed us to enable build version matching for automated builds but to leave it optionally disabled in dev builds.

An example of the `.wscript` change we used:
```
def build(bld):    
    defines = []
    if bld.is_option_true('teamcity_build'):
        defines.append( 'LOAD_BUILD_METADATA' )
	...
```

An easier way to test _(or to implement)_ this change would be to `#define LOAD_BUILD_METADATA` at the top of `MultiplayerGem.cpp`.

When this define is enabled, the code will attempt to load a new, bespoke, `.buildmeta` file with the same name as the game executable but with `.buildmeta` appended. For example, in DRG the game would attempt to load `...\dev\Bin64vc140\DRG.exe.buildmeta`. This will create CVars for each string/value pair in the file.

An example `.buildmeta` file for DRG looks like this:
``` 
build_changelist = 22716
build_time = 2/26/2018 1:20:23 PM
build_machine = BUILD01
build_stream = MAINLINE
```

##### New CVars introduced:

- `build_changelist`: The source changelist which was synced to make this build. This is read from `<game>.exe.buildmeta`. It defaults to 0.
- `build_time`: The local time at which the build was made.  This is read from `<game>.exe.buildmeta`. It defaults to "Unknown".

- `mp_build_version`: The build version which was synced to make this build. This is used to initialise `m_buildVersion` which is then used to determine whether the handshake between server and client succeeds. It is only set if `mp_build_version_matching` is true on startup. It should be set on startup via a `.cfg` file. It defaults to 0.
- `mp_build_version_matching`: Enables/Disables build version matching. It defaults to 0.

### Testing

This change should be relatively easy to test and has already been well battle-tested in our game. 
- Get the change and build the MultiplayerSampleLauncher.
- Add a line to  `#define LOAD_BUILD_METADATA` at the top of `MultiplayerGem.cpp`.
- `mp_build_version_matching` defaults to off, so attempt to connect two clients together in a LAN game. This should work as before this change.
- Next, create a file `...dev\Bin64vc140\MultiplayerSampleLauncher.exe.buildmeta` and put some default values in it: 
```
build_changelist = 1234
build_time = 14/05/2018 1:20:23 PM
```
- Run the games again. They should still connect, but in the console you should be able to inspect the values for `build_changelist` and for `build_time`. You can also see them in the log.
- Try turning on `mp_build_version_matching` and connecting, this should still work as the changelists are the same. Note, to turn on `mp_build_version_matching`, either do so via a `.cfg` file or via the console. If you do so in the console, you will get a warning noting that this will not be allowed in RELEASE as the CVar is marked as READ_ONLY, this is as expected.
- Finally, with `mp_build_version_matching` still enabled, load one game up, then once it is loaded, edit the `.buildmeta' file to have a different `build_changelist`. Run the second game and attempt to connect as before. You should see a message in the console informing you of the build version mismatch.