### PR TITLE
CZBufferCuller: There are identical sub-expressions 'MaxX < 0' to the left and to the right of the '||' operator.

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/CZBufferCuller.h
+++ b/dev/Code/CryEngine/Cry3DEngine/CZBufferCuller.h
@@ -125,7 +125,7 @@ protected:
         }
         if (ROTATE == 2)
         {
-            if (MinX >= m_SizeX || MinY >= m_SizeY || MaxX < 0 ||  MaxX < 0)
+            if (MinX >= m_SizeX || MinY >= m_SizeY || MaxX < 0 ||  MaxY < 0)
             {
                 return true;
             }


### PR DESCRIPTION
**Issue key: LY-84628 
Issue id: 203108**

**Trivial error / code cleanup:**
Fix typo `MaxX` which should be `MaxY`. This file doesn't even seem to be used anymore and could possibly just be removed entirely.