### PR TITLE
There are identical sub-expressions to the left and to the right of the '-' operator: q2.v.z - q2.v.z

### DIFF
--- a/dev/Gems/Maestro/Code/Source/Cinematics/EntityNode.cpp
+++ b/dev/Gems/Maestro/Code/Source/Cinematics/EntityNode.cpp
@@ -104,7 +104,7 @@ namespace
     {
         return (fabs_tpl(q1.v.x - q2.v.x) <= epsilon)
                && (fabs_tpl(q1.v.y - q2.v.y) <= epsilon)
-               && (fabs_tpl(q2.v.z - q2.v.z) <= epsilon)
+               && (fabs_tpl(q1.v.z - q2.v.z) <= epsilon)
                && (fabs_tpl(q1.w - q2.w) <= epsilon);
     }
 };


### PR DESCRIPTION
**Issue key: LY-84645
Issue id: 203135**

Typo here where q2.v.z was being compared with itself instead of with q1.v.z. This means that it was entirely possible that when comparing quaternion rotations, the wrong result will have been returned.