### PR TITLE
GameTokenSystem: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible

### DIFF
--- a/dev/Gems/CryLegacy/Code/Source/CryAction/GameTokens/GameTokenSystem.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryAction/GameTokens/GameTokenSystem.cpp
@@ -159,6 +159,8 @@ CGameTokenSystem::CGameTokenSystem()
 //////////////////////////////////////////////////////////////////////////
 CGameTokenSystem::~CGameTokenSystem()
 {
+    Unload();
+
     if (m_pScriptBind)
     {
         delete m_pScriptBind;


### PR DESCRIPTION
m_pGameTokensMap is not cleaned up correctly in the destructor of CGameTokenSystem, call Unload to properly handle the memory allocated.