### PR TITLE
Linux mismatch free and delete calls

### DIFF
--- a/dev/Code/CryEngine/CryCommon/CryMemoryManager_impl.h
+++ b/dev/Code/CryEngine/CryCommon/CryMemoryManager_impl.h
@@ -404,7 +404,7 @@ size_t CryCrtSize(void* p)
 
 //This code causes a seg fault in clang in profile builds if optimizations are turned on. In XCode 6.4
 //TODO: Try to remove in a future version of XCode.
-#if defined(AZ_MONOLITHIC_BUILD)&& (defined(IOS) || defined(APPLETV))
+#if defined(AZ_MONOLITHIC_BUILD)&& (defined(IOS) || defined(APPLETV)) || defined(LINUX)
 #pragma clang optimize off
 #endif
 

--- a/dev/Code/CryEngine/CryCommon/CryMemoryManager_impl.h
+++ b/dev/Code/CryEngine/CryCommon/CryMemoryManager_impl.h
@@ -468,7 +468,7 @@ void __cdecl operator delete[](void* p, const std::nothrow_t&) throw()
 	MEMREPLAY_SCOPE_FREE(p);
 }
 
-#if defined(AZ_MONOLITHIC_BUILD)&& (defined(IOS) || defined(APPLETV))
+#if defined(AZ_MONOLITHIC_BUILD)&& (defined(IOS) || defined(APPLETV)) || defined(LINUX)
 #pragma clang optimize on
 #endif
 


### PR DESCRIPTION
Valgrind detects that due to clang optimization there is mismatch between free and delete calls. The clang optimization should be also disabled for Linux as well.