### PR TITLE
AssetDatabase: V1004. The pointer was used unsafely after it was verified against nullptr

### DIFF
--- a/dev/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
+++ b/dev/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
@@ -553,9 +553,12 @@ namespace AssetProcessor
         Statement* statement = autoFinal.Get();
         AZ_Error(LOG_NAME, statement, "Statement not found: %s", SET_DATABASE_VERSION);
 
-        statement->BindValueInt(statement->GetNamedParamIdx(":ver"), static_cast<int>(ver));
-        Statement::SqlStatus result = statement->Step();
-        AZ_Warning(LOG_NAME, result != SQLite::Statement::SqlOK, "Failed to execute SetDatabaseVersion.");
+        if (statement)
+        {
+            statement->BindValueInt(statement->GetNamedParamIdx(":ver"), static_cast<int>(ver));
+            Statement::SqlStatus result = statement->Step();
+            AZ_Warning(LOG_NAME, result != SQLite::Statement::SqlOK, "Failed to execute SetDatabaseVersion.");
+        }
     }
 
     void AssetDatabaseConnection::CreateStatements()
@@ -815,6 +818,10 @@ namespace AssetProcessor
             StatementAutoFinalizer autoFinal(*m_databaseConnection, INSERT_SCANFOLDER);
             Statement* statement = autoFinal.Get();
             AZ_Error(LOG_NAME, statement, "Could not get statement: %s", INSERT_SCANFOLDER);
+            if (!statement)
+            {
+                return false;
+            }
 
             int scanFolderIdx = statement->GetNamedParamIdx(":scanfolder");
             if(!scanFolderIdx)
@@ -884,6 +891,10 @@ namespace AssetProcessor
             StatementAutoFinalizer autoFinal(*m_databaseConnection, UPDATE_SCANFOLDER);
             Statement* statement = autoFinal.Get();
             AZ_Error(LOG_NAME, statement, "Could not get statement: %s", UPDATE_SCANFOLDER);
+            if (!statement)
+            {
+                return false;
+            }
 
             int scanFolderIDIdx = statement->GetNamedParamIdx(":scanfolderid");
             if(!scanFolderIDIdx)
@@ -955,6 +966,10 @@ namespace AssetProcessor
         StatementAutoFinalizer autoFinal(*m_databaseConnection, DELETE_SCANFOLDER);
         Statement* statement = autoFinal.Get();
         AZ_Error(LOG_NAME, statement, "Could not get statement: %s", DELETE_SCANFOLDER);
+        if (!statement)
+        {
+            return false;
+        }
 
         int scanFolderIDIdx = statement->GetNamedParamIdx(":scanfolderid");
         if(!scanFolderIDIdx)


### PR DESCRIPTION
**Code cleanup**

V1004. The pointer was used unsafely after it was verified against nullptr
The analyzer has detected a possible null-pointer-dereferencing error. The pointer is checked for null before the first use but is then used for the second time without such a check.

Fixing a number of potential null pointer dereferencing errors. This file was flagged as a high-risk file due to the presence of a number of high priority issues alongside the fact that it is not a legacy Cry file. A number of the issues actually turned out to be benign and have been silenced in the analyzer, this error, however, is worth fixing.