### PR TITLE
V560. A part of conditional expression is always true/false.

### DIFF
--- a/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -580,7 +580,7 @@ namespace ScriptCanvas
             {
                 if (const Datum* datum = GetInput(slotID))
                 {
-                    return datum && (Data::IS_A(type, datum->GetType()) || datum->IsConvertibleFrom(type));
+                    return (Data::IS_A(type, datum->GetType()) || datum->IsConvertibleFrom(type));
                 }
 
                 const Data::Type& inputType = slotIter->GetDataType();


### PR DESCRIPTION
Code cleanup, remove an unnecessary check of datum after it has already been verified.