### PR TITLE
Articulated Entity: There are identical sub-expressions 'm_joints[i].limits[1][j]' to the left and to the right of the '-' operator.

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/articulatedentity.cpp
+++ b/dev/Code/CryEngine/CryPhysics/articulatedentity.cpp
@@ -791,8 +791,9 @@ int CArticulatedEntity::SetParams(const pe_params* _params, int bThreadSafe)
                 m_joints[op[1]].qext[i] = params->qext[i];
                 nChanges++;
                 if (!(m_joints[op[1]].flags & angle0_locked << i) &&
-                    isneg(m_joints[op[1]].limits[0][i] - m_joints[op[1]].qext[i]) + isneg(m_joints[op[1]].qext[i] - m_joints[op[1]].limits[1][i]) +
-                    isneg(m_joints[op[1]].limits[1][i] - m_joints[op[1]].limits[1][i]) < 2)
+                    isneg(m_joints[op[1]].limits[0][i] - m_joints[op[1]].qext[i]) + 
+                    isneg(m_joints[op[1]].qext[i] - m_joints[op[1]].limits[1][i]) +
+                    isneg(m_joints[op[1]].limits[1][i] - m_joints[op[1]].limits[0][i]) < 2)
                 {   // qext violates limits; adjust the limits
                     float diff[2];
                     diff[0] = m_joints[op[1]].limits[0][i] - m_joints[op[1]].qext[i];
@@ -2040,8 +2041,9 @@ int CArticulatedEntity::Step(float time_interval)
             for (j = 0; j < 3; j++)
             {
                 if (!(m_joints[i].flags & angle0_locked << j) &&
-                    isneg(m_joints[i].limits[0][j] - m_joints[i].qext[j]) + isneg(m_joints[i].qext[j] - m_joints[i].limits[1][j]) +
-                    isneg(m_joints[i].limits[1][j] - m_joints[i].limits[1][j]) < 2)
+                    isneg(m_joints[i].limits[0][j] - m_joints[i].qext[j]) +        
+                    isneg(m_joints[i].qext[j] - m_joints[i].limits[1][j]) +        
+                    isneg(m_joints[i].limits[1][j] - m_joints[i].limits[0][j]) < 2)
                 { // qext violates limits; adjust the limits
                     float diff[2];
                     diff[0] = m_joints[i].limits[0][j] - m_joints[i].qext[j];


### PR DESCRIPTION
**Issue key: LY-84630 
Issue id: 203111**

**Issue key: LY-84629 
Issue id: 203110**

**Bug fix:**
 A typo has been copied into two places in this file. The result of this is that when stepping the `CArticulatedEntity` simulation, if a joint is being forced into a position outside of its limits, the limits of the joint will not be updated as intended. The intention of the code is:

- For each dimension
- If the rotation in that dimension is not locked
- Check if the rotation of the joint in that dimension is less than the minimum limit allowed: `m_joints[i].limits[0][j] - m_joints[i].qext[j]`
- Check if the rotation of the joint in that dimension is above the maximum limit allowed: `m_joints[i].qext[j] - m_joints[i].limits[1][j]`
- Check if the maximum limit is actually greater than the minimum limit: `m_joints[i].limits[1][j] - m_joints[i].limits[0][j]`. Note: `limits[0]` == minimum, `limits[1]` == maximum
-- This is the crucial part:
--- Usually, if `max > min`, if Min = 0, Max = 90, then if `qExt` is outside the range 0-90, then the limits should be adjusted.
--- However, if `min > max` then we actually invert the checks, so if Min = 90, Max = 0, then `qExt` is outside the limits if it is within the range 0-90
- adjust the limits if the rotation of the joint is outside the limitations

The final check which checks the min vs max limit and sees if they are inverted had a typo which meant it would always evaluate to false and the limits would not be updated regardless of whether `qExt` was beyond its limits.