### PR TITLE
117) Lua EBus handler calling thread check

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Script/ScriptContext.h
+++ b/dev/Code/Framework/AzCore/AzCore/Script/ScriptContext.h
@@ -28,6 +28,7 @@
 #include <AzCore/std/containers/list.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/allocator_static.h>
+#include <AzCore/std/parallel/thread.h>
 
 #ifndef AZ_USE_CUSTOM_SCRIPT_BIND
 struct lua_State;
@@ -865,6 +866,19 @@ namespace AZ
         void EnableDebug();   ///< Creates debug context (you can obtain vie GetDebugContext()). Depending on the implementation this can require more memory.
         void DisableDebug();  ///< Destroys debug context
         ScriptContextDebug* GetDebugContext();
+
+        /**
+         * Make sure that the Lua EBus handlers are not called from background threads.
+         * By default the thread that creates the script context is the owner.
+         * This method allows to override this default behaviour.                                                                      
+        */        
+        void DebugSetOwnerThread(AZStd::thread::id ownerThreadId); 
+        
+        /**
+         * Make sure that the Lua EBus handlers are not called from background threads.
+         * Use this to make sure the calling thread is the thread that owns the script context.
+        */        
+        bool DebugIsCallingThreadTheOwner() const;                 
 
         void SetErrorHook(ErrorHook cb);
         ErrorHook GetErrorHook() const;


### PR DESCRIPTION
### Description

Add Lua EBus handler calling thread check - verify that the EBus Lua handler is called from the thread that owns the given script context. By default, the thread that creates a script context owns it. In DRG all contexts used are created by the main thread, this change is to help protect against the Lua EBus handlers getting called from background threads. 

NOTE: This will not catch all the threading related Lua bugs; the game may crash before getting to call the generic event hook because the EBus internals are not thread-safe if no mutex was used.