### PR TITLE
95) Fix for dedicated server not launching/waiting for the asset processor

### DIFF
--- a/dev/AssetProcessorPlatformConfig.ini
+++ b/dev/AssetProcessorPlatformConfig.ini
@@ -341,6 +341,7 @@ params=copy
 [RC cfg]
 glob=*.cfg
 params=copy
+critical=true
 productAssetType={9952F1E9-BF9F-4B0D-8627-D973A3D82230}
 version=2
 
@@ -450,6 +451,7 @@ params=copy
 [RC json]
 glob=*.json
 params=copy
+critical=true
 
 [RC lmg]
 glob=*.lmg
@@ -477,6 +479,7 @@ params=copy
 glob=*.xml
 params=copy
 version=2
+critical=true
 
 [RC font]
 glob=*.font
@@ -557,6 +560,7 @@ params=copy
 [RC ini]
 glob=*.ini
 params=copy
+critical=true
 
 [RC ttf]
 glob=*.ttf

--- a/dev/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -2183,6 +2183,25 @@ bool CSystem::LaunchAssetProcessor()
         azstrncpy(assetProcessorExe, AZ_ARRAY_SIZE(assetProcessorExe), engineAssetProcessorPath.c_str(), engineAssetProcessorPath.length());
     }
 
+#if defined (DEDICATED_SERVER)
+    // If running the ds, we want to launch the non-ds asset processor
+    auto StripDedicatedPath = [&](char* path)
+    {
+        AZStd::string pathString(path);
+        AZStd::string replaceSearch(".Dedicated");
+        size_t replaceStart = pathString.find(replaceSearch);
+        if (replaceStart != AZStd::string::npos)
+        {
+            pathString.replace(replaceStart, replaceSearch.length(), "");
+            size_t length = pathString.copy(path, AZ_MAX_PATH_LEN - 1);
+            path[length] = '\0';
+        }
+    };
+
+    StripDedicatedPath(assetProcessorExe);
+    StripDedicatedPath(workingDir);
+#endif
+
 
 #if defined(AZ_PLATFORM_WINDOWS)
     if (appRoot == nullptr)

--- a/dev/Code/Launcher/DedicatedLauncher/Main.cpp
+++ b/dev/Code/Launcher/DedicatedLauncher/Main.cpp
@@ -252,11 +252,6 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
         }
 #endif
 
-        /*
-        * Dedicated server does not depend on Asset Processor and assumes that assets are already prepared.
-        */
-        engineCfg.m_waitForConnect = false;
-
         char configPath[AZ_MAX_PATH_LEN];
         AzGameFramework::GameApplication::GetGameDescriptorPath(configPath, engineCfg.m_gameFolder);
         if (!AZ::IO::SystemFile::Exists(configPath))


### PR DESCRIPTION
### Description 

Fix for the dedicated server not launching or handshaking with the Asset Processor, resulting in it booting up before critical files are copied. If the asset processor is not meant to run it could be disabling via the config file.

- Marked `.ini`, `.cfg`, `.xml`, and `.json` files as critical, so that they are copied before the AP handshake completes. All of these types are used by critical system configuration and therefore needed immediately on boot.
- When launching the dedicated server, it will handshake with (or launch) the non-dedicated version of the asset processor. There isn't a use case for running the version in the dedicated server bin folder, and it fails to start.