### PR TITLE
111) Fix unimplemented function.

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/IPC/SharedMemory.h
+++ b/dev/Code/Framework/AzCore/AzCore/IPC/SharedMemory.h
@@ -82,7 +82,7 @@ namespace AZ
 
         /// Maps to the created map. If size == 0 it will map the whole memory.
         bool Map(AccessMode mode = ReadWrite, unsigned int size = 0);
-        bool IsMapped() const;
+        bool IsMapped() const { return m_mappedBase != NULL; }
         bool UnMap();
 
         /// Naming is conforming with AZStd::lock_guard/unique_lock/etc.


### PR DESCRIPTION
### Description

Trivial change to implement `SharedMemeory::IsMapped`.