### PR TITLE
UIAnimViewNodes: V567 The modification of the 'm_currentMatchIndex' variable is unsequenced relative to another operation on the same variable. This may lead to undefined behavior.

### DIFF
--- a/dev/Code/Sandbox/Editor/TrackView/TrackViewNodes.cpp
+++ b/dev/Code/Sandbox/Editor/TrackView/TrackViewNodes.cpp
@@ -2752,7 +2752,8 @@ void CTrackViewNodesCtrl::ShowNextResult()
 
             if (!items.empty())
             {
-                m_currentMatchIndex = ++m_currentMatchIndex % m_matchCount;
+                ++m_currentMatchIndex;
+                m_currentMatchIndex = m_currentMatchIndex % m_matchCount;
                 ui->treeWidget->selectionModel()->clear();
                 items[m_currentMatchIndex]->setSelected(true);
             }

--- a/dev/Code/Sandbox/Plugins/UiCanvasEditor/Animation/UiAnimViewNodes.cpp
+++ b/dev/Code/Sandbox/Plugins/UiCanvasEditor/Animation/UiAnimViewNodes.cpp
@@ -1594,7 +1594,8 @@ void CUiAnimViewNodesCtrl::ShowNextResult()
 
             if (!items.empty())
             {
-                m_currentMatchIndex = ++m_currentMatchIndex % m_matchCount;
+                ++m_currentMatchIndex;
+                m_currentMatchIndex = m_currentMatchIndex % m_matchCount;
                 ui->treeWidget->selectionModel()->clear();
                 items[m_currentMatchIndex]->setSelected(true);
             }


### PR DESCRIPTION
**Bug Fix**

See https://www.viva64.com/en/w/v567/ for a better explanation of the problems here better than I could hope to explain!

The intention of this code is to increment `m_currentMatchIndex` then to wrap it back around from zero based on `% m_matchCount.` We can make this behaviour much easier to read, and more importantly, not potentially undefined by simply splitting the expression over two lines. It looks like this behaviour will have been written once in TrackViewNodes, then copied into the newer UiAnimViewNodes.