### PR TITLE
decodeDX9: V512. A call of the 'Foo' function will lead to a buffer overflow or underflow.

### DIFF
--- a/dev/Code/Tools/HLSLCrossCompiler/src/decodeDX9.c
+++ b/dev/Code/Tools/HLSLCrossCompiler/src/decodeDX9.c
@@ -600,7 +600,7 @@ Shader* DecodeDX9BC(const uint32_t* pui32Tokens)
 	uint32_t bDeclareConstantTable = 0;
 	Shader* psShader = hlslcc_calloc(1, sizeof(Shader));
 
-	memset(aui32ImmediateConst, 0, 256);
+	memset(aui32ImmediateConst, 0, 256 * sizeof(uint32_t));
 
 	psShader->ui32MajorVersion = DecodeProgramMajorVersionDX9(*pui32CurrentToken);
 	psShader->ui32MinorVersion = DecodeProgramMinorVersionDX9(*pui32CurrentToken);

--- a/dev/Code/Tools/HLSLCrossCompilerMETAL/src/decodeDX9.c
+++ b/dev/Code/Tools/HLSLCrossCompilerMETAL/src/decodeDX9.c
@@ -601,7 +601,7 @@ ShaderData* DecodeDX9BC(const uint32_t* pui32Tokens)
     uint32_t bDeclareConstantTable = 0;
     ShaderData* psShader = hlslcc_calloc(1, sizeof(ShaderData));
 
-    memset(aui32ImmediateConst, 0, 256);
+    memset(aui32ImmediateConst, 0, 256 * sizeof(uint32_t));
 
 	psShader->ui32MajorVersion = DecodeProgramMajorVersionDX9(*pui32CurrentToken);
 	psShader->ui32MinorVersion = DecodeProgramMinorVersionDX9(*pui32CurrentToken);


### PR DESCRIPTION
> The analyzer found a potential error related to memory buffer filling, copying or comparison. The error might cause a buffer overflow or, vice versa, buffer underflow.
> This is a rather common kind of errors that occurs due to misprints or inattention. What is unpleasant about such errors is that a program might work well for a long time. Due to sheer luck, acceptable values might be found in uninitialized memory. The area of writable memory might not be used.

**Bug fix**
Here a misprint causes the aui32ImmediateConst array to only be partially overwritten with 0; the error is in the calculation of the size.