### PR TITLE
113) Adding ICameraZoomBehavior interface

### DIFF
--- a/dev/Gems/CameraFramework/Code/CameraFramework.waf_files
+++ b/dev/Gems/CameraFramework/Code/CameraFramework.waf_files
@@ -4,7 +4,8 @@
             "Include/CameraFramework/ICameraSubComponent.h",
             "Include/CameraFramework/ICameraLookAtBehavior.h",
             "Include/CameraFramework/ICameraTargetAcquirer.h",
-            "Include/CameraFramework/ICameraTransformBehavior.h"
+            "Include/CameraFramework/ICameraTransformBehavior.h",
+            "Include/CameraFramework/ICameraZoomBehavior.h"
         ],
         "Source": [
             "Source/CameraFrameworkGem.cpp",

--- a/dev/Gems/CameraFramework/Code/Include/CameraFramework/ICameraTargetAcquirer.h
+++ b/dev/Gems/CameraFramework/Code/Include/CameraFramework/ICameraTargetAcquirer.h
@@ -29,6 +29,6 @@ namespace Camera
         AZ_RTTI(ICameraTargetAcquirer, "{350C8DA8-732B-42F6-8EBD-70F8D5497436}", ICameraSubComponent);
         virtual ~ICameraTargetAcquirer() = default;
         /// Assign the transform of the desired target to outTransformInformation
-        virtual bool AcquireTarget(AZ::Transform& outTransformInformation) = 0;
+        virtual AZ::EntityId AcquireTarget(AZ::Transform& outTransformInformation) = 0;
     };
 } //namespace Camera

--- a/dev/Gems/CameraFramework/Code/Include/CameraFramework/ICameraZoomBehavior.h
+++ b/dev/Gems/CameraFramework/Code/Include/CameraFramework/ICameraZoomBehavior.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "CameraFramework/ICameraSubComponent.h"
+
+namespace Camera
+{
+    //////////////////////////////////////////////////////////////////////////
+    // This class is responsible for modifying the fov of a camera
+    //////////////////////////////////////////////////////////////////////////
+    class ICameraZoomBehavior
+        : public ICameraSubComponent
+    {
+    public:
+        AZ_RTTI(ICameraZoomBehavior, "{D7CED09E-B6B0-42CE-995F-B4FD235C2EC3}", ICameraSubComponent);
+        virtual ~ICameraZoomBehavior() = default;
+        
+        // Modify the zoom (passes in the current zoom, this value should be modified by the behaviour)
+		virtual void ModifyZoom( const AZ::EntityId& targetEntityId, float& inOutZoom ) = 0;
+    };
+} //namespace Camera 

--- a/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.h
+++ b/dev/Gems/CameraFramework/Code/Source/CameraRigComponent.h
@@ -19,6 +19,7 @@ namespace Camera
     class ICameraLookAtBehavior;
     class ICameraTargetAcquirer;
     class ICameraTransformBehavior;
+    class ICameraZoomBehavior;
 
     //////////////////////////////////////////////////////////////////////////
     /// The CameraRigComponent holds a recipe of behaviors.
@@ -55,6 +56,8 @@ namespace Camera
         AZStd::vector<ICameraTargetAcquirer*> m_targetAcquirers;
         AZStd::vector<ICameraLookAtBehavior*> m_lookAtBehaviors;
         AZStd::vector<ICameraTransformBehavior*> m_transformBehaviors;
+        AZStd::vector<ICameraZoomBehavior*> m_zoomBehaviors;
+        float m_initialFov;
         AZ::Transform m_initialTransform;
     };
 } // Camera

--- a/dev/Gems/StartingPointCamera/Code/Include/StartingPointCamera/StartingPointCameraZoomBehaviorBus.h
+++ b/dev/Gems/StartingPointCamera/Code/Include/StartingPointCamera/StartingPointCameraZoomBehaviorBus.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/EBus/EBus.h>
+
+namespace Camera
+{
+    class CameraZoomBehaviorRequest
+        : public AZ::ComponentBus 
+    {
+    public: 
+        virtual ~CameraZoomBehaviorRequest() = default;
+
+        virtual void SetZoomTarget(float zoomTarget) = 0;
+        virtual void SetTimeToZoom(float timeToZoom) = 0;
+        virtual void StartZoom() = 0;
+        virtual void StopZoom() = 0;
+    };
+    using CameraZoomBehaviorBus = AZ::EBus<CameraZoomBehaviorRequest>;
+} //namespace Camera

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByEntityId.cpp
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByEntityId.cpp
@@ -47,7 +47,7 @@ namespace Camera
         }
     }
 
