### PR TITLE
boolean3d: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/boolean3d.cpp
+++ b/dev/Code/CryEngine/CryPhysics/boolean3d.cpp
@@ -2052,6 +2052,8 @@ int CTriMesh::Slice(const triangle* pcut, float minlen, float minArea)
     }
     if (!nNewTri)
     {
+        delete[] removedTri;
+        delete[] newTri;
         return 0;
     }
 


### PR DESCRIPTION
Due to an early return midway through this function, it is possible to leak the memory allocated by `removedTri` and `newTri`.