### PR TITLE
ToolbarManager: V522 There might be dereferencing of a potential null pointer 'defaultToolbar'.

### DIFF
--- a/dev/Code/Sandbox/Editor/ToolbarManager.cpp
+++ b/dev/Code/Sandbox/Editor/ToolbarManager.cpp
@@ -631,25 +631,32 @@ void ToolbarManager::RestoreToolbarDefaults(const QString& toolbarName)
         const AmazonToolbar* defaultToolbar = FindDefaultToolbar(toolbarName);
         AmazonToolbar* existingToolbar = FindToolbar(toolbarName);
         Q_ASSERT(existingToolbar != nullptr);
-        const bool isInstantiated = existingToolbar->IsInstantiated();
-
-        if (isInstantiated)
+        if (existingToolbar != nullptr)
         {
-            // We have a QToolBar instance, updated it too
-            for (QAction* action : existingToolbar->Toolbar()->actions())
+            const bool isInstantiated = existingToolbar->IsInstantiated();
+
+            if (isInstantiated)
             {
-                existingToolbar->Toolbar()->removeAction(action);
+                // We have a QToolBar instance, updated it too
+                for (QAction* action : existingToolbar->Toolbar()->actions())
+                {
+                    existingToolbar->Toolbar()->removeAction(action);
+                }
             }
-        }
 
-        existingToolbar->CopyActions(*defaultToolbar);
+            Q_ASSERT(defaultToolbar != nullptr);
+            if (defaultToolbar != nullptr)
+            {
+                existingToolbar->CopyActions(*defaultToolbar);
+            }
 
-        if (isInstantiated)
-        {
-            existingToolbar->SetActionsOnInternalToolbar(m_actionManager);
-            existingToolbar->UpdateAllowedAreas();
+            if (isInstantiated)
+            {
+                existingToolbar->SetActionsOnInternalToolbar(m_actionManager);
+                existingToolbar->UpdateAllowedAreas();
+            }
+            SaveToolbars();
         }
-        SaveToolbars();
     }
     else
     {


### PR DESCRIPTION
**Code cleanup**
V522 There might be dereferencing of a potential null pointer 'existingToolbar'

Add null checks and asserts for `existingToolbar` and `defaultToolbar`. Nothing interesting here, there were a couple of more serious errors flagged in this file which turned out to be false positives so I am just submitting what I fixed whilst looking into those.