### PR TITLE
ParticleItem: several cases exist where the else and then statements are equivalent

### DIFF
--- a/dev/Code/Sandbox/Editor/Particles/ParticleItem.cpp
+++ b/dev/Code/Sandbox/Editor/Particles/ParticleItem.cpp
@@ -104,49 +104,24 @@ void CParticleItem::Serialize(SerializeContext& ctx, const ParticleParams* defau
     // If we dont do this we will get extra unwanted items in our library when we next load from the file.
     //
     // to remove any "folder" items from the library we go through and look for any items without the isParticle identifier ...
-    if (IsParticleItem)
+    XmlNodeRef node = ctx.node;
+    if (ctx.bLoading)
     {
-        XmlNodeRef node = ctx.node;
-        if (ctx.bLoading)
+        if (!ctx.bIgnoreChilds)
         {
-            if (!ctx.bIgnoreChilds)
-            {
-                ClearChilds();
-            }
-
-            m_pEffect->Serialize(node, true, !ctx.bIgnoreChilds, defaultParams);
-
-            if (!ctx.bIgnoreChilds)
-            {
-                AddAllChildren();
-            }
+            ClearChilds();
         }
-        else
+
+        m_pEffect->Serialize(node, true, !ctx.bIgnoreChilds, defaultParams);
+
+        if (!ctx.bIgnoreChilds)
         {
-            m_pEffect->Serialize(node, false, !ctx.bIgnoreChilds, defaultParams);
+            AddAllChildren();
         }
     }
     else
     {
-        XmlNodeRef node = ctx.node;
-        if (ctx.bLoading)
-        {
-            if (!ctx.bIgnoreChilds)
-            {
-                ClearChilds();
-            }
-
-            m_pEffect->Serialize(node, true, !ctx.bIgnoreChilds, defaultParams);
-
-            if (!ctx.bIgnoreChilds)
-            {
-                AddAllChildren();
-            }
-        }
-        else
-        {
-            m_pEffect->Serialize(node, false, !ctx.bIgnoreChilds, defaultParams);
-        }
+        m_pEffect->Serialize(node, false, !ctx.bIgnoreChilds, defaultParams);
     }
     m_bModified = false;
 }


### PR DESCRIPTION
**Issue key: LY-84619
Issue id: 203092 **

**Code cleanup**
V523. The 'then' statement is equivalent to the 'else' statement.
Code cleanup, old system, has been like this since at least 2016. Note, the diff makes this look more complicated than it is, all that is happening is the if/else has been removed.