### PR TITLE
There are identical sub-expressions 'geom_colltype_solid' to the left and to the right of the '|' operator.

### DIFF
--- a/dev/Code/CryEngine/CryAnimation/AttachmentManager.cpp
+++ b/dev/Code/CryEngine/CryAnimation/AttachmentManager.cpp
@@ -1055,7 +1055,7 @@ void CAttachmentManager::PhysicalizeAttachment(int idx, int nLod, IPhysicalEntit
     gp.flags = 0;
     if (pIAttachment->GetFlags() & FLAGS_ATTACH_PHYSICALIZED_COLLISIONS)
     {
-        gp.flags = geom_colltype_solid | geom_colltype_solid | geom_floats | geom_colltype_explosion;
+        gp.flags = geom_colltype_solid | geom_floats | geom_colltype_explosion;
     }
     if (pIAttachment->GetFlags() & FLAGS_ATTACH_PHYSICALIZED_RAYS)
     {


### PR DESCRIPTION
**Issue key: LY-84639 
Issue id: 203129**

Removing duplicated geom_colltype_solid.

The intention of the code highlighted by the analyzer is to add flags to an attachment so that it physically interacts with collisions. One of the flags added is a duplicate so it is worth asking whether this is actually just a duplicate and should be removed, or if the programmer intended to type something different and got the wrong autocorrect. We can examine the geom_flags enum and see what they may have intended. On examination, we can see that the only relevant flags are the ones already applied and that we should remove the duplicate.