### PR TITLE
ImageObject: V773 The function was exited without releasing the 'pAttached' pointer. A memory leak is possible.

### DIFF
--- a/dev/Code/Tools/RC/ResourceCompilerImage/ImageObject.cpp
+++ b/dev/Code/Tools/RC/ResourceCompilerImage/ImageObject.cpp
@@ -1195,6 +1195,7 @@ bool ImageObject::LoadExtendedData(FILE* in, bool bForceDX10)
 
             if (!pAttached->LoadImage(in, bForceDX10))
             {
+                delete pAttached;
                 return false;
             }
 


### PR DESCRIPTION
This is a simple fix for a possible memory leak in ImageObject. 