### PR TITLE
D3DHWShaderCompiling: V512. A call of the 'Foo' function will lead to a buffer overflow or underflow

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DHWShaderCompiling.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DHWShaderCompiling.cpp
@@ -4779,7 +4779,7 @@ bool CAsyncShaderTask::CompileAsyncShader(SShaderAsyncInfo* pAsync)
         D3D10CreateBlob(Data.size(), (LPD3D10BLOB*) & pAsync->m_pDevShader);
         LPD3D10BLOB pShader = (LPD3D10BLOB)*&pAsync->m_pDevShader;
         DWORD* pBuf = (DWORD*)pShader->GetBufferPointer();
-        memcpy(pBuf, &Data[0], Data.size());
+        memcpy(pBuf, &Data[0], Data.size() * sizeof(Data[0]));
 
         pAsync->m_pDevShader = (LPD3D10BLOB)pShader;
         pBuf = (DWORD*)pShader->GetBufferPointer();


### PR DESCRIPTION
**Bug fix**

> The analyzer found a potential error related to memory buffer filling, copying or comparison. The error might cause a buffer overflow or, vice versa, buffer underflow.
This is a rather common kind of errors that occurs due to misprints or inattention. What is unpleasant about such errors is that a program might work well for a long time. Due to sheer luck, acceptable values might be found in uninitialized memory. The area of writable memory might not be used.