### PR TITLE
Budgeting System: Several cases exist where the else and then statements are equivalent

### DIFF
--- a/dev/Code/CryEngine/CrySystem/BudgetingSystem.cpp
+++ b/dev/Code/CryEngine/CrySystem/BudgetingSystem.cpp
@@ -693,14 +693,7 @@ void CBudgetingSystem::MonitorStreaming(float& x, float& y)
     float color[ 4 ];
     GetColor(scale, color);
 
-    if (scale <= 1.0f)
-    {
-        DrawText(x, y, color, "Streaming throughput: %.2f KB/s (current budget is %.2f KB/s).", thp, m_streamingThroughputLimit);
-    }
-    else
-    {
-        DrawText(x, y, color, "Streaming throughput: %.2f KB/s (current budget is %.2f KB/s).", thp, m_streamingThroughputLimit);
-    }
+    DrawText(x, y, color, "Streaming throughput: %.2f KB/s (current budget is %.2f KB/s).", thp, m_streamingThroughputLimit);
 
     DrawMeter(x, y, scale);
 #endif


### PR DESCRIPTION
**Issue key: LY-84619 
Issue id: 203092** 

Cleaning up a benign error in an old CrySystem. 

I'm not sure how this error ended up here, but we could speculate that maybe in the block for `if(scale <= 1.0f)`, `DrawText` used to be called with one color, then in the else block it was called with a different one. The programmer may have refactored the code to use the `GetColor` function and not tidied up fully.