### PR TITLE
88) Trivial change to add client and server specific .cfg files.

### DIFF
--- a/dev/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -2858,6 +2858,14 @@ bool CSystem::InitFileSystem_LoadEngineFolders(const SSystemInitParams& initPara
     // Load game-specific folder.
     LoadConfiguration("game.cfg");
 
+#if defined (DEDICATED_SERVER)
+	// Load the dedicated-server-specific configuration
+    LoadConfiguration("server.cfg");
+#else
+	// Load the client-specific configuration
+    LoadConfiguration("client.cfg");
+#endif
+
     if (initParams.bShaderCacheGen)
     {
         LoadConfiguration("shadercachegen.cfg");


### PR DESCRIPTION
### Description 

A trivial change which was conspicuous by its absence. We needed specific config files for differentiating our dedicated server and client builds. For example, the server.cfg may have disconnect detection settings, access keys, etc.