### PR TITLE
LivingEntity: several cases exist where the else and then statements are equivalent

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/livingentity.cpp
+++ b/dev/Code/CryEngine/CryPhysics/livingentity.cpp
@@ -1385,19 +1385,7 @@ int CLivingEntity::SetStateFromSnapshot(TSerialize ser, int flags)
                 }
         */
 
-        float distance = m_pos.GetDistance(helper.pos);
-        if (ser.GetSerializationTarget() == eST_Network)
-        {
-            /*if (distance > MAX_DIFFERENCE)
-                setpos.pos = helper.pos + (m_pos - helper.pos).GetNormalized() * MAX_DIFFERENCE;
-            else
-                setpos.pos = m_pos + (helper.pos - m_pos) * distance/MAX_DIFFERENCE*0.033f;*/
-            setpos.pos = helper.pos;
-        }
-        else
-        {
-            setpos.pos = helper.pos;
-        }
+        setpos.pos = helper.pos;
 
         SetParams(&setpos, 0);
 


### PR DESCRIPTION
**Issue key: LY-84619 
Issue id: 203092**

**Code cleanup**
V523. The 'then' statement is equivalent to the 'else' statement.
Again we can see equivalent if/else blocks rendering the conditional unneeded. It is likely that in the eST_Network case the code used to do something different (as seen in the commented out code), but no longer does. If it is the intention of the programmer to refer to this code then source control will still contain the details for them.