### PR TITLE
ShaderCache: Code cleanup and array underrun

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderCache.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderCache.cpp
@@ -475,7 +475,8 @@ void CShaderMan::mfInitShadersCache(byte bForLevel, FXShaderCacheCombinations* C
 
             bool bExportEntry = false;
             int size = strlen(str);
-            if (str[size - 1] == 0xa)
+            assert(size > 0);
+            if ((size > 0) && str[size - 1] == 0xa)
             {
                 str[size - 1] = 0;
             }

--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderCache.h
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderCache.h
@@ -423,6 +423,11 @@ struct SShaderGenComb
 
     _inline SShaderGenComb& operator = (const SShaderGenComb& src)
     {
+        if (this == &src)
+        {
+            return *this;
+        }
+
         this->~SShaderGenComb();
         new(this)SShaderGenComb(src);
         return *this;


### PR DESCRIPTION
**Code cleanup**
Protect the assignment operator from self-assignment
Protect against a buffer underrun with a potential index of < 0