### PR TITLE
V564. The '&' or '|' operator is applied to bool type value. You've probably forgotten to include parentheses or intended to use the '&&' or '||' operator.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DHWShader.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DHWShader.cpp
@@ -1828,8 +1828,8 @@ namespace
                 {
                     if (gcpRendD3D->FX_GetEnabledGmemPath(nullptr))
                     {
-                        uint32 stencilRef = CRenderer::CV_r_VisAreaClipLightsPerPixel ? 0 : (rRP.m_RIs[0][0]->nStencRef | BIT_STENCIL_INSIDE_CLIPVOLUME);
-                        stencilRef |= (!(rRP.m_pCurObject->m_ObjFlags & FOB_DYNAMIC_OBJECT) | CRenderer::CV_r_deferredDecalsOnDynamicObjects ? BIT_STENCIL_RESERVED : 0);
+                        uint32 stencilRef = CRenderer::CV_r_VisAreaClipLightsPerPixel ? 0 : (rRP.m_RIs[0][0]->nStencRef | BIT_STENCIL_INSIDE_CLIPVOLUME);                        
+                        stencilRef |= (!(rRP.m_pCurObject->m_ObjFlags & FOB_DYNAMIC_OBJECT) || (CRenderer::CV_r_deferredDecalsOnDynamicObjects ? BIT_STENCIL_RESERVED : 0));
                         result[0].f[0] = azlossy_caster(stencilRef);
                         result[0].f[1] = 0.0f;
                         result[0].f[2] = 0.0f;

--- a/dev/Code/Sandbox/Editor/TrackView/TrackViewDialog.cpp
+++ b/dev/Code/Sandbox/Editor/TrackView/TrackViewDialog.cpp
@@ -2109,7 +2109,7 @@ void CTrackViewDialog::UpdateTracksToolBar()
                 }
 
                 CTrackViewTrack* pTrack = pAnimNode->GetTrackForParameter(paramType);
-                if (pTrack && (!pAnimNode->GetParamFlags(paramType) & IAnimNode::eSupportedParamFlags_MultipleTracks))
+                if (pTrack && !(pAnimNode->GetParamFlags(paramType) & IAnimNode::eSupportedParamFlags_MultipleTracks))
                 {
                     continue;
                 }

--- a/dev/Code/Tools/HLSLCrossCompiler/src/toGLSLInstruction.c
+++ b/dev/Code/Tools/HLSLCrossCompiler/src/toGLSLInstruction.c
@@ -2911,7 +2911,7 @@ void SetDataTypes(HLSLCrossCompilerContext* psContext, Instruction* psInst, cons
             {
                 eNewType = GetOperandDataType(psContext, &psInst->asOperands[2]);
                 //Check assumption that both the values which MOVC might pick have the same basic data type.
-                if (!psContext->flags & HLSLCC_FLAG_AVOID_TEMP_REGISTER_ALIASING)
+                if (!(psContext->flags & HLSLCC_FLAG_AVOID_TEMP_REGISTER_ALIASING))
                 {
                     ASSERT(GetOperandDataType(psContext, &psInst->asOperands[2]) == GetOperandDataType(psContext, &psInst->asOperands[3]));
                 }

--- a/dev/Code/Tools/RC/ResourceCompilerImage/ImageCompiler.cpp
+++ b/dev/Code/Tools/RC/ResourceCompilerImage/ImageCompiler.cpp
@@ -1034,9 +1034,7 @@ bool CImageCompiler::AnalyzeWithProperties(bool autopreset, const char* szExtend
             fprintf(stderr, "Name\n");
         }
 
-        bool optimizable = autopreset;
-
-        optimizable = optimizable | (eA != ImageObject::eAlphaContent_Greyscale ? (walpha ? true : false) : false);
+        const bool optimizable = autopreset || (eA != ImageObject::eAlphaContent_Greyscale ? walpha : false);
 
         fprintf(stderr, "%d,", optimizable ? 1 : 0);
 


### PR DESCRIPTION
4 fixes in this pull request related to code V564, I'll comment on the changes individually.