### PR TITLE
toMETALInstrution: several cases exist where the else and then statements are equivalent

### DIFF
--- a/dev/Code/Tools/HLSLCrossCompilerMETAL/src/toMETALInstruction.c
+++ b/dev/Code/Tools/HLSLCrossCompilerMETAL/src/toMETALInstruction.c
@@ -4189,17 +4189,8 @@ void TranslateInstructionMETAL(HLSLCrossCompilerContext* psContext, Instruction*
         } BT;
         BT  barrierType = BT_None;
 
-        if (ui32SyncFlags & SYNC_THREADS_IN_GROUP)
-        {
-            AddIndentation(psContext);
-            bcatcstr(metal, "threadgroup_barrier(");
-        }
-        else
-        {
-            AddIndentation(psContext);
-            //  Igor: simdgroup_barrier is faster than threadgroup_barrier. It is supported on iOS 10+ on all hardware.
-            bcatcstr(metal, "threadgroup_barrier(");
-        }
+        AddIndentation(psContext);
+        bcatcstr(metal, "threadgroup_barrier(");
 
         if (ui32SyncFlags & SYNC_THREAD_GROUP_SHARED_MEMORY)
         {


### PR DESCRIPTION
**Issue key: LY-84619 
Issue id: 203092 **

**Code cleanup**
V523. The 'then' statement is equivalent to the 'else' statement. 
It is hard to tell what was intended here but as both branches are equivalent we should clean them up unless we have any deeper insight into the programmers original intention, or if we have a bug relevant to this.