### PR TITLE
102) Add CVar to skipSleepIfNeeded

### DIFF
--- a/dev/Code/CryEngine/CrySystem/System.cpp
+++ b/dev/Code/CryEngine/CrySystem/System.cpp
@@ -1443,7 +1443,7 @@ bool CSystem::UpdatePreTickBus(int updateFlags, int nPauseMode)
 
 #ifndef EXCLUDE_UPDATE_ON_CONSOLE
     // do the dedicated sleep earlier than the frame profiler to avoid having it counted
-    if (gEnv->IsDedicated())
+    if (gEnv->IsDedicated() && g_cvars.sys_dedicatedServer_skipSleepIfNeeded == 0)
     {
 #if defined(MAP_LOADING_SLICING)
         gEnv->pSystemScheduler->SchedulingSleepIfNeeded();

--- a/dev/Code/CryEngine/CrySystem/System.h
+++ b/dev/Code/CryEngine/CrySystem/System.h
@@ -321,6 +321,8 @@ struct SSystemCVars
 #define AZ_RESTRICTED_SECTION SYSTEM_H_SECTION_2
 #include AZ_RESTRICTED_FILE(System_h, AZ_RESTRICTED_PLATFORM)
 #endif
+
+    int sys_dedicatedServer_skipSleepIfNeeded;
 };
 extern SSystemCVars g_cvars;
 

--- a/dev/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -6409,6 +6409,9 @@ void CSystem::CreateSystemVars()
 
     REGISTER_CVAR_CB(sys_ProfileLevelLoadingDump, 0, VF_CHEAT,  "Output level loading dump stats into log\n", OnLevelLoadingDump);
 
+    REGISTER_CVAR2("sys_ds_skipSleep", &g_cvars.sys_dedicatedServer_skipSleepIfNeeded, 0, VF_CHEAT, "If set then the sleepIfNeeded call is skipped.\n"
+        "0 = Sleep as usual (default)\n"
+        "1 = Skip the sleep for better frame profiling");
 
     assert(m_env.pConsole);
     m_env.pConsole->CreateKeyBind("alt_keyboard_key_function_F12", "Screenshot");


### PR DESCRIPTION
### Description 

Added cvar `sys_ds_skipSleep`. This is a trivial change to cause the dedicated server to not schedule a sleep if it is set to `1`. Turning this on was useful for profiling dedicated server spikes.