### PR TITLE
DX12Device: V557 Array overrun is possible. The value of 'poolType' index could reach 2.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DX12/API/DX12Device.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DX12/API/DX12Device.cpp
@@ -328,6 +328,7 @@ namespace DX12
             break;
         default:
             AZ_Assert(0, "DescriptorPoolType not supported!");
+            return;
         }
         
         m_DescriptorPools[poolType].push_back(AZStd::pair<AZ::u32, AZ::u32>(m_FrameCounter, offset));


### PR DESCRIPTION
**Bug fix**
m_DescriptorPools has size 2, poolType has max value of 2. This is checked in the switch above the code but due to a missing return, the code the assert wants to protect will still be executed.