### PR TITLE
1.15 integration issues

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/StatObjPhys.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/StatObjPhys.cpp
@@ -1916,8 +1916,8 @@ IStatObj* CStatObj::UpdateVertices(strided_pointer<Vec3> pVtx, strided_pointer<V
                 mesh->UnlockStream(VSF_TANGENTS);
             }
             mesh->UnlockStream(VSF_GENERAL);
-            mesh->UnLockForThreadAccess();
         }
+        mesh->UnLockForThreadAccess();
     }
     return pObj;
 }

--- a/dev/Code/CryEngine/Cry3DEngine/WaterVolumeRenderNode.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/WaterVolumeRenderNode.cpp
@@ -1365,7 +1365,7 @@ int OnWaterUpdate(const EventPhysAreaChange* pEvent)
         pe_status_area sa;
         sa.bUniformOnly = true;
         MARK_UNUSED sa.ctr;
-        if (pWVRN->GetPhysics() != pEvent->pEntity || !pEvent->pEntity->GetStatus(&sa))
+        if (pWVRN->>GetPhysArea() != pEvent->pEntity || !pEvent->pEntity->GetStatus(&sa))
         {
             return 1;
         }

--- a/dev/Code/CryEngine/Cry3DEngine/WaterVolumeRenderNode.h
+++ b/dev/Code/CryEngine/Cry3DEngine/WaterVolumeRenderNode.h
@@ -148,6 +148,7 @@ public:
 
     virtual IPhysicalEntity* GetPhysics() const;
     virtual void SetPhysics(IPhysicalEntity*);
+    inline IPhysicalEntity* GetPhysArea() const { return m_pPhysArea; }
 
     virtual void CheckPhysicalized();
     virtual void Physicalize(bool bInstant = false);

--- a/dev/Code/CryEngine/Cry3DEngine/terrain_sector.h
+++ b/dev/Code/CryEngine/Cry3DEngine/terrain_sector.h
@@ -417,6 +417,7 @@ public:
         , m_pProcObjPoolPtr(0)
         , m_nGSMFrameId(0)
         , m_pRNTmpData(0)
+        , m_bProcObjectsReady(0)
     {
         memset(&m_DistanceToCamera, 0, sizeof(m_DistanceToCamera));
     }

--- a/dev/Code/CryEngine/CryCommon/VariableCollection.h
+++ b/dev/Code/CryEngine/CryCommon/VariableCollection.h
@@ -25,6 +25,8 @@
 # define USING_VARIABLE_COLLECTION_XML_DESCRIPTION_CREATION
 #endif
 
+#include <ITimer.h>
+
 #ifdef DEBUG_VARIABLE_COLLECTION
 #include "IAISystem.h"
 #include "IAIDebugRenderer.h"

--- a/dev/Code/CryEngine/CrySystem/MiniGUI/MiniTable.cpp
+++ b/dev/Code/CryEngine/CrySystem/MiniGUI/MiniTable.cpp
@@ -70,7 +70,7 @@ void CMiniTable::OnPaint(CDrawContext& dc)
     float y = m_rect.top + indent;
 
     const int nColumns = m_columns.size();
-    int numEntries = m_columns[0].cells.size();
+    int numEntries = nColumns > 0 ? m_columns[0].cells.size() : 0;
 
     int startIdx = 0;
     int endIdx = numEntries;

--- a/dev/Code/CryEngine/CrySystem/System.cpp
+++ b/dev/Code/CryEngine/CrySystem/System.cpp
@@ -974,7 +974,9 @@ void CSystem::Quit()
     {
         GetIRenderer()->RestoreGamma();
     }
-    
+
+    SAFE_RELEASE(m_env.pNetwork);
+
 #if CAPTURE_REPLAY_LOG
     CryGetIMemReplay()->Stop();
 #endif
@@ -1564,7 +1566,7 @@ bool CSystem::UpdatePreTickBus(int updateFlags, int nPauseMode)
         m_env.pLog->Update();
     }
 
-#if !defined(RELEASE) || defined(RELEASE_LOGGING)
+#if !defined(RELEASE) || defined(RELEASE_LOGGING) || defined(ENABLE_PROFILING_CODE)
     GetIRemoteConsole()->Update();
 #endif
 
@@ -1801,6 +1803,12 @@ bool CSystem::UpdatePreTickBus(int updateFlags, int nPauseMode)
     {
         FRAME_PROFILER("SysUpdate:Console", this, PROFILE_SYSTEM);
         m_env.pConsole->Update();
+    }
+
+    if (IsQuitting())
+    {
+        Quit();
+        return (false);
     }
 
 #ifndef EXCLUDE_UPDATE_ON_CONSOLE

