### PR TITLE
CompilerStandalone: Fixes for dangerous function calls, memory leaks, and odd arguments

### DIFF
--- a/dev/Code/Tools/HLSLCrossCompiler/offline/compilerStandalone.cpp
+++ b/dev/Code/Tools/HLSLCrossCompiler/offline/compilerStandalone.cpp
@@ -205,8 +205,11 @@ int TryCompileShader(GLenum eShaderType, const char* inFilename, const char* sha
 
             //Dump to file
             fopen_s(&errorFile, filename.c_str(), "w");
-
-            fclose(errorFile);
+            if (errorFile)
+            {
+                fprintf(errorFile, "%s", pszInfoLog);
+                fclose(errorFile);
+            }
         }
         else
         {
@@ -506,16 +509,22 @@ int Run(const char* srcPath, const char* destPath, GLLang language, int flags, c
         {
             //Dump to file
             outputFile = fopen(destPath, "w");
-            fprintf(outputFile, "%s", result->sourceCode);
-            fclose(outputFile);
+            if (outputFile)
+            {
+                fprintf(outputFile, "%s", result->sourceCode);
+                fclose(outputFile);
+            }
         }
 
         if (reflectPath)
         {
             const char* jsonString = SerializeReflection(&result->reflection);
             outputFile = fopen(reflectPath, "w");
-            fprintf(outputFile, "%s", jsonString);
-            fclose(outputFile);
+            if (outputFile)
+            {
+                fprintf(outputFile, "%s", jsonString);
+                fclose(outputFile);
+            }
         }
 
 #if defined(VALIDATE_OUTPUT)

--- a/dev/Code/Tools/HLSLCrossCompiler/offline/compilerStandalone.cpp
+++ b/dev/Code/Tools/HLSLCrossCompiler/offline/compilerStandalone.cpp
@@ -667,6 +667,10 @@ const char* PatchHLSLShaderFile(const char* path)
     FILE* patchedFile = fopen(patchedFileName, "wb");
     if (!patchedFile)
     {
+        if (shaderFile)
+        {
+            fclose(shaderFile);
+        }
         return NULL;
     }
 

--- a/dev/Code/Tools/HLSLCrossCompiler/offline/compilerStandalone.cpp
+++ b/dev/Code/Tools/HLSLCrossCompiler/offline/compilerStandalone.cpp
@@ -195,7 +195,7 @@ int TryCompileShader(GLenum eShaderType, const char* inFilename, const char* sha
 
         glGetInfoLogARB (hShader, iInfoLogLength, NULL, pszInfoLog);
 
-        printf(pszInfoLog);
+        printf("%s", pszInfoLog);
 
         if (!useStdErr)
         {
@@ -506,7 +506,7 @@ int Run(const char* srcPath, const char* destPath, GLLang language, int flags, c
         {
             //Dump to file
             outputFile = fopen(destPath, "w");
-            fprintf(outputFile, result->sourceCode);
+            fprintf(outputFile, "%s", result->sourceCode);
             fclose(outputFile);
         }
 
@@ -514,7 +514,7 @@ int Run(const char* srcPath, const char* destPath, GLLang language, int flags, c
         {
             const char* jsonString = SerializeReflection(&result->reflection);
             outputFile = fopen(reflectPath, "w");
-            fprintf(outputFile, jsonString);
+            fprintf(outputFile, "%s", jsonString);
             fclose(outputFile);
         }
 

--- a/dev/Code/Tools/HLSLCrossCompilerMETAL/offline/compilerStandalone.cpp
+++ b/dev/Code/Tools/HLSLCrossCompilerMETAL/offline/compilerStandalone.cpp
@@ -543,7 +543,7 @@ int Run(const char* srcPath, const char* destPath, ShaderLang language, int flag
 		{
 			//Dump to file
 			outputFile = fopen(destPath, "w");
-			fprintf(outputFile, result->sourceCode);
+			fprintf(outputFile, "%s", result->sourceCode);
 
 			fclose(outputFile);
 		}
@@ -552,7 +552,7 @@ int Run(const char* srcPath, const char* destPath, ShaderLang language, int flag
 		{
 			const char* jsonString = SerializeReflection(&result->reflection);
 			outputFile = fopen(reflectPath, "w");
-			fprintf(outputFile, jsonString);
+			fprintf(outputFile, "%s", jsonString);
 			fclose(outputFile);
 		}
 

--- a/dev/Code/Tools/HLSLCrossCompilerMETAL/offline/compilerStandalone.cpp
+++ b/dev/Code/Tools/HLSLCrossCompilerMETAL/offline/compilerStandalone.cpp
@@ -196,16 +196,19 @@ int TryCompileShader(GLenum eShaderType, const char* inFilename, char* shader, d
 
 		printf(pszInfoLog);
 
-		if (!useStdErr)
-		{
-			std::string filename;
-			filename += inFilename;
-			filename += "_compileErrors.txt";
+        if (!useStdErr)
+        {
+            std::string filename;
+            filename += inFilename;
+            filename += "_compileErrors.txt";
 
-			//Dump to file
-			errorFile = fopen(filename.c_str(), "w");
-
-			fclose(errorFile);
+            //Dump to file
+            errorFile = fopen(filename.c_str(), "w");
+            if (errorFile)
+            {
+                fprintf(errorFile, "%s", pszInfoLog);
+                fclose(errorFile);
+            }
 		}
 		else
 		{
@@ -543,9 +546,11 @@ int Run(const char* srcPath, const char* destPath, ShaderLang language, int flag
 		{
 			//Dump to file
 			outputFile = fopen(destPath, "w");
-			fprintf(outputFile, "%s", result->sourceCode);
-
-			fclose(outputFile);
+            if (outputFile)
+            {
+                fprintf(outputFile, "%s", result->sourceCode);
+                fclose(outputFile);
+            }
 		}
 
 		if (reflectPath)

--- a/dev/Code/Tools/HLSLCrossCompilerMETAL/offline/compilerStandalone.cpp
+++ b/dev/Code/Tools/HLSLCrossCompilerMETAL/offline/compilerStandalone.cpp
@@ -691,6 +691,10 @@ const char* PatchHLSLShaderFile(const char* path)
     FILE* patchedFile = fopen(patchedFileName, "wb");
     if (!patchedFile)
     {
+        if (shaderFile)
+        {
+            fclose(shaderFile);
+        }
         return NULL;
     }
 


### PR DESCRIPTION
**Bug fix**

V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.
V618. It's dangerous to call the 'Foo' function in such a manner, as the line being passed could contain format specification.
V575. Function receives an odd argument.

Comments with each individual commit