### PR TITLE
V521. Such expressions using the ',' operator are dangerous. Make sure the expression is correct.

### DIFF
--- a/dev/Code/CryEngine/CryAISystem/TacticalPointSystem/TacticalPointSystem.cpp
+++ b/dev/Code/CryEngine/CryAISystem/TacticalPointSystem/TacticalPointSystem.cpp
@@ -3373,9 +3373,13 @@ bool CTacticalPointSystem::Parse(const char* sSpec, TTacticalPointQuery& _query,
     string sWords[MAXWORDS];
 
     int iC = 0, iWord = 0;
-    for (; iWord < MAXWORDS; !sWords[iWord].empty(), iWord++)
+    for (; iWord < MAXWORDS; iWord++)
     {
         sWords[iWord] = sInput.Tokenize("_", iC);
+        if (sWords[iWord].empty())
+        {
+            break;
+        }
     }
 
     TTacticalPointQuery token;


### PR DESCRIPTION
One change for this particular code _(so far)_. 
Moved the conditional into the main for loop body which is far easier to read and understand than previously. We can now clearly see that after tokenization the token is empty, we break out of the loop.