### PR TITLE
V546. Member of a class is initialized with itself: 'Foo(Foo)'.

### DIFF
--- a/dev/Code/CryEngine/CryCommon/ParticleParams.h
+++ b/dev/Code/CryEngine/CryCommon/ParticleParams.h
@@ -1834,7 +1834,7 @@ struct ParticleParams
         , fVolumeThickness(1.0f)
         , fSoundFXParam(1.f)
         , fSortConvergancePerFrame(1.f)
-        , eConfigMax(eConfigMax.VeryHigh)
+        , eConfigMax(EConfigSpecBrief::VeryHigh)
         // the default vec3 constructor sets values to nan if _DEBUG is defined.  This occurs after the ZeroInit base class initialization.  Reset these to zero.
         , vLocalInitAngles(ZERO)
         , vLocalRandomAngles(ZERO)


### PR DESCRIPTION
This looks like a simple intellisense autofill error, EConfigSpecBrief was meant but the programmer tabbed out to get eConfigMax.