### PR TITLE
ShaderCache: V512. A call of the 'Foo' function will lead to a buffer overflow or underflow.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderCache.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderCache.cpp
@@ -2237,7 +2237,7 @@ void CShaderMan::_MergeShaders()
         Names[i].bProcessed = true;
         const char* szNameA = Names[i].Name.c_str();
         iLog->Log(" Merging shader resource '%s'...", szNameA);
-        char szDrv[16], szDir[256], szName[256], szExt[32], szName1[256], szName2[256];
+        char szDrv[16], szDir[256], szName[256], szExt[32], szName1[288], szName2[288];
 #ifdef AZ_COMPILER_MSVC
         _splitpath_s(szNameA, szDrv, szDir, szName, szExt);
 #else


### PR DESCRIPTION
**Bug fix**
Increase size of szName1/szName2 by 32 to handle max length of "%s%s", szName, szExt