### PR TITLE
CryThreadRendererContainer: V555. The expression of the 'A - B > 0' kind will work as 'A != B'.

### DIFF
--- a/dev/Code/CryEngine/CryCommon/CryThreadSafeRendererContainer.h
+++ b/dev/Code/CryEngine/CryCommon/CryThreadSafeRendererContainer.h
@@ -542,7 +542,7 @@ inline CThreadSafeRendererContainer<T>::CMemoryPage::CMemoryPage()
     nMemoryBlockBegin = (nMemoryBlockBegin + nObjectAlignment - 1) & ~(nObjectAlignment - 1);
 
     // compute number of avaible elements
-    assert((nMemoryBlockEnd - nMemoryBlockBegin) > 0);
+    assert(nMemoryBlockEnd > nMemoryBlockBegin);
     m_nCapacity = (LONG)((nMemoryBlockEnd - nMemoryBlockBegin) / sizeof(T));
 
     // store pointer to store data to


### PR DESCRIPTION
**Bug fix**
The programmer wanted to check that `nMemoryBlockEnd > nMemoryBlockBegin`. 
However, they wrote `nMemoryBlockEnd  - nMemoryBlockBegin > 0`. 

The types being compared are both unsigned so:
-  if `nMemoryBlockEnd > nMemoryBlockBegin` then the result is above 0. 
- if `nMemoryBlockBegin > nMemoryBlockEnd` then the result is an overflow and still above 0. 

Change the code to check the intended condition.