### PR TITLE
AIMemStats: V568 It's odd that 'sizeof()' operator evaluates the size of a pointer to a class, but not the size of the 'vol' class object

### DIFF
--- a/dev/Code/Sandbox/Editor/AI/NavDataGeneration/AIMemStats.cpp
+++ b/dev/Code/Sandbox/Editor/AI/NavDataGeneration/AIMemStats.cpp
@@ -206,7 +206,7 @@ size_t CVolumeNavRegion::MemStats()
     for (unsigned i = 0; i < m_volumes.size(); ++i)
     {
         const CVolume* vol = m_volumes[i];
-        size += sizeof(vol);
+        size += sizeof(*vol);
         if (vol)
         {
             size += vol->m_portalIndices.capacity() * sizeof(int);


### PR DESCRIPTION
**Bug Fix**

The argument of the sizeof() operator is a pointer to a class. In most cases this shows that the programmer forgot to dereference the pointer. In this case it is clear that vol should be dereferenced so that we are returning the size of the object, not the pointer, for the MemStats.

This is probably a deprecated class, but if someone copies this code the bug will propagate. 