### PR TITLE
Sandbox/MainWindow: Possible array overrun and possible pointer dereference

### DIFF
--- a/dev/Code/Sandbox/Editor/MainWindow.cpp
+++ b/dev/Code/Sandbox/Editor/MainWindow.cpp
@@ -1953,7 +1953,7 @@ QComboBox* MainWindow::CreateSelectionMaskComboBox()
 
     connect(cb, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [](int index)
     {
-        if (index >= 0 && index < sizeof(s_selectionMasks))
+        if (index >= 0 && index < (sizeof(s_selectionMasks) / sizeof(s_selectionMasks[0])))
         {
             gSettings.objectSelectMask = s_selectionMasks[index].mask;
         }

--- a/dev/Code/Sandbox/Editor/MainWindow.cpp
+++ b/dev/Code/Sandbox/Editor/MainWindow.cpp
@@ -2242,7 +2242,14 @@ void MainWindow::OpenViewPane(QtViewPane* pane)
     }
     else
     {
-        qWarning() << Q_FUNC_INFO << "Invalid pane" << pane->m_id << pane->m_category << pane->m_name;
+        if (pane)
+        {
+            qWarning() << Q_FUNC_INFO << "Invalid pane" << pane->m_id << pane->m_category << pane->m_name;
+        }
+        else
+        {
+            qWarning() << Q_FUNC_INFO << "Invalid pane";
+        }
     }
 }
 


### PR DESCRIPTION
Two minor fixes; one simple dereference of a pointer whilst trying to write out a warning noting that the pointer is null, one mistake in finding the length of an array and causing a possible out of bounds exception.