### PR TITLE
Material: Assorted fixes

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/Material.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/Material.cpp
@@ -498,9 +498,13 @@ void CMatInfo::SetLayerCount(uint32 nCount)
     if (!m_pMaterialLayers)
     {
         m_pMaterialLayers = new MatLayers;
+        AZ_Assert(m_pMaterialLayers, "Failed to allocate new MatLayers");
     }
 
-    m_pMaterialLayers->resize(nCount);
+    if (m_pMaterialLayers)
+    {
+        m_pMaterialLayers->resize(nCount);
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/dev/Code/Framework/GFxFramework/GFxFramework/MaterialIO/Material.cpp
+++ b/dev/Code/Framework/GFxFramework/GFxFramework/MaterialIO/Material.cpp
@@ -802,8 +802,7 @@ namespace AZ
                 return nullptr;
             }
            
-            rapidxml::xml_node<char>* submaterialNode = nullptr;
-            submaterialNode = materialNode->first_node("SubMaterials");
+            rapidxml::xml_node<char>* submaterialNode = materialNode->first_node("SubMaterials");
 
             if (submaterialNode)
             {

--- a/dev/Code/Framework/GFxFramework/GFxFramework/MaterialIO/Material.cpp
+++ b/dev/Code/Framework/GFxFramework/GFxFramework/MaterialIO/Material.cpp
@@ -595,15 +595,13 @@ namespace AZ
         {
             rapidxml::xml_node<char>* materialNode = m_mtlDoc.first_node(MaterialExport::g_materialString);
 
-            rapidxml::xml_node<char>* submaterialNode = nullptr;
-
             if (!materialNode)
             {
                 AZ_Assert(false, "Attempted to add material to invalid xml document.")
                 return false;
             }
 
-            submaterialNode = materialNode->first_node("SubMaterials");
+            rapidxml::xml_node<char>* submaterialNode = materialNode->first_node("SubMaterials");
 
             if (submaterialNode)
             {

--- a/dev/Code/Framework/GFxFramework/GFxFramework/MaterialIO/Material.cpp
+++ b/dev/Code/Framework/GFxFramework/GFxFramework/MaterialIO/Material.cpp
@@ -538,10 +538,20 @@ namespace AZ
         void MaterialGroup::CreateMtlFile()
         {
             rapidxml::xml_node<char>* rootNode = m_mtlDoc.allocate_node(rapidxml::node_element, MaterialExport::g_materialString);
-            
+            if (!rootNode)
+            {
+                AZ_Assert(false, "Could not allocate node for xml document.");
+                return;
+            }
+
             // MtlFlags
             rapidxml::xml_attribute<char>* attr = m_mtlDoc.allocate_attribute(MaterialExport::g_mtlFlagString,
                 m_mtlDoc.allocate_string(AZStd::to_string(EMaterialFlags::MTL_64BIT_SHADERGENMASK | EMaterialFlags::MTL_FLAG_MULTI_SUBMTL).c_str()));
+            if (!attr) 
+            {
+                AZ_Assert(false, "Could not allocate attribute for xml document.");
+                return;
+            }
             rootNode->append_attribute(attr);
 
             // DccMaterialHash
@@ -551,6 +561,11 @@ namespace AZ
 
             // SubMaterials
             rapidxml::xml_node<char>* subMaterialNode = m_mtlDoc.allocate_node(rapidxml::node_element, MaterialExport::g_subMaterialString);
+            if (!subMaterialNode)
+            {
+                AZ_Assert(false, "Could not allocate subMaterialNode for xml document.");
+                return;
+            }
             rootNode->append_node(subMaterialNode);
 
             m_mtlDoc.append_node(rootNode);

--- a/dev/Gems/EMotionFX/Code/EMotionFX/Rendering/OpenGL2/Source/StandardMaterial.cpp
+++ b/dev/Gems/EMotionFX/Code/EMotionFX/Rendering/OpenGL2/Source/StandardMaterial.cpp
@@ -119,7 +119,7 @@ namespace RenderGL
         {
             EMotionFX::StandardMaterial* stdMaterial = (mMaterial->GetType() == EMotionFX::StandardMaterial::TYPE_ID) ? static_cast<EMotionFX::StandardMaterial*>(mMaterial) : nullptr;
 
-            if (mDiffuseMap == nullptr || mDiffuseMap == gfx->GetTextureCache()->GetWhiteTexture() && stdMaterial)
+            if (stdMaterial && (mDiffuseMap == nullptr || mDiffuseMap == gfx->GetTextureCache()->GetWhiteTexture()))
             {
                 mActiveShader->SetUniform("diffuseColor", stdMaterial->GetDiffuse());
             }


### PR DESCRIPTION
**Code Cleanup**

A selection of mostly benign errors relating to null pointer dereference and double variable assignment, with one slightly more interesting one relating to operator precedence. Comments with commits.