### PR TITLE
110) Fix for rain and snow gems.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Renderer.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Renderer.cpp
@@ -7516,7 +7516,8 @@ void S3DEngineCommon::UpdateRainOccInfo(int nThreadID)
         m_RainOccluders.Release();
     }
 
-    const Vec3 vCamPos = gRenDev->GetViewParameters().vOrigin;
+    // Get the rendering camera position from the renderer
+    const Vec3 vCamPos = gEnv->p3DEngine->GetRenderingCamera().GetPosition();
     bool bDisableOcclusion = m_RainInfo.bDisableOcclusion;
     static bool bOldDisableOcclusion = true;    // set to true to allow update at first run
 

--- a/dev/Gems/Rain/Code/Source/Rain.cpp
+++ b/dev/Gems/Rain/Code/Source/Rain.cpp
@@ -124,8 +124,12 @@ namespace LYGame
     //------------------------------------------------------------------------
     void CRain::Update(SEntityUpdateContext& ctx, int updateSlot)
     {
-        const IActor* pClient = gEnv->pGame->GetIGameFramework()->GetClientActor();
-        if (pClient && Reset())
+        if (GetISystem()->GetIGame()->GetIGameFramework()->IsEditing())
+        {
+            return;
+        }
+
+        if (Reset())
         {
             const Vec3 vCamPos = gEnv->pRenderer->GetCamera().GetPosition();
             const Vec3 worldPos = GetEntity()->GetWorldPos();

--- a/dev/Gems/Snow/Code/Source/Snow.cpp
+++ b/dev/Gems/Snow/Code/Source/Snow.cpp
@@ -74,8 +74,12 @@ void CSnow::FullSerialize(TSerialize ser)
 //------------------------------------------------------------------------
 void CSnow::Update(SEntityUpdateContext& ctx, int updateSlot)
 {
-    const IActor* pClient = GetISystem()->GetIGame()->GetIGameFramework()->GetClientActor();
-    if (pClient && Reset())
+    if (GetISystem()->GetIGame()->GetIGameFramework()->IsEditing())
+    {
+        return;
+    }
+
+    if (Reset())
     {
         if (!m_bEnabled || gEnv->IsEditor() && !gEnv->IsEditorSimulationMode() && !gEnv->IsEditorGameMode())
         {


### PR DESCRIPTION
### Description 

Bug fixes for the snow and rain gems. These are both old systems but are currently the most straightforward way to get rain or snow into a level.

- Both gems were dependent on having an Actor present, but actors are deprecated and we don't use one, so the effects were never triggering.
- The renderer was using the incorrect function to retrieve the camera position for calculating occlusion.