### PR TITLE
Shader: V791 The initial value of the index in the nested loop equals 'i'. Perhaps, 'i + 1' should be used instead.

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/Shader.h
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/Shader.h
@@ -877,7 +877,7 @@ _inline void SortLightTypes(int Types[4], int nCount)
     {
         for (int i = 0; i < 4; i++)
         {
-            for (int j = i; j < 4; j++)
+            for (int j = i + 1; j < 4; j++)
             {
                 if (Types[i] > Types[j])
                 {


### PR DESCRIPTION
**Code cleanup**

The intention of this code is to loop through and sort Types[] by exchanging elements where appropriate. This code will do that correctly, however, there is an unnecessary loop where i == j and nothing will be exchanged.