### PR TITLE
FileUtil: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Code/Tools/CryCommonTools/FileUtil.h
+++ b/dev/Code/Tools/CryCommonTools/FileUtil.h
@@ -96,6 +96,7 @@ namespace FileUtil
 
         if (ftimeModify == nullptr && ftimeCreate == nullptr && ftimeAccess == nullptr)
         {
+            FindClose(hFind);
             return true;
         }
 


### PR DESCRIPTION
FindClose is required to close a file search handle opened by FindFirstFileA.