### PR TITLE
TerrainLightGen: V537 Consider reviewing the correctness of 'GetWidth' item's usage.

### DIFF
--- a/dev/Code/Sandbox/Editor/Terrain/TerrainLightGen.cpp
+++ b/dev/Code/Sandbox/Editor/Terrain/TerrainLightGen.cpp
@@ -1069,7 +1069,7 @@ void CTerrainLightGen::GetSubImageStretched(const float fSrcLeft, const float fS
         CHeightmap& roHeightMap = *GetIEditor()->GetHeightmap();
 
         float fTerrainWidth = roHeightMap.GetWidth() * roHeightMap.GetUnitSize();
-        float fTerrainHeight = roHeightMap.GetWidth() * roHeightMap.GetUnitSize();
+        float fTerrainHeight = roHeightMap.GetHeight() * roHeightMap.GetUnitSize();
 
         //////////////////////////////////////////////////////////////////////////
         // Paint vegetation brighness.


### PR DESCRIPTION
**Bug fix**
This just looks like a copy and paste gone wrong. Terrain height was being calculated from the width instead of the height.