### PR TITLE
EditorUtils: There are identical sub-expressions to the left and to the right of the '||' operator: hotX < 0 || hotX < 0

### DIFF
--- a/dev/Code/Sandbox/Editor/Util/EditorUtils.cpp
+++ b/dev/Code/Sandbox/Editor/Util/EditorUtils.cpp
@@ -163,7 +163,7 @@ QCursor CMFCUtils::LoadCursor(unsigned int nIDResource, int hotX, int hotY)
     }
     path = QStringLiteral(":/cursors/res/") + path;
     QPixmap pm(path);
-    if (!pm.isNull() && (hotX < 0 || hotX < 0))
+    if (!pm.isNull() && (hotX < 0 || hotY < 0))
     {
         QFile f(path);
         f.open(QFile::ReadOnly);


### PR DESCRIPTION
**Issue key: LY-84621 
Issue id: 203098**

**Code cleanup:**
Typo, `hotX` should be `hotY`. Prior to this fix, `hotY < 0` would not have resulted in the execution of the code in the if block. Note: It is unlikely this was causing any issues anyway; this function has default parameters and is called in such a way that would always result in the if block being called.