### PR TITLE
MathReflection: V501 There are identical sub-expressions '!dc.IsClass < Vector3 > (0)' to the left and to the right of the '||' operator. 

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -2205,9 +2205,9 @@ namespace AZ
             // As one return value (hit point) is based on the other (hit time), for simplicity, the Lua implementation
             // just returns all three values: does the ray hit? When does it hit? Where does it hit?
 
-            if (!dc.IsClass<Vector3>(0) || !dc.IsClass<Vector3>(0))
+            if (!dc.IsClass<Vector3>(0) || !dc.IsClass<Vector3>(1))
             {
-                AZ_Error("Script", false, "ScriptPlane CastRay requires two ScriptVector3s as arguments.");
+                AZ_Error("Script", false, "ScriptPlane IntersectSegment requires two ScriptVector3s as arguments.");
                 return;
             }
 


### PR DESCRIPTION
**Bug fix**
The intention of this check is to make sure that the arguments passed to PlaneIntersectSegmentMultipleReturn are two vector 3s. This check will have only ever checked the first argument passed in. The AZ_Error was also copy and pasted incorrectly.