### PR TITLE
CharacterManager: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Gems/CryLegacy/Code/Source/CryAnimation/CharacterManager.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryAnimation/CharacterManager.cpp
@@ -3435,6 +3435,7 @@ CharacterDefinition* CharacterManager::LoadCDFFromXML(XmlNodeRef root, const cha
     uint32 numChildren = root->getChildCount();
     if (numChildren == 0)
     {
+        delete def;
         return nullptr;
     }
 


### PR DESCRIPTION
If `numChildren == 0`, the memory allocated for `def` will leak. Fix by deleting `def` correctly.