### PR TITLE
ExportManager: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Code/Sandbox/Editor/Export/ExportManager.cpp
+++ b/dev/Code/Sandbox/Editor/Export/ExportManager.cpp
@@ -1710,6 +1710,7 @@ bool CExportManager::AddTerrain()
         if (nExportHeight >= 10 && y % (nExportHeight / 10) == 0 && !progress.Step(100 * y / nExportHeight))
         {
             QMessageBox::critical(QApplication::activeWindow(), QString(), QObject::tr("Export Terrain was skipped by user."));
+            delete pMesh;
             return false;
         }
     }


### PR DESCRIPTION
Another case of an early return leading to a memory leak. C++ core guidelines say don't worry about having a single return, the more of these we fix, the less I believe them!