### PR TITLE
TrackViewTrack: V683 Consider inspecting the loop expression. It is possible that the  'childIndex' variable should be incremented instead of the 'childCount' variable.

### DIFF
--- a/dev/Code/Sandbox/Editor/TrackView/TrackViewTrack.cpp
+++ b/dev/Code/Sandbox/Editor/TrackView/TrackViewTrack.cpp
@@ -598,7 +598,7 @@ void CTrackViewTrack::SelectKeys(const bool bSelected)
     {
         // Affect sub tracks
         unsigned int childCount = GetChildCount();
-        for (unsigned int childIndex = 0; childIndex < childCount; ++childCount)
+        for (unsigned int childIndex = 0; childIndex < childCount; ++childIndex)
         {
             CTrackViewTrack* pChildTrack = static_cast<CTrackViewTrack*>(GetChild(childIndex));
             pChildTrack->SelectKeys(bSelected);


### PR DESCRIPTION
**Bug fix**
As usual, the analyzer appears to be spot on. The intention of this code is to loop through the child tracks and select keys appropriately. However, due to a typo, this does not happen as intended. 