### PR TITLE
87) Add notifications for various render steps

### DIFF
--- a/dev/Code/CryEngine/CryCommon/RenderBus.h
+++ b/dev/Code/CryEngine/CryCommon/RenderBus.h
@@ -48,4 +48,21 @@ namespace AZ
     };
 
     using RenderNotificationsBus = AZ::EBus<RenderNotifications>;
+
+	/**
+	* This bus will notify listeners when frame starts/ends, 
+	* scene3d finishes rendering, etc. so that custom rendering 
+	* can be added as appropriate.
+	*/
+	class RenderStepNotifications
+		: public AZ::EBusTraits
+	{
+	public:
+		virtual void OnStartFrame() {};
+		virtual void OnScene3DRendered() {};
+		virtual void OnUIRendered() {};
+		virtual void OnEndFrame() {};
+	};
+
+	using RenderStepNotificationBus = AZ::EBus<RenderStepNotifications>;
 }


### PR DESCRIPTION
### Description

Added a RenderStepNotificationBus which posts notifications about various render steps. 

This was used for adding various custom rendering steps, for example: 
- We needed OnStartFrame and OnEndFrame notifications to allow us to integrate a third-party graphical user interface.
- We needed OnUIRenderered, and OnScene3DRenderered to implement some of our trajectory visualization components.

**Note:** `EBUS_EVENT(AZ::RenderStepNotificationBus, OnUIRendered);` will be called whilst no level is loaded to allow for custom render steps to function correctly during loading screens.