### PR TITLE
EntityScript: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Code/Sandbox/Editor/Objects/EntityScript.cpp
+++ b/dev/Code/Sandbox/Editor/Objects/EntityScript.cpp
@@ -286,6 +286,7 @@ public:
             break;
         default:
             assert(0);
+            delete var;
             return 0;
         }
 


### PR DESCRIPTION
Fix memory leak in an old system because people love to copy and paste!