### PR TITLE
V611. The memory allocation and deallocation methods are incompatible.

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/vectorn.h
+++ b/dev/Code/CryEngine/CryPhysics/vectorn.h
@@ -99,7 +99,7 @@ public:
     {
         if (src.len != len && !(flags & mtx_foreign_data))
         {
-            delete data;
+            delete[] data;
             data = new ftype[src.len];
         }
         len = src.len;
@@ -114,7 +114,7 @@ public:
     {
         if (src.len != len && !(flags & mtx_foreign_data))
         {
-            delete data;
+            delete[] data;
             data = new ftype[src.len];
         }
         len = src.len;


### PR DESCRIPTION
**Issue Key: LY-84687 
Issue ID: 203197** 

The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Using delete on a pointer returned by new [] or delete [] on a pointer returned by new results in undefined behaviour.
