### PR TITLE
ShaderComponent: V501. There are identical sub-expressions to the left and to the right of the 'foo' operator.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderComponents.h
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderComponents.h
@@ -492,8 +492,6 @@ struct SCGTexture : SCGBind
             sp.m_BindingSlot == m_BindingSlot &&
             sp.m_Flags == m_Flags &&
             sp.m_pAnimInfo == m_pAnimInfo &&
-            sp.m_pTexture == m_pTexture &&
-            sp.m_eCGTextureType == m_eCGTextureType &&
             sp.m_bSRGBLookup == m_bSRGBLookup &&
             sp.m_bGlobal == m_bGlobal)
         {


### PR DESCRIPTION
**Issue key: LY-84623 
Issue id: 203100**

**Issue key: LY-84622 
Issue id: 203099**

**Code cleanup:**
Removing identical sub-expressions in != operator, it is a fairly common and (mostly) benign pattern in equality and in-equality operators to accidentally duplicate checks