### PR TITLE
There are identical sub-expressions '!pGroup->GetStatObj()' to the left and to the right of the '||' operator

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/terrain_node.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/terrain_node.cpp
@@ -591,7 +591,7 @@ bool CTerrainNode::CheckUpdateProcObjects(const SRenderingPassInfo& passInfo)
                     continue;
                 }
                 StatInstGroup* pGroup = &GetObjManager()->GetListStaticTypes()[DEFAULT_SID][nGroupId];
-                if (!pGroup || !pGroup->GetStatObj() || pGroup->fSize <= 0 || !pGroup->GetStatObj())
+                if (!pGroup || !pGroup->GetStatObj() || pGroup->fSize <= 0)
                 {
                     continue;
                 }


### PR DESCRIPTION
**Issue key: LY-84637 
Issue id: 203127**

Remove duplicated expression. 

It appears this error was the programmer simply not noticing the expression was already there. Having looked into this particular case it does not appear that there was another similar expression which would be appropriate here.