### PR TITLE
Texture: There are identical sub-expressions '(m_eTFSrc == eTF_BC6UH)' to the left and to the right of the '||' operator

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Textures/Texture.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Textures/Texture.cpp
@@ -1259,7 +1259,7 @@ bool CTexture::Load(CImageFile* pImage)
     td.m_pFilePath = pImage->mfGet_filename();
 
     // base range after normalization, fe. [0,1] for 8bit images, or [0,2^15] for RGBE/HDR data
-    if ((td.m_eTF == eTF_R9G9B9E5) || (td.m_eTF == eTF_BC6UH) || (td.m_eTF == eTF_BC6UH))
+    if ((td.m_eTF == eTF_R9G9B9E5) || (td.m_eTF == eTF_BC6UH) || (td.m_eTF == eTF_BC6SH))
     {
         td.m_cMinColor /= td.m_cMaxColor.a;
         td.m_cMaxColor /= td.m_cMaxColor.a;

--- a/dev/Code/CryEngine/RenderDll/Common/Textures/TextureStreaming.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Textures/TextureStreaming.cpp
@@ -980,7 +980,7 @@ bool CTexture::StreamPrepare(CImageFile* pIM)
     m_bStreamed = true;
 
     // base range after normalization, fe. [0,1] for 8bit images, or [0,2^15] for RGBE/HDR data
-    if ((m_eTFSrc == eTF_R9G9B9E5) || (m_eTFSrc == eTF_BC6UH) || (m_eTFSrc == eTF_BC6UH))
+    if ((m_eTFSrc == eTF_R9G9B9E5) || (m_eTFSrc == eTF_BC6UH) || (m_eTFSrc == eTF_BC6SH))
     {
         m_cMinColor /= m_cMaxColor.a;
         m_cMaxColor /= m_cMaxColor.a;


### PR DESCRIPTION
**Issue key: LY-84643 
Issue id: 203133** 

**Bug fix:**
This was a tricky one as I am not particularly familiar with the different possible texture formats, so I fell back to searching the codebase for similar functionality and comparing the flagged code with other instances doing the same thing. Fortunately, `Image_DXTC.cpp` is doing very similar checks for base range normalisation and we can see on line 601, 629, and 645 that the intended texture format enum is actually `eTF_BC6SH`. It is easy to see how this typo could slip past the implementing programmer and the reviewer. The result of this error will be that textures with the `eTF_BC6SH` format will not be normalized correctly.