### PR TITLE
DesignerPanel: There are identical sub-expressions to the left and to the right of the '&&' operator: pObj->GetParent() && pObj->GetParent()

### DIFF
--- a/dev/Code/Sandbox/Plugins/CryDesigner/UIs/DesignerPanel.cpp
+++ b/dev/Code/Sandbox/Plugins/CryDesigner/UIs/DesignerPanel.cpp
@@ -250,7 +250,7 @@ void DesignerPanel::UpdateCloneArrayButtons()
         return;
     }
 
-    if (pObj->GetParent() && pObj->GetParent())
+    if (pObj->GetParent())
     {
         GetButton(eDesigner_CircleClone)->setEnabled(false);
         GetButton(eDesigner_ArrayClone)->setEnabled(false);


### PR DESCRIPTION
**Issue key: LY-84647 
Issue id: 203138** 

**Code cleanup:**
Remove a duplicated check. I can't see why this might have ended up like this, but removing the check will not cause any new issues but will make the analyzer happy.