### PR TITLE
AlembicCompiler: V562. It's odd to compare a bool type value with a value of N.

### DIFF
--- a/dev/Code/Tools/RC/ResourceCompilerABC/AlembicCompiler.cpp
+++ b/dev/Code/Tools/RC/ResourceCompilerABC/AlembicCompiler.cpp
@@ -2460,7 +2460,7 @@ bool AlembicCompiler::CompileVertices(std::vector<AlembicCompilerVertex>& vertic
     else
     {
         assert(meshData.m_positions.size() == vertices.size());
-        if (!meshData.m_positions.size() == vertices.size())
+        if (meshData.m_positions.size() != vertices.size())
         {
             return false;
         }


### PR DESCRIPTION
The intention of this code appears to be to assert if the position size != vertices size, and then to return out. However, due to incorrect operator precedence this code will assert but not return.