### PR TITLE
Support vcvars args configuration for VS2017

### DIFF
--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/compile_rules_win_x64_win_x64_vs2017.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/compile_rules_win_x64_win_x64_vs2017.py
@@ -41,7 +41,7 @@ def load_win_x64_win_x64_vs2017_common_settings(conf):
     windows_kit = conf.options.win_vs2017_winkit
     vcvarsall_args = windows_kit + ' ' + conf.options.win_vs2017_vcvarsall_args
     try:
-        conf.auto_detect_msvc_compiler('msvc 15', 'x64', vcvarsall_args)
+        conf.auto_detect_msvc_compiler('msvc 15', 'x64', windows_kit)
     except:
         Logs.warn('Unable to find Visual Studio 2017 ({}) C++ compiler and/or Windows Kit {}, removing build target'.format(conf.options.win_vs2017_vswhere_args, vcvarsall_args))
         conf.mark_supported_platform_for_removal(PLATFORM)

--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/mscv_helper.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/mscv_helper.py
@@ -629,9 +629,10 @@ def gather_msvc_2017_targets(conf, versions, version, windows_kit, vc_path):
     #Looking for normal MSVC compilers!
     targets = []
     vcvarsall_bat = os.path.join(vc_path, 'VC', 'Auxiliary', 'Build', 'vcvarsall.bat')
+    vcvarsall_args = conf.options.win_vs2017_vcvarsall_args
     if os.path.isfile(vcvarsall_bat):
         try:
-            targets.append(('x64', ('x64', conf.get_msvc_version('msvc', version, 'x64', windows_kit, vcvarsall_bat))))
+            targets.append(('x64', ('x64', conf.get_msvc_version('msvc', version, 'x64', windows_kit, vcvarsall_bat, vcvarsall_args))))
         except conf.errors.ConfigurationError:
             pass
     if targets:
@@ -651,7 +652,7 @@ def _get_prog_names(conf, compiler):
     return compiler_name, linker_name, lib_name
     
 @conf
-def get_msvc_version(conf, compiler, version, target, windows_kit, vcvars):
+def get_msvc_version(conf, compiler, version, target, windows_kit, vcvars, vcvars_args=""):
     """
     Create a bat file to obtain the location of the libraries
 
@@ -667,11 +668,11 @@ def get_msvc_version(conf, compiler, version, target, windows_kit, vcvars):
     batfile.write("""@echo off
 set INCLUDE=
 set LIB=
-call "%s" %s %s
+call "%s" %s %s %s
 echo PATH=%%PATH%%
 echo INCLUDE=%%INCLUDE%%
 echo LIB=%%LIB%%;%%LIBPATH%%
-""" % (vcvars,target,windows_kit))
+""" % (vcvars,target,windows_kit,vcvars_args))
     sout = conf.cmd_and_log(['cmd', '/E:on', '/V:on', '/C', batfile.abspath()])
     lines = sout.splitlines()
     


### PR DESCRIPTION
Support using --win-vs2017-vcvarsall-args default setting. Now it can be configured as follows:
 "default_value": "-vcvars_ver=14.13" to stick with specific vs version