### PR TITLE
92) Fix for CompareRotation functions with copy/paste errors.

### DIFF
--- a/dev/Gems/LyShine/Code/Source/Animation/AzEntityNode.cpp
+++ b/dev/Gems/LyShine/Code/Source/Animation/AzEntityNode.cpp
@@ -99,7 +99,7 @@ namespace
     {
         return (fabs_tpl(q1.v.x - q2.v.x) <= epsilon)
                && (fabs_tpl(q1.v.y - q2.v.y) <= epsilon)
-               && (fabs_tpl(q2.v.z - q2.v.z) <= epsilon)
+               && (fabs_tpl(q1.v.z - q2.v.z) <= epsilon)
                && (fabs_tpl(q1.w - q2.w) <= epsilon);
     }
 

--- a/dev/Gems/Maestro/Code/Source/Cinematics/EntityNode.cpp
+++ b/dev/Gems/Maestro/Code/Source/Cinematics/EntityNode.cpp
@@ -104,7 +104,7 @@ namespace
     {
         return (fabs_tpl(q1.v.x - q2.v.x) <= epsilon)
                && (fabs_tpl(q1.v.y - q2.v.y) <= epsilon)
-               && (fabs_tpl(q2.v.z - q2.v.z) <= epsilon)
+               && (fabs_tpl(q1.v.z - q2.v.z) <= epsilon)
                && (fabs_tpl(q1.w - q2.w) <= epsilon);
     }
 };


### PR DESCRIPTION
### Description

Fix for copy/paste error in `CompareRotation` functions in `EntityNode.cpp` and `AZEntityNode.cpp`.