### PR TITLE
85) Add collapse all component properties context menu support

### DIFF
--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.cpp
@@ -753,6 +753,13 @@ namespace AzToolsFramework
         return false;
     }
 
+	void ComponentEditor::CollapseAllProperties()
+	{
+		m_header->SetExpanded(true);
+		m_propertyEditor->setVisible(true);
+		m_propertyEditor->CollapseAllProperties();
+	}
+
     void ComponentEditor::SetSelected(bool selected)
     {
         if (m_selected != selected)

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ComponentEditor.hxx
@@ -61,6 +61,8 @@ namespace AzToolsFramework
         bool IsExpanded() const;
         bool IsExpandable() const;
 
+		void CollapseAllProperties();
+
         void SetSelected(bool selected);
         bool IsSelected() const;
 

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1799,6 +1799,15 @@ namespace AzToolsFramework
         connect(m_actionToMoveComponentsBottom, &QAction::triggered, this, &EntityPropertyEditor::MoveComponentsBottom);
         addAction(m_actionToMoveComponentsBottom);
 
+		QAction* seperator3 = aznew QAction(this);
+		seperator3->setSeparator(true);
+		addAction(seperator3);
+
+		m_actionToCollapseAllProperties = aznew QAction(tr("Collapse Properties"), this);
+		m_actionToCollapseAllProperties->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+		connect(m_actionToCollapseAllProperties, &QAction::triggered, this, &EntityPropertyEditor::CollapseAllProperties);
+		addAction(m_actionToCollapseAllProperties);
+
         UpdateInternalState();
     }
 
@@ -1817,7 +1826,8 @@ namespace AzToolsFramework
         m_actionToMoveComponentsUp->setEnabled(allowRemove && IsMoveComponentsUpAllowed());
         m_actionToMoveComponentsDown->setEnabled(allowRemove && IsMoveComponentsDownAllowed());
         m_actionToMoveComponentsTop->setEnabled(allowRemove && IsMoveComponentsUpAllowed());
-        m_actionToMoveComponentsBottom->setEnabled(allowRemove && IsMoveComponentsDownAllowed());
+		m_actionToMoveComponentsBottom->setEnabled(allowRemove && IsMoveComponentsDownAllowed());
+		m_actionToCollapseAllProperties->setEnabled(IsCollapseAllPropertiesAllowed());
 
         bool allowEnable = false;
         bool allowDisable = false;
@@ -2258,6 +2268,12 @@ namespace AzToolsFramework
         return IsMoveAllowed(componentEditors);
     }
 
+	bool EntityPropertyEditor::IsCollapseAllPropertiesAllowed() const
+	{
+		const auto& componentsToEdit = GetSelectedComponentEditors();
+		return !m_selectedEntityIds.empty() && !componentsToEdit.empty();
+	}
+
     void EntityPropertyEditor::ResetToSlice()
     {
         // Reset selected components to slice values
@@ -2288,6 +2304,20 @@ namespace AzToolsFramework
             QueuePropertyRefresh();
         }
     }
+	
+	void EntityPropertyEditor::CollapseAllProperties()
+	{
+		const auto& componentsToEdit = GetSelectedComponentEditors();
+		if (m_selectedEntityIds.size() == 0 || componentsToEdit.size() == 0)
+		{
+			return;
+		}
+
+		for (auto component : componentsToEdit)
+		{
+			component->CollapseAllProperties();
+		}
+	}
 
     bool EntityPropertyEditor::DoesOwnFocus() const
     {

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -234,6 +234,7 @@ namespace AzToolsFramework
         QAction* m_actionToMoveComponentsTop;
         QAction* m_actionToMoveComponentsBottom;
         QAction* m_resetToSliceAction;
+		QAction* m_actionToCollapseAllProperties;
 
         void CreateActions();
         void UpdateActions();
@@ -252,6 +253,7 @@ namespace AzToolsFramework
         void MoveComponentsDown();
         void MoveComponentsTop();
         void MoveComponentsBottom();
+		void CollapseAllProperties();
 
         //component reorder and drag drop helpers
 
@@ -275,6 +277,7 @@ namespace AzToolsFramework
 
         bool IsMoveComponentsUpAllowed() const;
         bool IsMoveComponentsDownAllowed() const;
+		bool IsCollapseAllPropertiesAllowed() const;
 
         void ResetToSlice();
 

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -1472,6 +1472,17 @@ namespace AzToolsFramework
         }
     }
 
+	void ReflectedPropertyEditor::CollapseAllProperties()
+	{
+		for (PropertyRowWidget* widget : m_impl->m_widgetsInDisplayOrder)
+		{
+			if (widget->GetParentRow())
+			{
+				widget->DoExpandOrContract(false, true);
+			}
+		}
+	}
+
     const ReflectedPropertyEditor::WidgetList& ReflectedPropertyEditor::GetWidgets() const
     {
         return m_impl->m_widgets;

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx
@@ -86,6 +86,7 @@ namespace AzToolsFramework
 
         void ExpandAll();
         void CollapseAll();
+		void CollapseAllProperties();
 
         const WidgetList& GetWidgets() const;
 


### PR DESCRIPTION
### Description

Added an option to the context menu which will collapse all the properties of a component. At TKG we have numerous large scripts with deeply nested properties which can be overwhelming to work with. This feature was developed to allow designers using the editor to collapse everything and reduce visual clutter so they could focus on the important attributes of the component.

![collapseproperties](https://user-images.githubusercontent.com/36986799/40002776-95460806-5789-11e8-9b15-1033ce09e22b.gif)