### PR TITLE
TrackViewNodes: several cases exist where the else and then statements are equivalent

### DIFF
--- a/dev/Code/Sandbox/Editor/TrackView/TrackViewNodes.cpp
+++ b/dev/Code/Sandbox/Editor/TrackView/TrackViewNodes.cpp
@@ -1258,8 +1258,9 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                 }
                 else
                 {
-                    CUndo undo("Add TrackView Comment Node");
+                    AzToolsFramework::ScopedUndoBatch undoBatch("Add TrackView Comment Node");
                     pGroupNode->CreateSubNode(commentNodeName, AnimNodeType::Comment);
+                    undoBatch.MarkEntityDirty(pGroupNode->GetSequence()->GetSequenceComponentEntityId());
                 }
             }
             else if (cmd == eMI_AddRadialBlur)


### PR DESCRIPTION
**Issue key: LY-84619 
Issue id: 203092 **

**Bug fix**
V523. The 'then' statement is equivalent to the 'else' statement.

Copy and paste error. The programmer has clearly copied and pasted the if block into the else blocks throughout the file, and then done a pass to update the else block to do the correct non-legacy functionality. They obviously missed this one.