### PR TITLE
There are identical sub-expressions 'b->mlen <= 0' to the left and to the right of the '||' operator.

### DIFF
--- a/dev/Code/Tools/HLSLCrossCompiler/src/cbstring/bstrlib.c
+++ b/dev/Code/Tools/HLSLCrossCompiler/src/cbstring/bstrlib.c
@@ -1776,8 +1776,9 @@ int i, d;
 int breada (bstring b, bNread readPtr, void * parm) {
 int i, l, n;
 
-	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || readPtr == NULL) return BSTR_ERR;
+    if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen || readPtr == NULL) {
+        return BSTR_ERR;
+    }
 
 	i = b->slen;
 	for (n=i+16; ; n += ((n < BS_BUFF_SZ) ? n : BS_BUFF_SZ)) {
@@ -1824,8 +1825,10 @@ bstring buff;
 int bassigngets (bstring b, bNgetc getcPtr, void * parm, char terminator) {
 int c, d, e;
 
-	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || getcPtr == NULL) return BSTR_ERR;
+	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen || getcPtr == NULL) {
+        return BSTR_ERR;
+    }
+
 	d = 0;
 	e = b->mlen - 2;
 
@@ -1862,8 +1865,10 @@ int c, d, e;
 int bgetsa (bstring b, bNgetc getcPtr, void * parm, char terminator) {
 int c, d, e;
 
-	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || getcPtr == NULL) return BSTR_ERR;
+	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen || getcPtr == NULL) {
+        return BSTR_ERR;
+    }
+
 	d = b->slen;
 	e = b->mlen - 2;
 

--- a/dev/Code/Tools/HLSLCrossCompilerMETAL/src/cbstring/bstrlib.c
+++ b/dev/Code/Tools/HLSLCrossCompilerMETAL/src/cbstring/bstrlib.c
@@ -1776,8 +1776,9 @@ int i, d;
 int breada (bstring b, bNread readPtr, void * parm) {
 int i, l, n;
 
-	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || readPtr == NULL) return BSTR_ERR;
+    if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen || readPtr == NULL) {
+        return BSTR_ERR;
+    }
 
 	i = b->slen;
 	for (n=i+16; ; n += ((n < BS_BUFF_SZ) ? n : BS_BUFF_SZ)) {
@@ -1824,8 +1825,10 @@ bstring buff;
 int bassigngets (bstring b, bNgetc getcPtr, void * parm, char terminator) {
 int c, d, e;
 
-	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || getcPtr == NULL) return BSTR_ERR;
+	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen || getcPtr == NULL) {
+        return BSTR_ERR;
+    }
+
 	d = 0;
 	e = b->mlen - 2;
 
@@ -1862,8 +1865,10 @@ int c, d, e;
 int bgetsa (bstring b, bNgetc getcPtr, void * parm, char terminator) {
 int c, d, e;
 
-	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || getcPtr == NULL) return BSTR_ERR;
+	if (b == NULL || b->mlen <= 0 || b->slen < 0 || b->mlen < b->slen || getcPtr == NULL) {
+        return BSTR_ERR;
+    }
+
 	d = b->slen;
 	e = b->mlen - 2;
 


### PR DESCRIPTION
**LY-84634, 203124
LY-84633, 203123
LY-84632, 203122**

Fix for a number of duplicated expressions. `b->mlen <= 0` was repeatedly duplicated throughout this file. I also added curly braces to avoid any bugs being introduced as the result of a programmer modifying the if statements incorrectly.