### PR TITLE
For the SFMT expoent 19937 the array size is not 154.

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Math/Sfmt.h
+++ b/dev/Code/Framework/AzCore/AzCore/Math/Sfmt.h
@@ -27,7 +27,7 @@ namespace AZ
     {
         //
         static const int MEXP = 19937;
-        static const int N    = MEXP / (128 + 1);
+        static const int N    = (MEXP / 128 + 1);
 
 #if AZ_TRAIT_HARDWARE_HAS_M128I
         union W128_T


### PR DESCRIPTION
Acording of original SFMT implementation for the expoent 19937 the array size is 156.

The correct value is calculated by N = (MEXP / 128 + 1) = 156.
