### PR TITLE
CGFLoader: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/CGF/CGFLoader.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/CGF/CGFLoader.cpp
@@ -4186,6 +4186,7 @@ CMaterialCGF* CLoaderCGF::LoadMaterialNameChunk(IChunkFile::ChunkDesc* pChunkDes
                 if (nPhysicalizeType != PHYS_GEOM_TYPE_NONE &&
                     (nPhysicalizeType < PHYS_GEOM_TYPE_DEFAULT || nPhysicalizeType > PHYS_GEOM_TYPE_DEFAULT_PROXY))
                 {
+                    delete pSubMaterial;
                     m_LastError.Format("Invalid physicalize type in material name chunk (0x%08x) in %s, %s", nPhysicalizeType, pMtlCGF->name, m_filename);
                     return NULL;
                 }


### PR DESCRIPTION
In certain cases, pSubMaterial can be leaked.