### PR TITLE
V549. The 'first' argument of 'Foo' function is equal to the 'second' argument.

### DIFF
--- a/dev/Code/Tools/CryCommonTools/Export/MeshUtils.h
+++ b/dev/Code/Tools/CryCommonTools/Export/MeshUtils.h
@@ -891,7 +891,7 @@ namespace MeshUtils
                     }
                     else
                     {
-                        res = memcmp(&m.m_links[a].links[0], &m.m_links[a].links[0], sizeof(m.m_links[a].links[0]) * m.m_links[a].links.size());
+                        res = memcmp(&m.m_links[a].links[0], &m.m_links[b].links[0], sizeof(m.m_links[a].links[0]) * m.m_links[a].links.size());
                     }
                 }
 


### PR DESCRIPTION
**Issue Key: LY-84686 
Issue ID: 203196** 

The 'first' argument of 'Foo' function is equal to the 'second' argument.

Due to what is probably a typo, the implementation of using `memcpy` to compare the size of these two vectors will always return true as the two first arguments are the same.
