### PR TITLE
TraceContextBufferedFormatter: V555 The expression 'bufferSize - written > 0' will work as 'bufferSize != written'

### DIFF
--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/Debug/TraceContextBufferedFormatter.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/Debug/TraceContextBufferedFormatter.cpp
@@ -128,7 +128,7 @@ namespace AzToolsFramework
             int written = uuid.ToString(buffer, aznumeric_caster(bufferSize), false);
             if (written > 0)
             {
-                if (bufferSize - written > 0)
+                if (bufferSize > written)
                 {
                     buffer[written - 1] = '\n';
                     buffer[written] = 0;


### PR DESCRIPTION
**Bug fix**
The intention of this code appears to be:
- if `bufferSize` is greater than `written`, we add a `\n` plus `0` to `buffer` and return.

The problem is that as the expression is currently, it will always be true unless `bufferSize == written`. This means that if `written > bufferSize`, the code will write past the end of the buffer.

We just want to check if `bufferSize > written` to avoid the chance of unsigned overflow and off the end memory access.