-    bool AcquireByEntityId::AcquireTarget(AZ::Transform& outTransformInformation)
+    AZ::EntityId AcquireByEntityId::AcquireTarget(AZ::Transform& outTransformInformation)
     {
         if (m_target.IsValid())
         {
@@ -61,8 +61,8 @@ namespace Camera
             {
                 outTransformInformation.SetColumns(targetsTransform.GetColumn(0), targetsTransform.GetColumn(1), targetsTransform.GetColumn(2), outTransformInformation.GetColumn(3));
             }
-            return true;
+            return m_target;
         }
-        return false;
+        return AZ::EntityId();
     }
 } // namespace Camera

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByEntityId.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByEntityId.h
@@ -36,7 +36,7 @@ namespace Camera
 
         //////////////////////////////////////////////////////////////////////////
         // ICameraTargetAcquirer
-        bool AcquireTarget(AZ::Transform& outTransformInformation) override;
+        AZ::EntityId AcquireTarget(AZ::Transform& outTransformInformation) override;
         void Activate(AZ::EntityId) override {}
         void Deactivate() override {}
 

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByTag.cpp
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByTag.cpp
@@ -52,7 +52,7 @@ namespace Camera
         }
     }
 
-    bool AcquireByTag::AcquireTarget(AZ::Transform& outTransformInformation)
+    AZ::EntityId AcquireByTag::AcquireTarget(AZ::Transform& outTransformInformation)
     {
         if (m_targets.size())
         {
@@ -66,9 +66,9 @@ namespace Camera
             {
                 outTransformInformation.SetColumns(targetsTransform.GetColumn(0), targetsTransform.GetColumn(1), targetsTransform.GetColumn(2), outTransformInformation.GetColumn(3));
             }
-            return true;
+            return m_targets[0];
         }
-        return false;
+        return AZ::EntityId();
     }
 
     void AcquireByTag::Activate(AZ::EntityId)

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByTag.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraTargetAcquirers/AcquireByTag.h
@@ -37,7 +37,7 @@ namespace Camera
 
         //////////////////////////////////////////////////////////////////////////
         // ICameraTargetAcquirer
