### PR TITLE
There are identical sub-expressions '(TriMiddle - RMWPosition)' to the left and to the right of the '|' operator.

### DIFF
--- a/dev/Code/CryEngine/CryAnimation/ModelMesh.cpp
+++ b/dev/Code/CryEngine/CryAnimation/ModelMesh.cpp
@@ -171,7 +171,7 @@ ClosestTri CModelMesh::GetAttachmentTriangle(const Vec3& RMWPosition, const Join
         Vec3 v1 = *(Vec3*)(pPositions + pIndices[d + 1] * nPositionStride);
         Vec3 v2 = *(Vec3*)(pPositions + pIndices[d + 2] * nPositionStride);
         Vec3 TriMiddle = (v0 + v1 + v2) / 3.0f + m_vRenderMeshOffset;
-        f32 sqdist = (TriMiddle - RMWPosition) | (TriMiddle - RMWPosition);
+        f32 sqdist = (TriMiddle - RMWPosition) | (TriMiddle - RMWPosition); // Take the dot product of parallel, un-normalized vectors to get the squared distance
         if  (distance > sqdist)
         {
             distance = sqdist, foundPos = d;


### PR DESCRIPTION
**Issue key: LY-84640 
Issue id: 203130**

Code cleanup.

I have just been looking at this one and it had me confused at first, but the code is actually correct. The `|` operator is overloaded to perform the dot product on two Vec3s. If the vectors are parallel then the dot product just results in the ordinary multiplication of their lengths. If the vectors were normalised then this would just result in 1, but as they are not we get the squared distance. It's not clear, but it is correct. Let's add a comment to help the next person to look at this out!