### PR TITLE
ControllerPQ: V568 It's odd that 'sizeof()' operator evaluates the size of a pointer to a class, but not the size of the 'this' class object.

### DIFF
--- a/dev/Code/Tools/RC/ResourceCompilerPC/CGA/ControllerPQ.h
+++ b/dev/Code/Tools/RC/ResourceCompilerPC/CGA/ControllerPQ.h
@@ -466,7 +466,7 @@ public:
     virtual void DecodeKey(f32 normalized_time, Vec3& quat) = 0;
     virtual size_t SizeOfThis() const
     {
-        return sizeof(this) + m_pData->GetDataRawSize();
+        return sizeof(*this) + m_pData->GetDataRawSize();
     }
     virtual void GetValueFromKey(uint32 key, Vec3& val) const
     {
@@ -521,7 +521,7 @@ public:
     virtual void DecodeKey(f32 normalized_time, Quat& quat) = 0;
     virtual size_t SizeOfThis() const
     {
-        return sizeof(this) + m_pData->GetDataRawSize();
+        return sizeof(*this) + m_pData->GetDataRawSize();
     }
 
     virtual void GetValueFromKey(uint32 key, Quat& val) const


### PR DESCRIPTION
**Bug Fix**

SizeOfThis is returning the incorrect size as it finding the sum size of the pointer to this and the raw data, as opposed to the sum size of the this object and the raw data.