### PR TITLE
103) Added a modal popup when the application descriptor can't be found.

### DIFF
--- a/dev/Code/Launcher/DedicatedLauncher/Main.cpp
+++ b/dev/Code/Launcher/DedicatedLauncher/Main.cpp
@@ -264,7 +264,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
             char msg[ERROR_MESSAGE_BUF_SIZE] = { 0 };
             azsnprintf(msg, sizeof(msg), "Application descriptor file not found:\n%s", configPath);
             fprintf(stderr, msg);
-            MessageBox(0, msg, "Invalid Application Descriptor", MB_OK | MB_DEFAULT_DESKTOP_ONLY | MB_ICONERROR);
+            MessageBox(0, msg, "File not found", MB_OK | MB_DEFAULT_DESKTOP_ONLY | MB_ICONERROR);
             return 1;
         }
 

--- a/dev/Code/Launcher/DedicatedLauncher/Main.cpp
+++ b/dev/Code/Launcher/DedicatedLauncher/Main.cpp
@@ -261,7 +261,10 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
         AzGameFramework::GameApplication::GetGameDescriptorPath(configPath, engineCfg.m_gameFolder);
         if (!AZ::IO::SystemFile::Exists(configPath))
         {
-            fprintf(stderr, "Application descriptor file not found:\n%s", configPath);
+            char msg[ERROR_MESSAGE_BUF_SIZE] = { 0 };
+            azsnprintf(msg, sizeof(msg), "Application descriptor file not found:\n%s", configPath);
+            fprintf(stderr, msg);
+            MessageBox(0, msg, "Invalid Application Descriptor", MB_OK | MB_DEFAULT_DESKTOP_ONLY | MB_ICONERROR);
             return 1;
         }
 


### PR DESCRIPTION
### Description

Upgraded the silent failure and printf to a modal popup when the dedicated server fails to find `dev\<game>\config\game.xml`