### PR TITLE
ShaderCore: V512. A call of the 'Foo' function will lead to a buffer overflow or underflow.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderCore.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderCore.cpp
@@ -784,7 +784,7 @@ void CShaderMan:: mfCreateCommonGlobalFlags(const char* szName)
         }
 
 
-        char pszFileName[256];
+        char pszFileName[512];
         sprintf_s(pszFileName, "%s%s", pszShaderExtPath, fileinfo.name);
 
         AZ::IO::HandleType fileHandle = AZ::IO::InvalidHandle;


### PR DESCRIPTION
**Bug fix**
Increase the size of pszFileName to accommodate fileinfo.name size