### PR TITLE
V709. Suspicious comparison found: 'a == b == c'. Remember that 'a == b == c' is not equal to 'a == b && b == c'.. 

### DIFF
--- a/dev/Code/Tools/HLSLCrossCompiler/src/toGLSLInstruction.c
+++ b/dev/Code/Tools/HLSLCrossCompiler/src/toGLSLInstruction.c
@@ -561,7 +561,7 @@ void CallBinaryOp(HLSLCrossCompilerContext* psContext, const char* name, Instruc
     bool qualcommWorkaround = (psContext->flags & HLSLCC_FLAG_QUALCOMM_GLES30_DRIVER_WORKAROUND) != 0;
     bool isBitwiseOperator = psInst->eOpcode == OPCODE_AND || psInst->eOpcode == OPCODE_OR || psInst->eOpcode == OPCODE_XOR;
     const char* swizzleString[] = { ".x", ".y", ".z", ".w" };
-    if (src1SwizCount == src0SwizCount == dstSwizCount)
+    if ((src1SwizCount == src0SwizCount) && (src0SwizCount == dstSwizCount))
     {
         BeginAssignment(psContext, &psInst->asOperands[dest], dataType, psInst->bSaturate);
         if (qualcommWorkaround && isBitwiseOperator && src0SwizCount > 1)
@@ -651,7 +651,7 @@ void CallTernaryOp(HLSLCrossCompilerContext* psContext, const char* op1, const c
 
     AddIndentation(psContext);
 
-    if (src1SwizCount == src0SwizCount == src2SwizCount == dstSwizCount)
+    if ((src1SwizCount == src0SwizCount) && (src0SwizCount == src2SwizCount) && (src2SwizCount == dstSwizCount))
     {
         BeginAssignment(psContext, &psInst->asOperands[dest], dataType, psInst->bSaturate);
         TranslateOperand(psContext, &psInst->asOperands[src0], TO_FLAG_NONE | dataType);

--- a/dev/Code/Tools/HLSLCrossCompilerMETAL/src/toGLSLInstruction.c
+++ b/dev/Code/Tools/HLSLCrossCompilerMETAL/src/toGLSLInstruction.c
@@ -466,7 +466,7 @@ static void CallBinaryOp(HLSLCrossCompilerContext* psContext, const char* name, 
 
 	AddIndentation(psContext);
 
-	if (src1SwizCount == src0SwizCount == dstSwizCount)
+	if ((src1SwizCount == src0SwizCount) && (src0SwizCount == dstSwizCount))
 	{
 		// Optimization for readability (and to make for loops in WebGL happy): detect cases where either src == dest and emit +=, -= etc. instead.
 		if (AreTempOperandsIdentical(&psInst->asOperands[dest], &psInst->asOperands[src0]) != 0)

--- a/dev/Code/Tools/HLSLCrossCompilerMETAL/src/toMETALInstruction.c
+++ b/dev/Code/Tools/HLSLCrossCompilerMETAL/src/toMETALInstruction.c
@@ -536,7 +536,7 @@ static void CallBinaryOp(HLSLCrossCompilerContext* psContext, const char* name, 
 
     AddIndentation(psContext);
 
-    if (src1SwizCount == src0SwizCount == dstSwizCount)
+    if ((src1SwizCount == src0SwizCount) && (src0SwizCount == dstSwizCount))
     {
         // Optimization for readability (and to make for loops in WebGL happy): detect cases where either src == dest and emit +=, -= etc. instead.
         if (AreTempOperandsIdentical(&psInst->asOperands[dest], &psInst->asOperands[src0]) != 0)


### PR DESCRIPTION
Fix for a few instances of incorrect usage of == operator. To be completely honest, I'm not 100% sure what the net end result of this error would be, other than it is clearly not the intended functionality.