### PR TITLE
There are identical sub-expressions to the left and to the right of the '&&' operator: s_pPropertiesPanel && s_pPropertiesPanel

### DIFF
--- a/dev/Code/Sandbox/Editor/Objects/EntityObject.cpp
+++ b/dev/Code/Sandbox/Editor/Objects/EntityObject.cpp
@@ -1697,7 +1697,7 @@ void CEntityObject::EndEditParams(IEditor* ie)
     }
     ms_pTreePanel = NULL;
 
-    if (s_pPropertiesPanel && s_pPropertiesPanel)
+    if (s_pPropertiesPanel)
     {
         s_pPropertiesPanel->ClearUpdateCallback();
     }


### PR DESCRIPTION
**Issue key: LY-84627 
Issue id: 203107**

**Code cleanup:**
Remove identical sub-expressions. I can't see a reason for this, nor can I see what it may have intended to be instead of this.