### PR TITLE
ScriptNetBindings:  V557 Array overrun is possible. The value of 's_chunkIndex ++' index could reach 32.

### DIFF
--- a/dev/Code/CryEngine/CryNetwork/GridMate/Replicas/EntityScriptReplicaChunk.cpp
+++ b/dev/Code/CryEngine/CryNetwork/GridMate/Replicas/EntityScriptReplicaChunk.cpp
@@ -40,9 +40,9 @@ namespace GridMate
 
         AZ_STATIC_ASSERT(EntityScriptReplicaChunk::k_maxScriptableDataSets <= AZ_ARRAY_SIZE(s_nameArray),"Insufficient number of names supplied to EntityScriptDataSet::GetDataSetName()");
 
-        if (s_chunkIndex > EntityScriptReplicaChunk::k_maxScriptableDataSets && EntityScriptReplicaChunk::k_maxScriptableDataSets >= 0)
+        if ((s_chunkIndex >= EntityScriptReplicaChunk::k_maxScriptableDataSets) && (EntityScriptReplicaChunk::k_maxScriptableDataSets >= 0))
         {
-            s_chunkIndex = s_chunkIndex%EntityScriptReplicaChunk::k_maxScriptableDataSets;
+            s_chunkIndex = s_chunkIndex % EntityScriptReplicaChunk::k_maxScriptableDataSets;
         }
 
         return s_nameArray[s_chunkIndex++];

--- a/dev/Code/Framework/AzFramework/AzFramework/Script/ScriptNetBindings.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Script/ScriptNetBindings.cpp
@@ -93,9 +93,9 @@ namespace AzFramework
             "DataSet31","DataSet32"
         };
 
-        if (s_chunkIndex > AZ_ARRAY_SIZE(s_nameArray) && AZ_ARRAY_SIZE(s_nameArray) >= 0)
+        if ((s_chunkIndex >= AZ_ARRAY_SIZE(s_nameArray)) && (AZ_ARRAY_SIZE(s_nameArray) >= 0))
         {
-            s_chunkIndex = s_chunkIndex%AZ_ARRAY_SIZE(s_nameArray);
+            s_chunkIndex = s_chunkIndex % AZ_ARRAY_SIZE(s_nameArray);
         }
 
         return s_nameArray[s_chunkIndex++];


### PR DESCRIPTION
**Bug fix**
A simple case of two off by one errors which could easily cause an out of range exception. 
