### PR TITLE
Fix black outlines for r_AntialiasingMode 0/1

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/GraphicsPipeline/PostAA.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/GraphicsPipeline/PostAA.cpp
@@ -588,7 +588,7 @@ void PostAAPass::RenderComposites(CTexture* sourceTexture)
     }
     else
     {
-        const Vec4 temporalParams(0, 0, 0, max(1.0f + CRenderer::CV_r_AntialiasingTAASharpening, 1.0f));
+        const Vec4 temporalParams(0, 0, 0, max(0.5f + CRenderer::CV_r_AntialiasingTAASharpening, 0.5f));
         static CCryNameR paramName("TemporalParams");
         CShaderMan::s_shPostAA->FXSetPSFloat(paramName, &temporalParams, 1);
 


### PR DESCRIPTION
Objects gain black outlines if Anti-aliasing is set to 0 or 1. 
This happens due to TAA_SHARPENING_FACTOR > 1.0f in lerp( cFiltered, OUT.Color.rgb * OUT.Color.rgb, TAA_SHARPENING_FACTOR)
shader PostAAComposites_PS