### PR TITLE
101) Add a tick callback to allow injection of code between entity deserialisation

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.h
+++ b/dev/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.h
@@ -113,6 +113,9 @@ namespace AZ
         /// Called to indicate that loading has completed
         typedef AZStd::function< void (Handle /*objectstream*/, bool /*success*/) > CompletionCB;
 
+        /// Tick callback to allow injection of code between entity deserialization
+        typedef AZStd::function< void() > TickCB;
+
         /// Filter flags control the overall behavior of the serialize operation and can cause it to skip over unnecessary data (the default)
         /// or instead throw an error and fail if any error is encountered.
         enum FilterFlags
@@ -155,7 +158,7 @@ namespace AZ
         };
 
         /// Create objects from a stream. All processing happens in the caller thread. Returns true on success.
-        static bool LoadBlocking(IO::GenericStream* stream, SerializeContext& sc, const ClassReadyCB& readyCB, const FilterDescriptor& filterDesc = FilterDescriptor(), const InplaceLoadRootInfoCB& inplaceRootInfo = InplaceLoadRootInfoCB());
+        static bool LoadBlocking(IO::GenericStream* stream, SerializeContext& sc, const ClassReadyCB& readyCB, const FilterDescriptor& filterDesc = FilterDescriptor(), const InplaceLoadRootInfoCB& inplaceRootInfo = InplaceLoadRootInfoCB(), const TickCB& tickCB = TickCB());
 
         /// Create a new object stream for writing
         static ObjectStream* Create(IO::GenericStream* stream, SerializeContext& sc, DataStream::StreamType fmt);

--- a/dev/Code/Framework/AzCore/AzCore/Serialization/Utils.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/Serialization/Utils.cpp
@@ -113,7 +113,7 @@ namespace AZ
             return LoadObjectFromStreamInPlace(fileStream, context, targetClassId, destination, filterDesc);
         }
 
-        void* LoadObjectFromStream(IO::GenericStream& stream, AZ::SerializeContext* context, const Uuid* targetClassId, const FilterDescriptor& filterDesc)
+        void* LoadObjectFromStream(IO::GenericStream& stream, AZ::SerializeContext* context, const Uuid* targetClassId, const FilterDescriptor& filterDesc, const ObjectStream::TickCB& tickCB)
         {
             AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::AzCore);
 
@@ -164,7 +164,8 @@ namespace AZ
                         }
                     },
                     filterDesc,
-                    ObjectStream::InplaceLoadRootInfoCB()
+                    ObjectStream::InplaceLoadRootInfoCB(),
+                    tickCB
                     );
 
             if (!success)

--- a/dev/Code/Framework/AzCore/AzCore/Serialization/Utils.h
+++ b/dev/Code/Framework/AzCore/AzCore/Serialization/Utils.h
@@ -26,14 +26,14 @@ namespace AZ
     {
         typedef AZ::ObjectStream::FilterDescriptor FilterDescriptor;
 
-        void* LoadObjectFromStream(IO::GenericStream& stream, SerializeContext* context = nullptr, const Uuid* targetClassId = nullptr, const FilterDescriptor& filterDesc = FilterDescriptor());
+        void* LoadObjectFromStream(IO::GenericStream& stream, SerializeContext* context = nullptr, const Uuid* targetClassId = nullptr, const FilterDescriptor& filterDesc = FilterDescriptor(), const ObjectStream::TickCB& tickCB = ObjectStream::TickCB());
         bool LoadObjectFromStreamInPlace(IO::GenericStream& stream, AZ::SerializeContext* context, const Uuid& targetClassId, void* targetPointer, const FilterDescriptor& filterDesc = FilterDescriptor());
         bool LoadObjectFromStreamInPlace(IO::GenericStream& stream, AZ::SerializeContext* context, const SerializeContext::ClassData* objectClassData, void* targetPointer, const FilterDescriptor& filterDesc = FilterDescriptor());
 
         template <typename ObjectType>
-        ObjectType* LoadObjectFromStream(IO::GenericStream& stream, SerializeContext* context = nullptr, const FilterDescriptor& filterDesc = FilterDescriptor())
+        ObjectType* LoadObjectFromStream(IO::GenericStream& stream, SerializeContext* context = nullptr, const FilterDescriptor& filterDesc = FilterDescriptor(), const ObjectStream::TickCB& tickCB = ObjectStream::TickCB())
         {
-            return reinterpret_cast<ObjectType*>(LoadObjectFromStream(stream, context, &AzTypeInfo<ObjectType>::Uuid(), filterDesc));
+            return reinterpret_cast<ObjectType*>(LoadObjectFromStream(stream, context, &AzTypeInfo<ObjectType>::Uuid(), filterDesc, tickCB));
         }
 
         template <typename ObjectType>

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/EntityContext.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/EntityContext.cpp
@@ -528,13 +528,13 @@ namespace AzFramework
     //=========================================================================
     // LoadFromStream
     //=========================================================================
-    bool EntityContext::LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds, AZ::SliceComponent::EntityIdToEntityIdMap* idRemapTable, const AZ::ObjectStream::FilterDescriptor& filterDesc)
+    bool EntityContext::LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds, AZ::SliceComponent::EntityIdToEntityIdMap* idRemapTable, const AZ::ObjectStream::FilterDescriptor& filterDesc, const AZ::ObjectStream::TickCB& tickCB)
     {
         AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::AzFramework);
 
         AZ_Assert(m_rootAsset, "The context has not been initialized.");
 
