### PR TITLE
Fix copy-paste bugs with static analyzer.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DXGL/Interfaces/CCryDXGLDeviceContext.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DXGL/Interfaces/CCryDXGLDeviceContext.cpp
@@ -917,14 +917,14 @@ void CCryDXGLDeviceContext::OMSetBlendState(ID3D11BlendState* pBlendState, const
         m_auBlendFactor[0] = 1.0f;
         m_auBlendFactor[1] = 1.0f;
         m_auBlendFactor[2] = 1.0f;
-        m_auBlendFactor[2] = 1.0f;
+        m_auBlendFactor[3] = 1.0f;
     }
     else
     {
         m_auBlendFactor[0] = BlendFactor[0];
         m_auBlendFactor[1] = BlendFactor[1];
         m_auBlendFactor[2] = BlendFactor[2];
-        m_auBlendFactor[2] = BlendFactor[3];
+        m_auBlendFactor[3] = BlendFactor[3];
     }
 
     m_pContext->SetBlendColor(m_auBlendFactor[0], m_auBlendFactor[1], m_auBlendFactor[2], m_auBlendFactor[3]);
@@ -1281,7 +1281,7 @@ void CCryDXGLDeviceContext::OMGetBlendState(ID3D11BlendState** ppBlendState, FLO
     BlendFactor[0] = m_auBlendFactor[0];
     BlendFactor[1] = m_auBlendFactor[1];
     BlendFactor[2] = m_auBlendFactor[2];
-    BlendFactor[2] = m_auBlendFactor[3];
+    BlendFactor[3] = m_auBlendFactor[3];
     *pSampleMask = m_uSampleMask;
 }
 


### PR DESCRIPTION
We have found and fixed bugs using PVS-Studio Static Code Analyzer.

You can find all the warnings found in the article: [Amazon Lumberyard: A Scream of Anguish](https://www.viva64.com/en/b/0574/).