### PR TITLE
UiAnimTrackView: V683 Consider inspecting the loop expression. It is possible that the 'childIndex' variable should be incremented instead of the 'childCount' variable

### DIFF
--- a/dev/Code/Sandbox/Plugins/UiCanvasEditor/Animation/UiAnimViewTrack.cpp
+++ b/dev/Code/Sandbox/Plugins/UiCanvasEditor/Animation/UiAnimViewTrack.cpp
@@ -548,7 +548,7 @@ void CUiAnimViewTrack::SelectKeys(const bool bSelected)
     {
         // Affect sub tracks
         unsigned int childCount = GetChildCount();
-        for (unsigned int childIndex = 0; childIndex < childCount; ++childCount)
+        for (unsigned int childIndex = 0; childIndex < childCount; ++childIndex)
         {
             CUiAnimViewTrack* pChildTrack = static_cast<CUiAnimViewTrack*>(GetChild(childIndex));
             pChildTrack->SelectKeys(bSelected);


### PR DESCRIPTION
**Bug fix**
This appears to be the same as my last pull request, just copied into a new file.

The intention of this code is to iterate the child tracks and select the keys as appropriate, however, due to a typo, the index variable is not getting incremented and the code will not function as intended.