### PR TITLE
V596. The object was created but it is not being used. The 'throw' keyword could be missing.

### DIFF
--- a/dev/Code/Sandbox/Editor/Objects/PrefabObject.cpp
+++ b/dev/Code/Sandbox/Editor/Objects/PrefabObject.cpp
@@ -1488,7 +1488,7 @@ namespace
         CPrefabManager* pPrefabManager = GetIEditor()->GetPrefabManager();
         if (!pPrefabManager)
         {
-            std::runtime_error("Invalid Prefab Manager.");
+            throw std::runtime_error("Invalid Prefab Manager.");
         }
 
         std::vector<std::string> results;
@@ -1512,7 +1512,7 @@ namespace
         CPrefabManager* pPrefabManager = GetIEditor()->GetPrefabManager();
         if (!pPrefabManager)
         {
-            std::runtime_error("Invalid Prefab Manager.");
+            throw std::runtime_error("Invalid Prefab Manager.");
         }
 
         IDataBaseLibrary* pPrefabLibrary = pPrefabManager->FindLibrary(pLibraryName);
@@ -1540,7 +1540,7 @@ namespace
         CPrefabManager* pPrefabManager = GetIEditor()->GetPrefabManager();
         if (!pPrefabManager)
         {
-            std::runtime_error("Invalid Prefab Manager.");
+            throw std::runtime_error("Invalid Prefab Manager.");
         }
 
         IDataBaseLibrary* pPrefabLibrary = pPrefabManager->FindLibrary(pLibraryName);
@@ -1600,7 +1600,7 @@ namespace
         CPrefabManager* pPrefabManager = GetIEditor()->GetPrefabManager();
         if (!pPrefabManager)
         {
-            std::runtime_error("Invalid Prefab Manager.");
+            throw std::runtime_error("Invalid Prefab Manager.");
         }
 
         IDataBaseLibrary* pPrefabLibrary = pPrefabManager->FindLibrary(pLibraryName);
@@ -1616,7 +1616,7 @@ namespace
         CPrefabManager* pPrefabManager = GetIEditor()->GetPrefabManager();
         if (!pPrefabManager)
         {
-            std::runtime_error("Invalid Prefab Manager.");
+            throw std::runtime_error("Invalid Prefab Manager.");
         }
 
         IDataBaseLibrary* pPrefabLibrary = pPrefabManager->FindLibrary(pLibraryName);
@@ -1641,7 +1641,7 @@ namespace
         CPrefabManager* pPrefabManager = GetIEditor()->GetPrefabManager();
         if (!pPrefabManager)
         {
-            std::runtime_error("Invalid Prefab Manager.");
+            throw std::runtime_error("Invalid Prefab Manager.");
         }
 
         IDataBaseLibrary* pPrefabLibrary = pPrefabManager->FindLibrary(pLibraryName);


### PR DESCRIPTION
Two separate issue fixed in one commit:

**Issue Key: LY-84685** 
**Issue ID: 203195**

**Issue Key: Y-84684** 
**Issue ID: 203194**

The analyzer has detected a strange use of the std::exception class or derived class. The analyzer generates this warning when an object of the std::exception / CException type is created but not being used. In this case, a std::runtime_error(...) is being created but not thrown. 
