### PR TITLE
UiAnimViewNodes: V773. The function was exited without releasing the pointer/handle. A memory/resource leak is possible.

### DIFF
--- a/dev/Code/Sandbox/Plugins/UiCanvasEditor/Animation/UiAnimViewNodes.cpp
+++ b/dev/Code/Sandbox/Plugins/UiCanvasEditor/Animation/UiAnimViewNodes.cpp
@@ -746,7 +746,7 @@ void CUiAnimViewNodesCtrl::OnFillItems()
         // Additional empty record like space for scrollbar in key control
         CRecord* pGroupRec = new CRecord();
         pGroupRec->setSizeHint(0, QSize(width(), 18));
-        ui->treeWidget->addTopLevelItem(pRootGroupRec);
+        ui->treeWidget->addTopLevelItem(pGroupRec);
     }
 }
 


### PR DESCRIPTION
Typo/copy and paste error lead to a memory leak which was actually also a functionality bug too. 

It appears that `pGroupRec` should be added to the UI structure but instead, `pRootGroupRec` was added for a second time.

I have tested this out in the UI Animation Editor and can't actually see what it does so I'm hoping someone more familiar with this system will be able to identify the change in behaviour! This should fix the memory leak though.