-        bool AcquireTarget(AZ::Transform& outTransformInformation) override;
+        AZ::EntityId AcquireTarget(AZ::Transform& outTransformInformation) override;
         void Activate(AZ::EntityId) override;
         void Deactivate() override;
         

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraZoomBehaviors/DefaultZoomBehavior.cpp
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraZoomBehaviors/DefaultZoomBehavior.cpp
@@ -1,0 +1,106 @@
+#include "StartingPointCamera_precompiled.h"
+#include "DefaultZoomBehavior.h"
+#include <AzCore/Debug/Profiler.h>
+#include <AzCore/Math/MathUtils.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace Camera
+{
+    float const DefaultZoomBehavior::k_defaultTimeToZoom = 1.0f;
+    float const DefaultZoomBehavior::k_defaultZoom = 1.0f;
+		
+	void DefaultZoomBehavior::Reflect( AZ::ReflectContext* reflection )
+	{
+		AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>( reflection );
+		if( serializeContext )
+		{
+			serializeContext->Class< DefaultZoomBehavior >()
+				->Version( 1 )
+                ->Field("ZoomOnActivate", &DefaultZoomBehavior::m_zoomOnActivate)
+                ->Field("TimeToZoom", &DefaultZoomBehavior::m_timeToZoom)
+                ->Field("ZoomTarget", &DefaultZoomBehavior::m_zoomTarget)
+                ;
+
+			AZ::EditContext* editContext = serializeContext->GetEditContext();
+			if( editContext )
+			{
+				editContext->Class<DefaultZoomBehavior>( "Default zoom", "Handles augmenting zoom based on overrides set on components" )
+					->ClassElement( AZ::Edit::ClassElements::EditorData, "" )
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DefaultZoomBehavior::m_zoomOnActivate,
+                        "Zoom on Activate", "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DefaultZoomBehavior::m_timeToZoom, 
+                        "Time to Zoom", "")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &DefaultZoomBehavior::m_zoomTarget,
+                        "Zoom Target", "")
+                    ;
+			}
+		}
+	}
+
+	void DefaultZoomBehavior::Activate( AZ::EntityId entityId )
+	{
+        CameraZoomBehaviorBus::Handler::BusConnect(entityId);
+        if (m_zoomOnActivate)
+        {
+		    AZ::TickBus::Handler::BusConnect();
+        }
+	}
+
+	void DefaultZoomBehavior::Deactivate()
+	{
+        CameraZoomBehaviorBus::Handler::BusDisconnect();
+		AZ::TickBus::Handler::BusDisconnect();
+	}
+
+	void DefaultZoomBehavior::ModifyZoom( const AZ::EntityId& targetEntityId, float& inOutZoom )
+	{
+		inOutZoom *= m_zoom;
+	}
+
+	void DefaultZoomBehavior::OnTick( float deltaTime, AZ::ScriptTimePoint /*time*/ )
+	{
+		AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::Game);
+
+		if( !AZ::IsClose( m_zoom, m_zoomTarget, FLT_EPSILON ) )
+		{
+			m_zoomVelocity = ( m_zoomTarget - m_zoom ) / m_timeToZoom;
+
+			// Assuming that this is just a normal update that won't reach the target, what is the new value?
+			float newZoom	= m_zoom + ( deltaTime * m_zoomVelocity );
+
+			// Have we reached the target?
+			if( ( m_zoomVelocity > 0.0f && newZoom >= m_zoomTarget ) ||
+				( m_zoomVelocity < 0.0f && newZoom <= m_zoomTarget ) )
+			{
+				m_zoom = m_zoomTarget;
+                AZ::TickBus::Handler::BusDisconnect();
+			}
+			else
+			{
+				m_zoom = newZoom;
+			}
+		}
+	}
+
+    void DefaultZoomBehavior::SetZoomTarget(float zoomTarget)
+    {
+        m_zoomTarget = zoomTarget;
+    }
+
+    void DefaultZoomBehavior::SetTimeToZoom(float timeToZoom)
+    {
+        m_timeToZoom = timeToZoom;
+    }
+
+    void DefaultZoomBehavior::StartZoom()
+    {
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+    void DefaultZoomBehavior::StopZoom()
+    {
+        AZ::TickBus::Handler::BusDisconnect();
+    }
+}

--- a/dev/Gems/StartingPointCamera/Code/Source/CameraZoomBehaviors/DefaultZoomBehavior.h
+++ b/dev/Gems/StartingPointCamera/Code/Source/CameraZoomBehaviors/DefaultZoomBehavior.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <CameraFramework/ICameraZoomBehavior.h>
+#include <StartingPointCamera/StartingPointCameraZoomBehaviorBus.h>
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/Component/TickBus.h>
+
+namespace AZ
+{
+	class ReflectContext;
+}
+
+namespace Camera
+{
+	class DefaultZoomBehavior
+		: public Camera::ICameraZoomBehavior
+		, private AZ::TickBus::Handler
+        , private Camera::CameraZoomBehaviorBus::Handler
+	{
+	public:
+        ~DefaultZoomBehavior() override = default;
+		AZ_RTTI( DefaultZoomBehavior, "{EFDA60A6-16B3-4199-BE31-1C7F105BFF25}", Camera::ICameraZoomBehavior );
+        AZ_CLASS_ALLOCATOR(DefaultZoomBehavior, AZ::SystemAllocator, 0);
+		static void Reflect( AZ::ReflectContext* reflection );
+
+        //////////////////////////////////////////////////////////////////////////
+        // ICameraZoomBehavior
+		void ModifyZoom( const AZ::EntityId& targetEntityId, float& inOutZoom ) override;
+		void Activate( AZ::EntityId ) override;
+		void Deactivate() override;
+
+	private:
+
+        //////////////////////////////////////////////////////////////////////////
+        // AZ::TickBus::Handler
+		void OnTick( float deltaTime, AZ::ScriptTimePoint time ) override;
+
+        //////////////////////////////////////////////////////////////////////////
+        // Camera::CameraZoomBehaviorBus::Handler
+        void SetZoomTarget(float zoomTarget) override;
+        void SetTimeToZoom(float timeToZoom) override;
+        void StartZoom() override;
+        void StopZoom() override;
+
+        static float const k_defaultTimeToZoom;
+        static float const k_defaultZoom;
+
+        bool m_zoomOnActivate   = false;
+        float m_timeToZoom      = k_defaultTimeToZoom;
+		float m_zoom			= k_defaultZoom;			// Current zoom modifier to apply to the camera
+		float m_zoomTarget		= k_defaultZoom;			// The zoom modifier that is being interpolated to
+		float m_zoomVelocity	= 0.0f;						// The velocity for modifying the zoom 
+                                                            // note that we use velocity and not a current time calc, 
+                                                            // as then if the zoom in is interrupted then the zoom out time is correctly shorter.
+	};
+}