-        AZ::Entity* newRootEntity = AZ::Utils::LoadObjectFromStream<AZ::Entity>(stream, m_serializeContext, filterDesc);
+        AZ::Entity* newRootEntity = AZ::Utils::LoadObjectFromStream<AZ::Entity>(stream, m_serializeContext, filterDesc, tickCB);
 
         // make sure that PRE_NOTIFY assets get their notify before we activate, so that we can preserve the order of 
         // (load asset) -> (notify) -> (init) -> (activate)

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/EntityContext.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/EntityContext.h
@@ -94,7 +94,8 @@ namespace AzFramework
         /// \param remapIds - if true, entity Ids will be remapped post-load
         /// \param idRemapTable - if remapIds is true, the provided table is filled with a map of original ids to new ids.
         /// \param loadFlags - any ObjectStream::LoadFlags.
-        virtual bool LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds, AZ::SliceComponent::EntityIdToEntityIdMap* idRemapTable = nullptr, const AZ::ObjectStream::FilterDescriptor& filterDesc = AZ::ObjectStream::FilterDescriptor());
+        /// \param tickCB - Tick callback to pass to the ObjectStream
+        virtual bool LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds, AZ::SliceComponent::EntityIdToEntityIdMap* idRemapTable = nullptr, const AZ::ObjectStream::FilterDescriptor& filterDesc = AZ::ObjectStream::FilterDescriptor(), const AZ::ObjectStream::TickCB& tickCB = AZ::ObjectStream::TickCB());
 
         /// Initialize this entity context with a newly loaded root slice
         /// \return whether or not the root slice is valid.

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextBus.h
@@ -144,10 +144,11 @@ namespace AzFramework
          * Loads game entities from a stream.
          * @param stream The root slice.
          * @param remapIds Use true to remap the entity IDs after the stream is loaded.
+         * @param tickCB Tick callback to pass to the ObjectStream
          * @return True if the stream successfully loaded. Otherwise, false. This operation  
          * can fail if the source file is corrupt or the data could not be up-converted.
          */
-        virtual bool LoadFromStream(AZ::IO::GenericStream& /*stream*/, bool /*remapIds*/) = 0;
+        virtual bool LoadFromStream(AZ::IO::GenericStream& /*stream*/, bool /*remapIds*/, const AZ::ObjectStream::TickCB& /*tickCB*/) = 0;
 
         /**
          * Completely resets the game context. 

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -374,9 +374,9 @@ namespace AzFramework
     //=========================================================================
     // EntityContextEventBus::LoadFromStream
     //=========================================================================
-    bool GameEntityContextComponent::LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds)
+    bool GameEntityContextComponent::LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds, const AZ::ObjectStream::TickCB& tickCB)
     {
-        if (AzFramework::EntityContext::LoadFromStream(stream, remapIds))
+        if (AzFramework::EntityContext::LoadFromStream(stream, remapIds, nullptr, AZ::ObjectStream::FilterDescriptor(), tickCB))
         {
             EBUS_EVENT(GameEntityContextEventBus, OnGameEntitiesStarted);
             return true;

--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.h
@@ -62,7 +62,7 @@ namespace AzFramework
         void DeactivateGameEntity(const AZ::EntityId&) override;
         SliceInstantiationTicket InstantiateDynamicSlice(const AZ::Data::Asset<AZ::Data::AssetData>& sliceAsset, const AZ::Transform& worldTransform, const AZ::IdUtils::Remapper<AZ::EntityId>::IdMapper& customIdMapper) override;
         void CancelDynamicSliceInstantiation(const SliceInstantiationTicket& ticket) override;
-        bool LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds) override;
+        bool LoadFromStream(AZ::IO::GenericStream& stream, bool remapIds, const AZ::ObjectStream::TickCB& tickCB) override;
         AZStd::string GetEntityName(const AZ::EntityId& id) override;
         void MarkEntityForNoActivation(AZ::EntityId entityId) override;
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -590,7 +590,7 @@ namespace AzToolsFramework
 
         // Load the exported stream into the game context.
         stream.Seek(0, AZ::IO::GenericStream::ST_SEEK_BEGIN);
-        AzFramework::GameEntityContextRequestBus::Broadcast(&AzFramework::GameEntityContextRequests::LoadFromStream, stream, true);
+        AzFramework::GameEntityContextRequestBus::Broadcast(&AzFramework::GameEntityContextRequests::LoadFromStream, stream, true, AZ::ObjectStream::TickCB());
 
         // Retrieve Id map from game entity context (editor->runtime).
         AzFramework::EntityContextId gameContextId = AzFramework::EntityContextId::CreateNull();


### PR DESCRIPTION
### Description

Similarly to the callbacks `InplaceLoadRootInfoCB`, `ClassReadyCB`, and `CompletionCB`, we have added a `TickCB` to allow injection of code between entity deserialisation. 
This is currently only used from `CLevelSystem::LoadLevelInternal`. In `LoadLevelInternal` we have added a lambda which will pump the loading screen during the synchronous level loading. This was needed because in DRG were seeing stalls due to our large number of entities necessary in the biggest level we used.
