### PR TITLE
AnimatedCharacter: V778. Two similar code fragments were found. Perhaps, this is a typo and 'X' variable should b

### DIFF
--- a/dev/Gems/CryLegacy/Code/Source/CryAction/AnimationGraph/AnimatedCharacter.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryAction/AnimationGraph/AnimatedCharacter.cpp
@@ -428,7 +428,7 @@ bool CAnimatedCharacter::LoadAnimationGraph(IGameObject* pGameObject)
             {
                 m_pAnimDatabase1P = mannequinSys.GetAnimationDatabaseManager().Load(szAnimDatabase);
             }
-            if ((pSourceTable->GetValue("SoundDatabase", szSoundDatabase) || pSourceTable->GetValue("fileSoundDatabase", szAnimDatabase))  && szSoundDatabase)
+            if ((pSourceTable->GetValue("SoundDatabase", szSoundDatabase) || pSourceTable->GetValue("fileSoundDatabase", szSoundDatabase))  && szSoundDatabase)
             {
                 m_pSoundDatabase = mannequinSys.GetAnimationDatabaseManager().Load(szSoundDatabase);
             }


### PR DESCRIPTION
The intention of this code is to look for a key-value pair in a script table and if it exists, to load in the appropriate database. In this instance, if the key is "SoundDatabase", the code would work, however, for "fileSoundDatabase", the sound database would never be loaded in.