--- a/dev/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -2029,7 +2029,7 @@ bool CSystem::InitPhysicsRenderer(const SSystemInitParams& initParams)
     {
         m_pPhysRenderer = new CPhysRenderer;
         m_pPhysRenderer->Init(); // needs to be created after physics and renderer
-        m_p_draw_helpers_str = REGISTER_STRING_CB("p_draw_helpers", "0", VF_CHEAT,
+        m_p_draw_helpers_str = REGISTER_STRING_CB("p_draw_helpers", "0", VF_DEV_ONLY,
                 "Same as p_draw_helpers_num, but encoded in letters\n"
                 "Usage [Entity_Types]_[Helper_Types] - [t|s|r|R|l|i|g|a|y|e]_[g|c|b|l|t(#)]\n"
                 "Entity Types:\n"
@@ -3569,7 +3569,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
 #endif // #if defined(DEDICATED_SERVER)
 
 #if !defined(CONSOLE)
-#if !defined(_RELEASE)
+#if !defined(_RELEASE) || defined(DEDICATED_SERVER)
     bool isDaemonMode = (m_pCmdLine->FindArg(eCLAT_Pre, "daemon") != 0);
 #else
     bool isDaemonMode = false;
@@ -3595,7 +3595,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
 #elif defined(USE_ANDROIDCONSOLE)
         CAndroidConsole* pConsole = new CAndroidConsole();
 #else
-        CNULLConsole* pConsole = new CNULLConsole(false);
+        CNULLConsole* pConsole = new CNULLConsole(isDaemonMode);
 #endif
         m_pTextModeConsole = static_cast<ITextModeConsole*>(pConsole);
 
@@ -3692,6 +3692,8 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
         {
             m_env.pLog = startupParams.pLog;
         }
+
+        LogVersion();
 
         //here we should be good to ask Crypak to do something
 
@@ -3826,8 +3828,6 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
 #endif
 
         InitFileSystem_LoadEngineFolders(startupParams);
-
-        LogVersion();
 
         // CPU features detection.
         m_pCpu = new CCpuFeatures;
@@ -4312,7 +4312,8 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
         //////////////////////////////////////////////////////////////////////////
         if (!startupParams.bPreview && !startupParams.bShaderCacheGen)
         {
-            if (!gEnv->IsDedicated() || !m_svAISystem || m_svAISystem->GetIVal())
+            if ((gEnv->IsDedicated() && (!m_svAISystem || m_svAISystem->GetIVal())) ||
+                (!gEnv->IsDedicated() && (!m_clAISystem || m_clAISystem->GetIVal())))
             {
                 AZ_Printf(AZ_TRACE_SYSTEM_WINDOW, "Initializing AI System");
                 INDENT_LOG_DURING_SCOPE();

--- a/dev/Code/CryEngine/RenderDll/Common/Renderer.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Renderer.cpp
@@ -1624,7 +1624,7 @@ void CRenderer::InitRenderer()
         "  1: Visualize g-buffer and l-buffers\n"
         "  2: Debug deferred lighting fillrate (brighter colors means more expensive)\n");
 
-    DefineConstIntCVar3("r_DebugGBuffer", CV_r_DeferredShadingDebugGBuffer, 0, VF_NULL,
+    DefineConstIntCVar3("r_DebugGBuffer", CV_r_DeferredShadingDebugGBuffer, 0, VF_DEV_ONLY,
         "Debug view for gbuffer attributes\n"
         "  0 - Disabled\n"
         "  1 - Normals\n"

--- a/dev/Code/CryEngine/RenderDll/Common/RendererDefs.h
+++ b/dev/Code/CryEngine/RenderDll/Common/RendererDefs.h
@@ -572,7 +572,7 @@ typedef uintptr_t SOCKET;
 #       endif
 #   else
         typedef IDXGIFactory1           DXGIFactory;
-#       if !defined(ANDROID) && !defined(APPLE)
+#       if !defined(ANDROID) && !defined(APPLE) && !defined(LINUX)
             typedef IDXGIDevice1        DXGIDevice;
 #       endif
         typedef IDXGIAdapter1           DXGIAdapter;


### PR DESCRIPTION
Fix for CRenderMesh assert due to mismatched lock/unlock
Fix vtable call
Valgrind uninitialized value fix
Fix error on release build - "VariableCollection.h(84): error C2027: use of undefined type 'ITimer'"
PerfHUD fix
Disconnect from network on exit
Client crashes on close game: recheck if bQuit flag was set above
Enable remote console on performance build
Daemon mode fix for Linux dedicated server
Fix log backup feature
Compilation fix for Linux
Legacy AI init respects both AI enabled cvars