### PR TITLE
PropertyOArchive: several cases exist where the else and then statements are equivalent

### DIFF
--- a/dev/Code/Sandbox/Plugins/EditorCommon/QPropertyTree/PropertyOArchive.cpp
+++ b/dev/Code/Sandbox/Plugins/EditorCommon/QPropertyTree/PropertyOArchive.cpp
@@ -438,13 +438,9 @@ bool PropertyOArchive::operator()(Serialization::ICallback& callback, const char
 
 bool PropertyOArchive::operator()(Serialization::Object& obj, const char *name, const char *label)
 {
-    const char* typeName = obj.type().name();
-
     PropertyRowObject* row = 0;
-    if (typeName_.empty())
-         row = updateRow<PropertyRowObject>(name, label, obj.type().name(), obj);
-    else
-         row = updateRow<PropertyRowObject>(name, label, obj.type().name(), obj);
+    row = updateRow<PropertyRowObject>(name, label, obj.type().name(), obj);
+
     lastNode_ = row;
     return true;
 }


### PR DESCRIPTION
**Issue key: LY-84619 
Issue id: 203092**

**Code cleanup**
V523. The 'then' statement is equivalent to the 'else' statement.
