### PR TITLE
Physinterface: V519. The 'x' variable is assigned values twice successively. Perhaps this is a mistake.

### DIFF
--- a/dev/Code/CryEngine/CryCommon/physinterface.h
+++ b/dev/Code/CryEngine/CryCommon/physinterface.h
@@ -3694,8 +3694,6 @@ struct IPhysicalWorld
             IPhysicalEntity** _pSkipEnts = 0, int _nSkipEnts = 0, PhysicsForeignData _pForeignData = 0, int _iForeignData = 0, ray_hit_cached* _phitLast = 0)
         {
             memset(this, 0, sizeof(*this));
-            objtypes = ent_all;
-            flags = rwi_stop_at_pierceable;
             org = _org;
             dir = _dir;
             objtypes = _objtypes;
@@ -3756,8 +3754,6 @@ struct IPhysicalWorld
             intersection_params* _pip = 0, PhysicsForeignData _pForeignData = 0, int _iForeignData = 0, IPhysicalEntity** _pSkipEnts = 0, int _nSkipEnts = 0)
         {
             memset(this, 0, sizeof(*this));
-            entTypes = ent_all;
-            geomFlagsAny = geom_colltype0 | geom_colltype_player;
             lockContacts.prw = &lockContacts.iActive;
             itype = _itype;
             pprim = _pprim;


### PR DESCRIPTION
This file had a lot of errors flagged in it but many turned out to be false positives or to be strange but correct and probably not worth the risk of fixing. These two minor changes are what was left; simple cases of double assignment without usage in between each assignment.