### PR TITLE
91) Additions to the AttachmentComponentRequestBus

### DIFF
--- a/dev/Code/CryEngine/CryAnimation/AttachmentManager.h
+++ b/dev/Code/CryEngine/CryAnimation/AttachmentManager.h
@@ -88,7 +88,10 @@ public:
     void UpdateAllLocations(Skeleton::CPoseData& pPoseData);
 
     void UpdateAllLocationsFast(Skeleton::CPoseData& pPoseData);
-    void ProcessAllAttachedObjectsFast();
+    void ProcessAllAttachedObjectsFast()
+    {
+        AZ_Error("AttachmentManager", false, "ProcessAllAttachedObjectsFast has not been implemented.");
+    }
 
     void DrawAttachments(const SRendParams& rRendParams, const Matrix34& m, const SRenderingPassInfo& passInfo);
 

--- a/dev/Gems/LmbrCentral/Code/Source/Animation/AttachmentComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Animation/AttachmentComponent.h
@@ -78,8 +78,11 @@ namespace LmbrCentral
         ////////////////////////////////////////////////////////////////////////
         // AttachmentComponentRequests
         void Attach(AZ::EntityId targetId, const char* targetBoneName, const AZ::Transform& offset) override;
+        void AttachWithCurrentOffset(AZ::EntityId targetId, const char* targetBoneName) override;
         void Detach() override;
         void SetAttachmentOffset(const AZ::Transform& offset) override;
+        const AZ::Transform GetAttachmentOffset() override;
+        const char* GetTargetBoneName() override;
         ////////////////////////////////////////////////////////////////////////
 
     private:

--- a/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Animation/AttachmentComponentBus.h
+++ b/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Animation/AttachmentComponentBus.h
@@ -41,11 +41,26 @@ namespace LmbrCentral
         //! \param offset           Attachment's offset from target.
         virtual void Attach(AZ::EntityId targetId, const char* targetBoneName, const AZ::Transform& offset) = 0;
 
+        //! Change attachment target, use the offset specified in the editor, or set previously.
+        //! The entity will detach from any previous target.
+        //!
+        //! \param targetId         Attach to this entity.
+        //! \param targetBoneName   Attach to this bone on target entity.
+        //!                         If targetBone is not found then attach to
+        //!                         target entity's transform origin.
+        virtual void AttachWithCurrentOffset(AZ::EntityId targetId, const char* targetBoneName) = 0;
+
         //! The entity will detach from its target.
         virtual void Detach() = 0;
 
         //! Update entity's offset from target.
         virtual void SetAttachmentOffset(const AZ::Transform& offset) = 0;
+
+        //! Return current attachment offset
+        virtual const AZ::Transform GetAttachmentOffset() = 0;
+
+        //! Get name of the target bone
+        virtual const char* GetTargetBoneName() = 0;
     };
     using AttachmentComponentRequestBus = AZ::EBus<AttachmentComponentRequests>;
 


### PR DESCRIPTION
### Description

Continuing the attachment related changes: added utility function `GetTargetBoneName` to the `AttachmentComponentRequestBus`: 
``` lua
local weaponJointName = AttachmentComponentRequestBus.Event.GetTargetBoneName(self.weaponId)
self.weaponJointCrc = weaponJointName and Crc32(weaponJointName) or nil
local weaponBoneLocalTM = SkeletalHierarchyRequestBus.Event.GetLocalJointTransformByCrc(self.possessedCharacterId, self.weaponJointCrc)
...
```

Added utility function `AttachWithCurrentOffset` to the `AttachmentComponentRequestBus`: 
``` c++
if (!m_throwableAttachmentName.empty())
{
	EBUS_EVENT_ID(equippedItemId, LmbrCentral::AttachmentComponentRequestBus, AttachWithCurrentOffset, GetEntityId(), m_throwableAttachmentName.c_str());
}
```