### PR TITLE
94) Additions to the CryCharacterPhysicsRequestBus

### DIFF
--- a/dev/Code/CryEngine/CryCommon/physinterface.h
+++ b/dev/Code/CryEngine/CryCommon/physinterface.h
@@ -1127,6 +1127,7 @@ struct pe_player_dynamics
     {
         type = type_id;
         MARK_UNUSED kInertia, kInertiaAccel, kAirControl, gravity, gravity.z, nodSpeed, mass, bSwimming, surface_idx, bActive, collTypes, pLivingEntToIgnore;
+        MARK_UNUSED bUseCustomGravity;
         MARK_UNUSED minSlideAngle, maxClimbAngle, maxJumpAngle, minFallAngle, kAirResistance, maxVelGround, timeImpulseRecover, bReleaseGroundColliderWhenNotActive;
     }
 
@@ -1149,6 +1150,7 @@ struct pe_player_dynamics
     IPhysicalEntity* pLivingEntToIgnore; // ignore collisions with this *living entity* (doesn't work with other entity types)
     int bActive; // 0 disables all simulation for the character, apart from moving along the requested velocity
     int bReleaseGroundColliderWhenNotActive; // when not 0, if the living entity is not active, the ground collider, if any, will be explicitly released during the simulation step.
+    int bUseCustomGravity;	// when 1, the living entity will use the supplied gravity, 0 or default will use world gravity
 };
 
 ////////// particle entity params

--- a/dev/Code/CryEngine/CryPhysics/livingentity.cpp
+++ b/dev/Code/CryEngine/CryPhysics/livingentity.cpp
@@ -198,6 +198,7 @@ CLivingEntity::CLivingEntity(CPhysicalWorld* pWorld, IGeneralMemoryHeap* pHeap)
     m_dtRequested = 0;
 
     m_bReleaseGroundColliderWhenNotActive = 1;
+    m_bUseCustomGravity = 0;
 }
 
 CLivingEntity::~CLivingEntity()
@@ -647,6 +648,10 @@ int CLivingEntity::SetParams(const pe_params* _params, int bThreadSafe)
         {
             m_bReleaseGroundColliderWhenNotActive = params->bReleaseGroundColliderWhenNotActive;
         }
+        if (!is_unused(params->bUseCustomGravity))
+        {
+            m_bUseCustomGravity = params->bUseCustomGravity;
+        }
         if (!is_unused(params->bActive))
         {
             if (m_bActive + params->bActive * 2 == 2)
@@ -708,6 +713,7 @@ int CLivingEntity::GetParams(pe_params* _params) const
         params->pLivingEntToIgnore = m_pLivingEntToIgnore;
         params->bActive = m_bActive;
         params->bReleaseGroundColliderWhenNotActive = m_bReleaseGroundColliderWhenNotActive;
+        params->bUseCustomGravity = m_bUseCustomGravity;
         return 1;
     }
 
