### PR TITLE
86) Added a ConsoleNotificationBus 

### DIFF
--- a/dev/Code/CryEngine/CryCommon/ConsoleNotificationBus.h
+++ b/dev/Code/CryEngine/CryCommon/ConsoleNotificationBus.h
@@ -1,0 +1,35 @@
+#pragma once
+// Send EBus notifications when console variables change,
+// so that we do not need to create Gem-specific EBuses only to redirect CVar's static OnChanged notification
+// to the actual listener. Additionally, a console command can be registered with a generic handler
+// that redirects the command execution to the EBus handler .
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/Math/Crc.h>
+#include <IConsole.h>
+
+namespace AZ
+{
+    // Subscribe to AZ::Crc32() (crc zero) to get notifications about all variables.
+    class ConsoleNotifications : public AZ::EBusTraits
+    {
+    public:
+        static const EBusAddressPolicy AddressPolicy = EBusAddressPolicy::ById;
+        using BusIdType = AZ::Crc32;
+
+        virtual bool OnVariableChanging(const ICVar* cvar) { return true; };
+        virtual void OnVariableChanged(const ICVar* cvar) {};
+        virtual void OnExecuteConsoleCommand(const IConsoleCmdArgs* args) {};
+    };
+    using ConsoleNotificationBus = AZ::EBus<ConsoleNotifications>;
+
+    // Helper method that forwards console command request to an EBus event. This can be used with REGISTER_COMMAND macros.
+    class ConsoleCommand
+    {
+    public:
+        static AZ_INLINE void UseConsoleNotificationBus(IConsoleCmdArgs* args)
+        {
+            EBUS_EVENT_ID(AZ::Crc32(args->GetArg(0)), AZ::ConsoleNotificationBus, OnExecuteConsoleCommand, args);
+        }
+    };
+}

--- a/dev/Code/CryEngine/CryCommon/crycommon.waf_files
+++ b/dev/Code/CryEngine/CryCommon/crycommon.waf_files
@@ -433,7 +433,8 @@
             "ManualResetEvent.h",
             "UniqueManualEvent.h",
             "CryCommonReflection.h",
-            "OceanConstants.h"
+            "OceanConstants.h",
+            "ConsoleNotificationBus.h"
         ],
         "Common_h/RenderElements":
         [


### PR DESCRIPTION
### Description 

Added a ConsoleNotificationBus which will send EBus notifications when console variables change. 

This is a utility so that we do not need to create Gem-specific EBuses only to redirect CVar's static OnChanged notification to the actual listener. Additionally, a console command can be registered with a generic handler that redirects the command execution to the EBus handler .

Example of registering a command which uses this:
```
// .h
#include <ConsoleNotificationBus.h>
class ConsoleNotificationDebug : private AZ::ConsoleNotificationBus::Handler
{
	...
	void OnExecuteConsoleCommand(const IConsoleCmdArgs* args) override;		
}		
	
// .cpp
void ConsoleNotificationDebug::RegisterCVars()
{
	REGISTER_COMMAND("test_command", AZ::ConsoleCommand::UseConsoleNotificationBus, VF_DEV_ONLY, "Execute a test command to invoke a callback from the console.");
	AZ::ConsoleNotificationBus::Handler::BusConnect(AZ_CRC("test_command"));
}
	
// When "test_command" is entered into the console we will get this callback:
void ConsoleNotificationDebug::OnExecuteConsoleCommand(const IConsoleCmdArgs* args)
{
	AZ_Printf("Window", "ConsoleNotificationDebug::OnExecuteConsoleCommand - Callback for test_command");
}
```