### PR TITLE
Geometry: V778. Two similar code fragments were found. Perhaps, this is a typo and 'X' variable should be used inst

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/geometry.cpp
+++ b/dev/Code/CryEngine/CryPhysics/geometry.cpp
@@ -898,7 +898,7 @@ int CPrimitive::Intersect(IGeometry* _pCollider, geom_world_data* pdata1, geom_w
         gtest.contacts->id[0] = gtest.contacts->id[1];
         gtest.contacts->id[1] = i;
         i = gtest.contacts->iPrim[0];
-        gtest.contacts->iPrim[0] = gtest.contacts->id[1];
+        gtest.contacts->iPrim[0] = gtest.contacts->iPrim[1];
         gtest.contacts->iPrim[1] = i;
         pcontacts->n.Flip();
         return 1;


### PR DESCRIPTION
**Bug fix**

From inspection of the code fragment we can see that the intention is to swap `iPrim[0]` and `iPrim[1]` but the programmer has clearly copy pasted the code fragment here... 

```
        i = gtest.contacts->id[0];
        gtest.contacts->id[0] = gtest.contacts->id[1];
        gtest.contacts->id[1] = i;
```

... and not swapped out the variables correctly. Looking elsewhere in this file can also help to confirm that this is what was intended.