### PR TITLE
106) Fix blend state copy and paste error.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DXGL/Interfaces/CCryDXGLDeviceContext.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DXGL/Interfaces/CCryDXGLDeviceContext.cpp
@@ -1281,7 +1281,7 @@ void CCryDXGLDeviceContext::OMGetBlendState(ID3D11BlendState** ppBlendState, FLO
     BlendFactor[0] = m_auBlendFactor[0];
     BlendFactor[1] = m_auBlendFactor[1];
     BlendFactor[2] = m_auBlendFactor[2];
-    BlendFactor[2] = m_auBlendFactor[3];
+    BlendFactor[3] = m_auBlendFactor[3];
     *pSampleMask = m_uSampleMask;
 }
 


### PR DESCRIPTION
### Description

Trivial fix in `CCryDXGLDeviceContext::OMGetBlendState` to fix `BlendFactor[2]` being assigned to incorrectly.