### PR TITLE
104) Add parameter to optionally load a canvas if it was not found.

### DIFF
--- a/dev/Code/CryEngine/CryCommon/LyShine/Bus/UiCanvasManagerBus.h
+++ b/dev/Code/CryEngine/CryCommon/LyShine/Bus/UiCanvasManagerBus.h
@@ -31,8 +31,8 @@ public:
     //! Unload a canvas
     virtual void UnloadCanvas(AZ::EntityId canvasEntityId) = 0;
 
-    //! Find a loaded canvas by pathname
-    virtual AZ::EntityId FindLoadedCanvasByPathName(const AZStd::string& canvasPathname) = 0;
+    //! Find a canvas by path, optionally load the canvas if it was not found
+    virtual AZ::EntityId FindLoadedCanvasByPathName(const AZStd::string& canvasPathname, bool loadIfNotFound = false) = 0;
 
     //! Get a list of canvases that are loaded in game, this is sorted by draw order
     virtual CanvasEntityList GetLoadedCanvases() = 0;

--- a/dev/Gems/LyShine/Code/Source/Script/UiCanvasLuaBus.cpp
+++ b/dev/Gems/LyShine/Code/Source/Script/UiCanvasLuaBus.cpp
@@ -114,12 +114,36 @@ void UiCanvasLuaProxy::BusConnect(AZ::EntityId entityId)
     }
 }
 
+void UiCanvasLuaProxy::BusDisconnect()
+{
+    CryWarning(VALIDATOR_MODULE_SYSTEM, VALIDATOR_WARNING,
+        "UiCanvasLuaProxy:BusDisconnect is deprecated. Please use the UiCanvasBus instead of the UiCanvasLuaBus and UiCanvasLuaProxy\n");
+
+    if (UiCanvasLuaBus::Handler::BusIsConnected())
+    {
+        UiCanvasLuaBus::Handler::BusDisconnect();
+    }
+}
+
 AZ::EntityId UiCanvasLuaProxy::LoadCanvas(const char* canvasFilename)
 {
     CryWarning(VALIDATOR_MODULE_SYSTEM, VALIDATOR_WARNING,
         "UiCanvasLuaProxy:LoadCanvas is deprecated. Please use UiCanvasManagerBus:LoadCanvas instead\n");
 
     return gEnv->pLyShine->LoadCanvas(canvasFilename);
+}
+
+AZ::EntityId UiCanvasLuaProxy::FindCanvasByPathname(const char* canvasFilename, bool loadIfNotFound/* = false*/)
+{
+    CryWarning(VALIDATOR_MODULE_SYSTEM, VALIDATOR_WARNING,
+        "UiCanvasLuaProxy:FindCanvasByPathname is deprecated. Please use UiCanvasManagerBus:FindCanvasByPathname instead\n");
+
+    AZ::EntityId canvasId = gEnv->pLyShine->FindLoadedCanvasByPathName(canvasFilename);
+    if (!canvasId.IsValid() && loadIfNotFound)
+    {
+        canvasId = LoadCanvas(canvasFilename);
+    }
+    return canvasId;
 }
 
 void UiCanvasLuaProxy::UnloadCanvas(AZ::EntityId canvasEntityId)
@@ -164,8 +188,10 @@ void UiCanvasLuaProxy::Reflect(AZ::ReflectContext* context)
             ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
             ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
             ->Method("LoadCanvas", &UiCanvasLuaProxy::LoadCanvas)
+            ->Method("FindCanvasByPathname", &UiCanvasLuaProxy::FindCanvasByPathname)
             ->Method("UnloadCanvas", &UiCanvasLuaProxy::UnloadCanvas)
             ->Method("BusConnect", &UiCanvasLuaProxy::BusConnect)
+            ->Method("BusDisconnect", &UiCanvasLuaProxy::BusDisconnect)
         ;
     }
 }

--- a/dev/Gems/LyShine/Code/Source/Script/UiCanvasLuaBus.h
+++ b/dev/Gems/LyShine/Code/Source/Script/UiCanvasLuaBus.h
@@ -62,8 +62,14 @@ public:
     //! \brief Adds this object as a handler for UiCanvasLuaBus
     void BusConnect(AZ::EntityId entityId);
 
+    //! \brief Clean up
+    void BusDisconnect();
+
     //! \brief Loads the canvas with the given filename
     AZ::EntityId LoadCanvas(const char* canvasFilename);
+
+    //! Find a canvas by path, optionally load the canvas if it was not found
+    AZ::EntityId FindCanvasByPathname(const char* canvasFilename, bool loadIfNotFound = false);
 
     //! \brief Unloads the canvas with the given canvas entity Id
     void UnloadCanvas(AZ::EntityId canvasEntityId);

--- a/dev/Gems/LyShine/Code/Source/UiCanvasManager.cpp
+++ b/dev/Gems/LyShine/Code/Source/UiCanvasManager.cpp
@@ -173,11 +173,16 @@ void UiCanvasManager::UnloadCanvas(AZ::EntityId canvasEntityId)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-AZ::EntityId UiCanvasManager::FindLoadedCanvasByPathName(const AZStd::string& assetIdPathname)
+AZ::EntityId UiCanvasManager::FindLoadedCanvasByPathName(const AZStd::string& assetIdPathname, bool loadIfNotFound/*= false*/)
 {
     // this is only used for finding canvases loaded in game
     UiCanvasComponent* canvasComponent = FindCanvasComponentByPathname(assetIdPathname.c_str());
-    return canvasComponent ? canvasComponent->GetEntityId() : AZ::EntityId();
+    AZ::EntityId canvasId = canvasComponent ? canvasComponent->GetEntityId() : AZ::EntityId();
+    if (!canvasId.IsValid() && loadIfNotFound)
+    {
+        canvasId = LoadCanvas(assetIdPathname);
+    }
+    return canvasId;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/LyShine/Code/Source/UiCanvasManager.h
+++ b/dev/Gems/LyShine/Code/Source/UiCanvasManager.h
@@ -57,7 +57,7 @@ public: // member functions
     AZ::EntityId CreateCanvas() override;
     AZ::EntityId LoadCanvas(const AZStd::string& canvasPathname) override;
     void UnloadCanvas(AZ::EntityId canvasEntityId) override;
-    AZ::EntityId FindLoadedCanvasByPathName(const AZStd::string& canvasPathname) override;
+    AZ::EntityId FindLoadedCanvasByPathName(const AZStd::string& canvasPathname, bool loadIfNotFound = false) override;
     CanvasEntityList GetLoadedCanvases() override;
     // ~UiCanvasManagerBus
 


### PR DESCRIPTION
### Description 

Added `UiCanvasLuaProxy::BusDisconnect`. This is a deprecated system but as we were still using it, it was useful to have both `BusConnect` and `BusDisconnect` available to Lua.

Added a default parameter `loadIfNotFound = false` to `FindCanvasByPathname`. Our use case for this was to lazily load reticle canvases. This change was initially made to `UiCanvasLuaProxy` but has also been added to the newer `UiCanvasManager`.