### PR TITLE
LY-84644 203134, V501. There are identical sub-expressions to the lef…

### DIFF
--- a/dev/Gems/LyShine/Code/Source/Animation/AzEntityNode.cpp
+++ b/dev/Gems/LyShine/Code/Source/Animation/AzEntityNode.cpp
@@ -99,7 +99,7 @@ namespace
     {
         return (fabs_tpl(q1.v.x - q2.v.x) <= epsilon)
                && (fabs_tpl(q1.v.y - q2.v.y) <= epsilon)
-               && (fabs_tpl(q2.v.z - q2.v.z) <= epsilon)
+               && (fabs_tpl(q1.v.z - q2.v.z) <= epsilon)
                && (fabs_tpl(q1.w - q2.w) <= epsilon);
     }
 


### PR DESCRIPTION
**Issue key: LY-84644 
Issue id: 203134**

This is exactly the same issue as seen in another pull request for entitynode: https://github.com/aws/lumberyard/pull/210

Clearly, the function was copied from entitynode.cpp and the bug is replicating through the codebase. As with the other pull request, when comparing two quaternions for an animation entitynode the function will not return the correct result.