### PR TITLE
DX12: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DX12/API/DX12PSO.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DX12/API/DX12PSO.cpp
@@ -96,6 +96,7 @@ namespace DX12
         if (!result->Init(params))
         {
             DX12_ERROR("Could not create PSO!");
+            delete result;
             return nullptr;
         }
 
@@ -118,6 +119,7 @@ namespace DX12
         if (!result->Init(params))
         {
             DX12_ERROR("Could not create PSO!");
+            delete result;
             return nullptr;
         }
 

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DX12/API/DX12RootSignature.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DX12/API/DX12RootSignature.cpp
@@ -596,6 +596,7 @@ namespace DX12
         if (!result->Init(params))
         {
             DX12_ERROR("Could not create root signature!");
+            delete result;
             nullptr;
         }
 
@@ -618,6 +619,7 @@ namespace DX12
         if (!result->Init(params))
         {
             DX12_ERROR("Could not create root signature!");
+            delete result;
             nullptr;
         }
 


### PR DESCRIPTION
The same issue occurs in both of these files; `result` is leaked due to an early return on an error condition.