@@ -2987,13 +2993,16 @@ nomove:;
     {
         if (bMoving)
         {
-            Vec3 gravity;
-            MARK_UNUSED gravity;
-            pe_params_buoyancy pb;
-            m_pWorld->CheckAreas(this, gravity, &pb, 0);
-            if (!is_unused(gravity))
+            if (!m_bUseCustomGravity)
             {
-                m_gravity = gravity;
+                Vec3 gravity;
+                MARK_UNUSED gravity;
+                pe_params_buoyancy pb;
+                m_pWorld->CheckAreas(this, gravity, &pb, 0);
+                if (!is_unused(gravity))
+                {
+                    m_gravity = gravity;
+                }
             }
 
             if (m_pWorld->m_pWaterMan)

--- a/dev/Code/CryEngine/CryPhysics/livingentity.h
+++ b/dev/Code/CryEngine/CryPhysics/livingentity.h
@@ -225,6 +225,7 @@ public:
     unsigned int m_bActiveEnvironment : 1;
     unsigned int m_bStuck : 1;
     unsigned int m_bReleaseGroundColliderWhenNotActive : 1;
+    unsigned int m_bUseCustomGravity : 1;
     mutable unsigned int m_bHadCollisions : 1;
     int m_bSquashed;
 

--- a/dev/Gems/LmbrCentral/Code/Source/Physics/CharacterPhysicsComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/CharacterPhysicsComponent.h
@@ -161,6 +161,7 @@ namespace LmbrCentral
                 const bool s_defaultLivingEntityIsActive = true;
                 const bool s_defaultLivingEntityReleaseGroundColliderWhenNotActive = true;
                 const bool s_defaultLivingEntityIsSwimming = false;
+                const bool s_defaultLivingEntityIsFlying = false;
                 const int s_defaultLivingEntitySurfaceIndex = 0;
                 const float s_defaultLivingEntityMinFallAngle = 70.2f;
                 const float s_defaultLivingEntityMinSlideAngle = 36.f;
@@ -211,6 +212,9 @@ namespace LmbrCentral
 
                 //! whether entity is swimming (is not bound to ground plane)
                 bool m_isSwimming = s_defaultLivingEntityIsSwimming;
+
+                //! whether entity is in the air, ie has released ground colliders
+                bool m_isFlying = s_defaultLivingEntityIsFlying;
 
                 //! surface identifier for collisions
                 int m_surfaceIndex = s_defaultLivingEntitySurfaceIndex;
@@ -324,6 +328,13 @@ namespace LmbrCentral
         ////////////////////////////////////////////////////////////////////////
         // CharacterPhysicsRequestBus
         void RequestVelocity(const AZ::Vector3& velocity, int jump) override;
+        bool IsFlying() override;
+        void EnableGravity() override;
+        void DisableGravity() override;
+        AZ::Vector3 GetCurrentGravity() override;
+        void SetCustomGravity(AZ::Vector3 customGravity) override;
+        ////////////////////////////////////////////////////////////////////////
+
         ////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////
@@ -337,6 +348,7 @@ namespace LmbrCentral
         bool m_isApplyingPhysicsToEntityTransform = false;
         SProximityElement* m_proximityTriggerProxy = nullptr;
         AZ::Transform m_previousEntityTransform = AZ::Transform::CreateIdentity();
+        bool m_wasFlying = false;
         //////////////////////////////////////////////////////////////////////////
 
     };

--- a/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Physics/CryCharacterPhysicsBus.h
+++ b/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Physics/CryCharacterPhysicsBus.h
@@ -34,7 +34,39 @@ namespace LmbrCentral
         /// \param velocity - Requested velocity (direction and magnitude).
         /// \param jump - Controls how velocity is applid within Living Entity. See physinterface.h, \ref pe_action_move::iJump for more details.
         virtual void RequestVelocity(const AZ::Vector3& velocity, int jump) = 0;
+
+        /// Is the character grounded.
+        virtual bool IsFlying() = 0;
+
+        /// Get the velocity of the living entity
+        virtual AZ::Vector3 GetVelocity() { return AZ::Vector3::CreateZero(); }
+
+        ///  Enables gravity on a character so they fall.
+        virtual void EnableGravity() {};
+
+        ///  Disables gravity on a character so they do not fall.
+        virtual void DisableGravity() {};
+
+        /// Get the current value of gravity.
+        virtual AZ::Vector3 GetCurrentGravity() { return AZ::Vector3::CreateZero(); };
+
+        ///  Set gravity to be a custom vector3
+        virtual void SetCustomGravity(AZ::Vector3 customGravity) {};
+
     };
 
     using CryCharacterPhysicsRequestBus = AZ::EBus<CryCharacterPhysicsRequests>;
+
+    class CryCharacterPhysicsNotifications
+        : public AZ::ComponentBus
+    {
+    public:
+
+        virtual ~CryCharacterPhysicsNotifications() {}
+
+        /// Notifies when isFlying variable changes.
+        virtual void OnCharacterIsFlyingChanged(bool bIsFlying) = 0;
+    };
+
+    using CryCharacterPhysicsNotificationsBus = AZ::EBus<CryCharacterPhysicsNotifications>;
 } // namespace LmbrCentral


### PR DESCRIPTION
### Description 

A number of additions to round out the lua interface to the character physics system.

Additions to the CryCharacterPhysicsRequestBus
- IsFlying
- GetVelocity
- EnableGravity
- DisableGravity
- GetCurrentGravity
- SetCustomGravity

Addition of a new CryCharacterPhysicsNotificationsBus
- OnCharacterIsFlyingChanged

``` lua
local TestScript = {}

function TestScript:OnActivate()
	Debug.Log("Gravity before change: " .. tostring(CryCharacterPhysicsRequestBus.Event.GetVelocity(self.entityId)))
	CryCharacterPhysicsRequestBus.Event.SetCustomGravity(self.entityId, Vector3(0.0,0.0,10))
	CryCharacterPhysicsRequestBus.Event.EnableGravity(self.entityId)
	Debug.Log("Gravity after change: " .. tostring(CryCharacterPhysicsRequestBus.Event.GetVelocity(self.entityId)))
	Debug.Log("IsFlying: " .. tostring(CryCharacterPhysicsRequestBus.Event.IsFlying(self.entityId)))
end
return TestScript
```