### PR TITLE
V519. The 'x' variable is assigned values twice successively. Perhaps this is a mistake.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DXGL/Interfaces/CCryDXGLDeviceContext.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DXGL/Interfaces/CCryDXGLDeviceContext.cpp
@@ -917,14 +917,14 @@ void CCryDXGLDeviceContext::OMSetBlendState(ID3D11BlendState* pBlendState, const
         m_auBlendFactor[0] = 1.0f;
         m_auBlendFactor[1] = 1.0f;
         m_auBlendFactor[2] = 1.0f;
-        m_auBlendFactor[2] = 1.0f;
+        m_auBlendFactor[3] = 1.0f;
     }
     else
     {
         m_auBlendFactor[0] = BlendFactor[0];
         m_auBlendFactor[1] = BlendFactor[1];
         m_auBlendFactor[2] = BlendFactor[2];
-        m_auBlendFactor[2] = BlendFactor[3];
+        m_auBlendFactor[3] = BlendFactor[3];
     }
 
     m_pContext->SetBlendColor(m_auBlendFactor[0], m_auBlendFactor[1], m_auBlendFactor[2], m_auBlendFactor[3]);


### PR DESCRIPTION
m_auBlendFactor is not being set correctly due to an easy to miss typo which was then probably copied and pasted.