### PR TITLE
Add distcc support for Linux

### DIFF
--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/clangdeps.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/clangdeps.py
@@ -299,6 +299,10 @@ def wrap_compiled_task_clang(classname):
             node = None
             assert os.path.isabs(path)
 
+            # Support distcc - skip distcc-style self-dependency
+            if '<built-in>' in path:
+                continue
+
             drive_hack = False
             node = path_to_node(bld.root, path, cached_nodes, drive_hack)
 

--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/compile_settings_clang.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/compile_settings_clang.py
@@ -74,6 +74,9 @@ def load_clang_common_settings(conf):
         '-Werror',
         '-Wno-unknown-warning-option',
 
+        # Support distcc - suppress "argument unused during compilation: '-stdlib=libc++'"
+        '-Wno-unused-command-line-argument',
+
         # Disabled warnings (please do not disable any others without first consulting ly-warnings)
         '-Wno-#pragma-messages',
         '-Wno-absolute-value',


### PR DESCRIPTION
Changes in WAF system required to start using distcc for Linux dedicated server compilation