### PR TITLE
V779. Unreachable code detected. It is possible that an error is present.

### DIFF
--- a/dev/Code/Sandbox/Plugins/EditorUI_QT/DockableLibraryTreeView.cpp
+++ b/dev/Code/Sandbox/Plugins/EditorUI_QT/DockableLibraryTreeView.cpp
@@ -133,6 +133,7 @@ bool DockableLibraryTreeView::Init(IDataBaseLibrary* lib)
     m_defaultView->setAcceptDrops(true);
     m_centralWidget->setAcceptDrops(true);
 
+    bool returnValue = false;
     if (m_treeView && m_titleBar && m_defaultView)
     {
         if (m_treeView->topLevelItemCount() > 0)
@@ -143,14 +144,16 @@ bool DockableLibraryTreeView::Init(IDataBaseLibrary* lib)
         {
             ShowDefaultView();
         }
-        return true;
+        returnValue = true;
     }
     else
     {
-        return false;
+        returnValue = false;
     }
 
     emit SignalFocused(this);
+
+    return returnValue;
 }
 
 void DockableLibraryTreeView::ShowDefaultView()

--- a/dev/Code/Tools/SceneAPI/FbxSceneBuilder/Importers/FbxSkinImporter.cpp
+++ b/dev/Code/Tools/SceneAPI/FbxSceneBuilder/Importers/FbxSkinImporter.cpp
@@ -57,16 +57,11 @@ namespace AZ
                 if (BuildSceneMeshFromFbxMesh(createdData, *context.m_sourceNode.GetMesh(), context.m_sourceSceneSystem))
                 {
                     context.m_createdData.push_back(std::move(createdData));
+                    context.m_createdData.push_back();
                     return Events::ProcessingResult::Success;
                 }
-                else
-                {
-                    return Events::ProcessingResult::Failure;
-                }
-
-                context.m_createdData.push_back();
-
-                return Events::ProcessingResult::Success;
+                
+                return Events::ProcessingResult::Failure;
             }
         } // namespace FbxSceneBuilder
     } // namespace SceneAPI


### PR DESCRIPTION
This pull request address error code V779 and addresses two separate issues.

**Issue Key: LY-84688
Issue ID: 203198**
Programmer intended context.m_createdData.push_back(); to be called but due to early returns from the function, it is not ever executed.

**Issue Key: LY-84689
Issue ID: 203199**
emit SignalFocused(this); was added in LY 1.9 and it appears as if the programmer wanted this signal to be executed on exiting the Init(...) function. However, due to the function returning before this point, the code will never get executed. By introducing a local boolean parameter it is possible to maintain the same flow of execution whilst also emitting the signal as per the intended design.