### PR TITLE
97) Re-add GetRigidPhysicsConfiguration

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Physics/RigidPhysicsComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Physics/RigidPhysicsComponent.h
@@ -29,6 +29,8 @@ namespace LmbrCentral
         RigidPhysicsComponent() = default;
         ~RigidPhysicsComponent() override = default;
 
+        const AzFramework::RigidPhysicsConfig& GetRigidPhysicsConfiguration() const { return m_configuration; }
+
     protected:
         ////////////////////////////////////////////////////////////////////////
         // PhysicsComponent


### PR DESCRIPTION
### Description

At some point in a previous version of Lumberyard, `GetRigidPhysicsConfiguration` was removed. We have re-added this as we are still using it in our `TrajectorVisualiserComponent` (which I may review and submit at some point in the future!).