### PR TITLE
HeightFieldGeom: V773. The function was exited without releasing the pointer/handle.

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/heightfieldgeom.cpp
+++ b/dev/Code/CryEngine/CryPhysics/heightfieldgeom.cpp
@@ -26,6 +26,15 @@
 #include "heightfieldbv.h"
 #include "heightfieldgeom.h"
 
+CHeightfield::~CHeightfield()
+{
+    delete[] m_pIndices;
+    delete[] m_pNormals;
+    delete[] m_pIds;
+    delete[] m_pTopology;
+    m_pTree = 0;
+}
+
 CHeightfield* CHeightfield::CreateHeightfield(heightfield* phf)
 {
     phf->stepr.x = 1.0f / phf->step.x;

--- a/dev/Code/CryEngine/CryPhysics/heightfieldgeom.h
+++ b/dev/Code/CryEngine/CryPhysics/heightfieldgeom.h
@@ -23,7 +23,7 @@ class CHeightfield
 {
 public:
     CHeightfield() { m_pTree = &m_Tree; }
-    virtual ~CHeightfield() { m_pTree = 0; }
+    virtual ~CHeightfield();
 
     CHeightfield* CreateHeightfield(heightfield* phf);
     virtual int GetType() { return GEOM_HEIGHTFIELD; }


### PR DESCRIPTION
A memory/resource leak is possible. Clean up allocated memory and move destructor into source file as it is no longer trivial.