### PR TITLE
AssetTagging: V773 The function was exited without releasing the 'sqlSchema' pointer. A memory leak is possible

### DIFF
--- a/dev/Code/Tools/AssetTagging/AssetTagging/AssetTagging.cpp
+++ b/dev/Code/Tools/AssetTagging/AssetTagging/AssetTagging.cpp
@@ -78,6 +78,7 @@ bool CreateDatabase(IDBConnection* pConn, const std::string& schemafile, int typ
 
     if (sqlSchema[0] == '\0')
     {
+        delete[] sqlSchema;
         return false;
     }
 


### PR DESCRIPTION
**Bug fix**
V773 The function was exited without releasing the 'sqlSchema' pointer. A memory leak is possible.