### PR TITLE
114) Fix for potential bad raycast

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/rwi.cpp
+++ b/dev/Code/CryEngine/CryPhysics/rwi.cpp
@@ -644,7 +644,7 @@ int CPhysicalWorld::RayWorldIntersection(const IPhysicalWorld::SRWIParams& rp, c
         objtypes |= ent_areas;
     }
 
-    IF (objtypes & ~(ent_terrain | ent_water), 1)
+    IF ((objtypes & ~(ent_terrain | ent_water)) && m_gthunks, 1)
     {
         MarkSkipEnts(rp.pSkipEnts, rp.nSkipEnts, 1 << iCaller);
 


### PR DESCRIPTION
### Description

Fix for a crash seen once in `CPhysicalWorld::RayWorldIntersection`. 

Don't do the part of the raycast which relies on the entity grid if the entity grid is in an invalid state. We caught `m_gthunks` as `nullptr` which caused a crash as it is needed for all calls to `egc.check_cell` including the call to `DrawRayOnGrid`. 

Unfortunately, we did not get the root cause of this, but this should stop any invalid access issues in the future.