### PR TITLE
90) Additions to SkeletalHierarchyRequestBus and IAttachmentManager

### DIFF
--- a/dev/Code/CryEngine/CryAnimation/AttachmentManager.cpp
+++ b/dev/Code/CryEngine/CryAnimation/AttachmentManager.cpp
@@ -909,8 +909,19 @@ IAttachment* CAttachmentManager::CreateAttachment(const char* szAttName, uint32 
     return 0;
 };
 
-
-
+IAttachmentManager::AttachmentNames CAttachmentManager::GetAllAttachmentNames() const
+{
+    AttachmentNames attachmentNames;
+    attachmentNames.reserve(GetAttachmentCount());
+    for (const auto attachment : m_arrAttachments)
+    {
+        if (attachment)
+        {
+            attachmentNames.push_back(attachment->GetName());
+        }
+    }
+    return attachmentNames;
+}
 
 ICharacterInstance* CAttachmentManager::GetSkelInstance() const
 {

--- a/dev/Code/CryEngine/CryAnimation/AttachmentManager.h
+++ b/dev/Code/CryEngine/CryAnimation/AttachmentManager.h
@@ -58,6 +58,7 @@ public:
     IAttachment* CreateAttachment(const char* szAttName, uint32 type, const char* szFirstJointName = 0, bool bCallProject = true, const char* szSecondJointName = 0);
 
     int32 GetAttachmentCount() const { return m_arrAttachments.size(); };
+    AttachmentNames GetAllAttachmentNames() const override;
 
     IAttachment* GetInterfaceByIndex(uint32 c) const;
     IAttachment* GetInterfaceByName(const char* szName) const;

--- a/dev/Code/CryEngine/CryCommon/IAttachment.h
+++ b/dev/Code/CryEngine/CryCommon/IAttachment.h
@@ -296,6 +296,10 @@ struct IAttachmentManager
     virtual IAttachment* GetInterfaceByNameCRC(uint32 nameCRC) const = 0;
 
     virtual int32 GetAttachmentCount() const = 0;
+
+    using AttachmentNames = AZStd::vector<const char*>;
+    virtual AttachmentNames GetAllAttachmentNames() const = 0;
+
     virtual int32 GetIndexByName(const char* szName) const = 0;
     virtual int32 GetIndexByNameCRC(uint32 nameCRC) const = 0;
 

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/SkinnedMeshComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/SkinnedMeshComponent.h
@@ -289,6 +289,11 @@ namespace LmbrCentral
         const char* GetJointNameByIndex(AZ::u32 jointIndex) override;
         AZ::s32 GetJointIndexByName(const char* jointName) override;
         AZ::Transform GetJointTransformCharacterRelative(AZ::u32 jointIndex) override;
+        SkeletalHierarchyRequests::AttachmentNames GetAllAttachmentNames() override;
+        AZ::Transform GetWorldJointTransformByName(const char* jointName) override;
+        AZ::Transform GetWorldJointTransformByCrc(AZ::Crc32 jointNameCrc) override;
+        AZ::Transform GetLocalJointTransformByName(const char* jointName) override;
+        AZ::Transform GetLocalJointTransformByCrc(AZ::Crc32 jointNameCrc) override;
         //////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshComponentBus.h
+++ b/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshComponentBus.h
@@ -91,9 +91,39 @@ namespace LmbrCentral
 
         /**
         * \param jointIndex Index of joint whose local-space transform should be returned.
-        * \return Joint's character-space transform. Identify if joint index was not valid.
+        * \return Joint's character-space transform. Identity if joint index was not valid.
         */
         virtual AZ::Transform GetJointTransformCharacterRelative(AZ::u32 /*jointIndex*/) { return AZ::Transform::CreateIdentity(); }
+        
+        /**
+        * \param jointName Name of joint whose world-space transform should be returned.
+        * \return Joint's world-space transform. Identity if joint was not valid.
+        */
+        virtual AZ::Transform GetWorldJointTransformByName(const char* jointName) { return AZ::Transform::CreateIdentity(); }
+
+        /**
+        * \param jointNameCrc Crc32 of joint whose world-space transform should be returned.
+        * \return Joint's world-space transform. Identity if joint was not valid.
+        */
+        virtual AZ::Transform GetWorldJointTransformByCrc(AZ::Crc32 jointNameCrc) { return AZ::Transform::CreateIdentity(); }
+
+        /**
+        * \param jointName Name of joint whose local-space transform should be returned.
+        * \return Joint's local-space transform. Identity if joint was not valid.
+        */
+        virtual AZ::Transform GetLocalJointTransformByName(const char* jointName) { return AZ::Transform::CreateIdentity(); }
+
+        /**
+        * \param jointNameCrc Crc32 of joint whose local-space transform should be returned.
+        * \return Joint's local-space transform. Identity if joint was not valid.
+        */
+        virtual AZ::Transform GetLocalJointTransformByCrc(AZ::Crc32 jointNameCrc) { return AZ::Transform::CreateIdentity(); }
+
+        /**
+        * \return List of all attachment names.
+        */
+        using AttachmentNames = AZStd::vector<const char*>;
+        virtual AttachmentNames GetAllAttachmentNames() { return AZStd::vector<const char*>(); }
     };
 
     using SkeletalHierarchyRequestBus = AZ::EBus<SkeletalHierarchyRequests>;


### PR DESCRIPTION
### Description

Added `GetAllAttachmentNames` to the `SkeletalHierarchyRequestBus` to allow all attachments to be returned:
``` lua
local attachmentSubString = "melee"
local attachments = SkeletalHierarchyRequestBus.Event.GetAllAttachmentNames(self.entityId)
if attachments ~= nil and #attachments > 0 then         
for i = 1, #attachments  do
    local attachmentName = attachments [i] 
    Debug.Log("Found attachment " .. tostring(attachmentName))
     if string.find(attachmentName, attachmentSubString) ~= nil then
         table.insert(self.attachmentCRCs, Crc32(attachmentName))
     end
 end
 Debug.Log("Found " .. #attachmentVector .. " attachments, of which " .. #self.attachmentCRCs .. " are melee_ attachments")
```

Added various functions to `SkeletalHierarchyRequestBus` for returning joint transforms:
``` lua
local barrelEndWorldTM	= SkeletalHierarchyRequestBus.Event.GetWorldBoneTransformByCrc(self.entityId, self.barrelEndJointNameCrc)

local barrelEndLocalTM = SkeletalHierarchyRequestBus.Event.GetLocalBoneTransformByCrc(self.entityId, self.barrelEndJointNameCrc);
```