### PR TITLE
Fix for V622. Consider inspecting the 'switch' statement.

### DIFF
--- a/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
+++ b/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Datum.cpp
@@ -870,6 +870,7 @@ namespace
     {
         switch (type.GetType())
         {
+        case Data::eType::BehaviorContextObject:
             AZ_Error("ScriptCanvas", false, "BehaviorContextObject passed into IsDataGreater, which is invalid, an attempt must be made to call the behavior method");
             return false;
 


### PR DESCRIPTION
**Fix for V622. Consider inspecting the 'switch' statement. It's possible that the first 'case' operator is missing.** 

The analyzer has detected a potential error: the first operator in the 'switch' operator's block is not the 'case' operator. It causes the code fragment never to get control.
In this case, it will result in an AZ_Error being missed which would catch incorrect code flow further up the call stack.