### PR TITLE
98) Fix deserialisation of data on linux.

### DIFF
--- a/dev/Code/CryEngine/CryCommon/IEntityRenderState.h
+++ b/dev/Code/CryEngine/CryCommon/IEntityRenderState.h
@@ -356,7 +356,7 @@ struct IRenderNode
     virtual uint8 GetSortPriority() { return 0; }
 
     // Types of voxelization for objects and lights
-    enum EVoxelGIMode : int
+    enum EVoxelGIMode : signed int
     {
         VM_None = 0, // No voxelization
         VM_Static, // Incremental or asynchronous lazy voxelization


### PR DESCRIPTION
### Description 

Force enum EVoxelGIMode to be a signed int: `Type {72039442-EB38-4D42-A1AD-CB68F7E0EEF6}`, instead of an unsigned int :`Type {43DA906B-7DEF-4CA8-9790-854106D3F983}`. 
This fixes potential serialisation warnings during loading on Linux.

```
Serialize: Trace::Error
/game01/dev/BinTemp/uber_files/AzCore/../../../Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp(1867): 'void AZ::SerializeContext::ErrorHandler::ReportError(const char *)'
Serialize: Element 'VoxelGIMode'(0xf5c72d4b) in class 'LightConfiguration' is of type {72039442-EB38-4D42-A1AD-CB68F7E0EEF6} but needs to be type {43DA906B-7DEF-4CA8-9790-854106D3F983}.
```