### PR TITLE
BreakablePlane: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Gems/CryLegacy/Code/Source/CryEntitySystem/BreakablePlane.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryEntitySystem/BreakablePlane.cpp
@@ -1197,6 +1197,7 @@ int CBreakablePlane::ProcessImpact(const SProcessImpactIn& in, SProcessImpactOut
 
         if (in.bVerify)
         {
+            delete pPlane;
             return result;
         }
 


### PR DESCRIPTION
Early return from function causes a memory leak as pPlane is not deleted.