### PR TITLE
AttributePool: Fix for memory leak and for "expression always true" error.

### DIFF
--- a/dev/Gems/EMotionFX/Code/MCore/Source/AttributePool.cpp
+++ b/dev/Gems/EMotionFX/Code/MCore/Source/AttributePool.cpp
@@ -154,6 +154,7 @@ namespace MCore
         Pool* pool = new Pool(typeID);
         if (pool->mAttribute == nullptr)
         {
+            delete pool;
             return;
         }
 

--- a/dev/Gems/EMotionFX/Code/MCore/Source/AttributePool.cpp
+++ b/dev/Gems/EMotionFX/Code/MCore/Source/AttributePool.cpp
@@ -71,14 +71,17 @@ namespace MCore
     // destructor
     AttributePool::Pool::~Pool()
     {
-        if (mPoolType == POOLTYPE_STATIC)
+        switch (mPoolType)
+        {
+        case MCore::AttributePool::POOLTYPE_STATIC:
         {
             MCore::AlignedFree(mAttributeData);
             mAttributeData = nullptr;
             mFreeList.Clear();
         }
-        else
-        if (mPoolType == POOLTYPE_DYNAMIC)
+        break;
+        
+        case MCore::AttributePool::POOLTYPE_DYNAMIC:
         {
             MCORE_ASSERT(mAttributeData == nullptr);
 
@@ -92,9 +95,13 @@ namespace MCore
 
             mFreeList.Clear();
         }
-        else
+        break;
+        
+        default:
         {
             MCORE_ASSERT(false);
+        }
+        break;
         }
     }
 


### PR DESCRIPTION
**Bug fix / Code cleanup**

Fixes for:
V547 Expression 'poolType == POOLTYPE_DYNAMIC' is always true. attributepool.cpp 179
V773 The function was exited without releasing the 'pool' pointer. A memory leak is possible.

More notes with the individual commits.