### PR TITLE
There are identical sub-expressions 'm_listRect.contains(event->pos())' to the left and to the right of the '||' operator.

### DIFF
--- a/dev/Code/Sandbox/Editor/AI/AIDebuggerView.cpp
+++ b/dev/Code/Sandbox/Editor/AI/AIDebuggerView.cpp
@@ -460,7 +460,7 @@ void CAIDebuggerView::OnMButtonDown(QMouseEvent* event)
             update();
             grabMouse();
         }
-        else if (m_listRect.contains(event->pos()) || m_listRect.contains(event->pos()))
+        else if (m_listRect.contains(event->pos()) || m_detailsRect.contains(event->pos()))
         {
             m_dragStartVal = m_itemsOffset;
             m_dragStartPt = event->pos();


### PR DESCRIPTION
**Issue key: LY-84646
Issue id: 203136**

Copy/paste error or possibly autocorrect error. 

Mouse button down events were not being handled correctly in the details window for the ai debugger. This is actually an easy one to test; breakpoint the affected function and clicking around the ai debugger. Prior to this change, any mouse clicks in the details windows on the right side of the window are not registered, whereas in the list, timeline, and ruler views they are.

This is in a system which I believe will be deprecated/removed but it is worth fixing this whilst the tool is still available.