### PR TITLE
105) Add activate property to camera.

### DIFF
--- a/dev/Gems/Camera/Code/Source/CameraComponent.cpp
+++ b/dev/Gems/Camera/Code/Source/CameraComponent.cpp
@@ -35,6 +35,7 @@ namespace Camera
         , m_specifyDimensions(properties.m_specifyFrustumDimensions)
         , m_frustumWidth(properties.m_frustumWidth)
         , m_frustumHeight(properties.m_frustumHeight)
+        , m_autoActivate(properties.m_autoActivate)
     {
     }
 
@@ -60,7 +61,14 @@ namespace Camera
                 m_view->LinkTo(GetEntity());
                 UpdateCamera();
             }
-            MakeActiveView();
+
+
+            // Only activate the view if m_activate checkbox is ticked. 
+            // This allows more control over multiple cameras in a scene.
+            if (m_autoActivate)
+            {
+                MakeActiveView();
+            }
         }
         CameraRequestBus::Handler::BusConnect(GetEntityId());
         AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
@@ -97,13 +105,15 @@ namespace Camera
         {
             serializeContext->ClassDeprecate("CameraComponent", "{A0C21E18-F759-4E72-AF26-7A36FC59E477}", &ClassConverters::DeprecateCameraComponentWithoutEditor);
             serializeContext->Class<CameraComponent, AZ::Component>()
-                ->Version(1)
+                ->Version(2)
                 ->Field("Field of View", &CameraComponent::m_fov)
                 ->Field("Near Clip Plane Distance", &CameraComponent::m_nearClipPlaneDistance)
                 ->Field("Far Clip Plane Distance", &CameraComponent::m_farClipPlaneDistance)
                 ->Field("SpecifyDimensions", &CameraComponent::m_specifyDimensions)
                 ->Field("FrustumWidth", &CameraComponent::m_frustumWidth)
-                ->Field("FrustumHeight", &CameraComponent::m_frustumHeight);
+                ->Field("FrustumHeight", &CameraComponent::m_frustumHeight)
+                ->Field("Activate", &CameraComponent::m_autoActivate)
+                ;
         }
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(reflection))
         {

--- a/dev/Gems/Camera/Code/Source/CameraComponent.h
+++ b/dev/Gems/Camera/Code/Source/CameraComponent.h
@@ -27,6 +27,7 @@ namespace Camera
         float m_frustumWidth;
         float m_frustumHeight;
         bool m_specifyFrustumDimensions;
+        bool m_autoActivate;
     };
 
     const float s_defaultFoV = 75.0f;
@@ -110,5 +111,6 @@ namespace Camera
         bool m_specifyDimensions = false;
         float m_frustumWidth = s_defaultFrustumDimension;
         float m_frustumHeight = s_defaultFrustumDimension;
+        bool m_autoActivate = true;
     };
 } // Camera

--- a/dev/Gems/Camera/Code/Source/EditorCameraComponent.cpp
+++ b/dev/Gems/Camera/Code/Source/EditorCameraComponent.cpp
@@ -92,7 +92,7 @@ namespace Camera
         if (serializeContext)
         {
             serializeContext->Class<EditorCameraComponent, AzToolsFramework::Components::EditorComponentBase>()
-                ->Version(1)
+                ->Version(2)
                 ->Field("Field of View", &EditorCameraComponent::m_fov)
                 ->Field("Near Clip Plane Distance", &EditorCameraComponent::m_nearClipPlaneDistance)
                 ->Field("Far Clip Plane Distance", &EditorCameraComponent::m_farClipPlaneDistance)
@@ -102,6 +102,7 @@ namespace Camera
                 ->Field("ViewButton", &EditorCameraComponent::m_viewButton)
                 ->Field("FrustumLengthPercent", &EditorCameraComponent::m_frustumViewPercentLength)
                 ->Field("FrustumDrawColor", &EditorCameraComponent::m_frustumDrawColor)
+                ->Field("AutoActivate", &EditorCameraComponent::m_autoActivate)
                 ;
 
             AZ::EditContext* editContext = serializeContext->GetEditContext();
@@ -137,6 +138,8 @@ namespace Camera
                         ->Attribute(AZ::Edit::Attributes::Suffix, " m")
                         ->Attribute(AZ::Edit::Attributes::Step, 10.f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ_CRC("RefreshAttributesAndValues", 0xcbc2147c))
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &EditorCameraComponent::m_autoActivate, "Auto-activate",
+                        "switch the view to this camera when the camera entity is activated")
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Debug")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, false)
@@ -353,6 +356,7 @@ namespace Camera
         properties.m_specifyFrustumDimensions = m_specifyDimensions;
         properties.m_frustumWidth = m_frustumWidth;
         properties.m_frustumHeight = m_frustumHeight;
+        properties.m_autoActivate = m_autoActivate;
         CameraComponent* cameraComponent = gameEntity->CreateComponent<CameraComponent>(properties);
     }
 

--- a/dev/Gems/Camera/Code/Source/EditorCameraComponent.h
+++ b/dev/Gems/Camera/Code/Source/EditorCameraComponent.h
@@ -130,5 +130,6 @@ namespace Camera
         bool m_viewButton = false;
         float m_frustumViewPercentLength = 1.f;
         AZ::Color m_frustumDrawColor = AzFramework::ViewportColors::HoverColor;
+        bool m_autoActivate = true;
     };
 } // Camera


### PR DESCRIPTION
### Description

Added an "Auto-activate" property to the CameraComponent. This allowed us to have multiple camera components enabled and being manipulated in the level without them automatically displaying to the viewport.