### PR TITLE
LoaderTCB: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Gems/CryLegacy/Code/Source/CryAnimation/LoaderTCB.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryAnimation/LoaderTCB.cpp
@@ -447,6 +447,7 @@ bool CLoaderTCB::ReadController(IChunkFile::ChunkDesc* pChunkDesc)
             ITrackRotationStorage* pStorage = ControllerHelper::GetRotationControllerPtr(pCtrlChunk->RotationFormat);
             if (!pStorage)
             {
+                delete pRotation;
                 return false;
             }
 
@@ -475,6 +476,7 @@ bool CLoaderTCB::ReadController(IChunkFile::ChunkDesc* pChunkDesc)
             TrackPositionStoragePtr pStorage = ControllerHelper::GetPositionControllerPtr(pCtrlChunk->PositionFormat);
             if (!pStorage)
             {
+                delete pPosition;
                 return false;
             }
 
@@ -580,6 +582,7 @@ bool CLoaderTCB::ReadController(IChunkFile::ChunkDesc* pChunkDesc)
             ITrackRotationStorage* pStorage = ControllerHelper::GetRotationControllerPtr(pCtrlChunk->RotationFormat);
             if (!pStorage)
             {
+                delete pRotation;
                 return false;
             }
 
@@ -608,6 +611,7 @@ bool CLoaderTCB::ReadController(IChunkFile::ChunkDesc* pChunkDesc)
             TrackPositionStoragePtr pStorage = ControllerHelper::GetPositionControllerPtr(pCtrlChunk->PositionFormat);
             if (!pStorage)
             {
+                delete pPosition;
                 return false;
             }
 


### PR DESCRIPTION
Fix for a number of early returns leading to memory leaks.