--- a/dev/Gems/StartingPointCamera/Code/Source/StartingPointCameraGem.cpp
+++ b/dev/Gems/StartingPointCamera/Code/Source/StartingPointCameraGem.cpp
@@ -23,8 +23,10 @@
 #include "CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h"
 #include "CameraLookAtBehaviors/RotateCameraLookAt.h"
 #include "CameraTransformBehaviors/FaceTarget.h"
+#include "CameraZoomBehaviors/DefaultZoomBehavior.h"
 
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Module/Module.h>
 
 #include <AzFramework/Metrics/MetricsPlainTextNameRegistration.h>
@@ -48,11 +50,22 @@ namespace StartingPointCamera
             Camera::SlideAlongAxisBasedOnAngle::Reflect(reflection);
             Camera::RotateCameraLookAt::Reflect(reflection);
             Camera::FaceTarget::Reflect(reflection);
+            Camera::DefaultZoomBehavior::Reflect(reflection);
 
             if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflection))
             {
                 serializeContext->Class<StartingPointCameraGemComponent, AZ::Component>()
                     ->Version(0)
+                    ;
+            }
+
+            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(reflection))
+            {
+                behaviorContext->EBus<Camera::CameraZoomBehaviorBus>("CameraZoomBehaviorBus")
+                    ->Event("SetZoomTarget", &Camera::CameraZoomBehaviorBus::Events::SetZoomTarget)
+                    ->Event("SetTimeToZoom", &Camera::CameraZoomBehaviorBus::Events::SetTimeToZoom)
+                    ->Event("StartZoom", &Camera::CameraZoomBehaviorBus::Events::StartZoom)
+                    ->Event("StopZoom", &Camera::CameraZoomBehaviorBus::Events::StopZoom)
                     ;
             }
         }

--- a/dev/Gems/StartingPointCamera/Code/startingpointcamera.waf_files
+++ b/dev/Gems/StartingPointCamera/Code/startingpointcamera.waf_files
@@ -4,7 +4,8 @@
         "Include": 
         [
             "Include/StartingPointCamera/StartingPointCameraConstants.h",
-            "Include/StartingPointCamera/StartingPointCameraUtilities.h"
+            "Include/StartingPointCamera/StartingPointCameraUtilities.h",
+            "Include/StartingPointCamera/StartingPointCameraZoomBehaviorBus.h"
         ],
         "Source": 
         [
@@ -38,6 +39,11 @@
             "Source/CameraTransformBehaviors/OffsetCameraPosition.cpp",
             "Source/CameraTransformBehaviors/Rotate.h",
             "Source/CameraTransformBehaviors/Rotate.cpp"
+        ],
+        "Source/ZoomBehaviors": 
+        [
+            "Source/CameraZoomBehaviors/DefaultZoomBehavior.h",
+            "Source/CameraZoomBehaviors/DefaultZoomBehavior.cpp"
         ]
     },
     "none":


### PR DESCRIPTION
### Description

- Augmented the camera rig framework to add a final step which modifies the camera zoom.
- Changed the ICameraTargetAcquirer interface to return the target entity id.

This addition is intended as an example which users can study as a starting point to build their own custom zoom behaviors. For example, DRG used shoulder zooms, a weapon scopes, etc. Multiple behaviors can be combined as would be required for a dynamic third-person camera rig. 

Provided, is a basic DefaultZoomBehavior which can be set to start on activating, and will change the FoV to zoom to the "Zoom Target" over "Time to Zoom" duration. Examples of usage might be for zooming out on activating a player camera, zooming in when changing to a security camera, and so on.