### PR TITLE
DataWriter: V701. realloc() possible leak: when realloc() fails in allocating memory, original pointer is lost. Consider assigning realloc() to a temporary pointer.

### DIFF
--- a/dev/Code/Tools/RC/ResourceCompilerPC/CGF/DataWriter.cpp
+++ b/dev/Code/Tools/RC/ResourceCompilerPC/CGF/DataWriter.cpp
@@ -275,12 +275,18 @@ void DataWriter::ExpandBuffer(const uint32 addBytes)
         const uint32 newBufferSize = m_currentBufferSize + BUFFERINCREASESIZE;
         if (m_outputBuffer)
         {
-            m_outputBuffer = realloc(m_outputBuffer, newBufferSize);
+            void* tmp = realloc(m_outputBuffer, newBufferSize);
+            AZ_Assert(tmp != nullptr, "realloc failed, this is possible when allocating a large data array whose size is comparable to RAM size, and also when the memory is highly segmented");
+            if (tmp)
+            {
+                m_outputBuffer = tmp;
+                m_currentBufferSize = newBufferSize;
+            }
         }
         else
         {
             m_outputBuffer = malloc(newBufferSize);
+            m_currentBufferSize = newBufferSize;
         }
-        m_currentBufferSize = newBufferSize;
     }
 }


### PR DESCRIPTION
The analyzer has detected an expression of the 'foo = realloc(foo, ...)' pattern. This expression is potentially dangerous: it is recommended to save the result of the realloc function into a different variable.

The realloc(ptr, ...) function is used to change the size of some memory block. When it succeeds to do so without moving the data, the resulting pointer will coincide with the source ptr. When changing a memory block's size is impossible without moving it, the function will return the pointer to the new block while the old one will be freed. But when changing a memory block's size is currently impossible at all even with moving it, the function will return a null pointer. This situation may occur when allocating a large data array whose size is comparable to RAM size, and also when the memory is highly segmented. This third scenario is just what makes it potentially dangerous: if realloc(ptr, ...) returns a null pointer, the data block at the ptr address won't change in size. The main problem is that using a construct of the "ptr = realloc(ptr, ...)" pattern may cause losing the ptr pointer to this data block.