### PR TITLE
Framework integration issues

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -1004,6 +1004,7 @@ namespace AZ
 #else
         // http://man7.org/linux/man-pages/man5/proc.5.html
         size_t pathLen = readlink("/proc/self/exe", exeDirectory, AZ_ARRAY_SIZE(exeDirectory));
+        exeDirectory[pathLen] = '\0';
 #endif // MSVC
 
         char* exeDirEnd = exeDirectory + pathLen;

--- a/dev/Code/Framework/AzCore/AzCore/Memory/HphaSchema.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/Memory/HphaSchema.cpp
@@ -319,8 +319,8 @@ namespace AZ {
             {
                 BL_USED = 1
             };
-            block_header* mPrev;
-            size_t mSizeAndFlags;
+            block_header* mPrev { nullptr };
+            size_t mSizeAndFlags { 0 };
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning (disable : 4200) // zero sized array
@@ -2239,7 +2239,10 @@ namespace AZ {
         return VirtualAlloc(NULL, size, MEM_COMMIT, PAGE_READWRITE);
 #   endif
 #else
-        return memalign(align, size);
+        // Use the same behaviour as VirtualAlloc
+        void* mem = memalign(align, size);
+        memset(mem, 0, size);
+        return mem;
 #endif
     }
 

--- a/dev/Code/Framework/AzCore/AzCore/std/containers/deque.h
+++ b/dev/Code/Framework/AzCore/AzCore/std/containers/deque.h
@@ -572,6 +572,13 @@ namespace AZStd
             }
         }
 
+#ifdef AZ_HAS_INITIALIZERS_LIST
+        AZ_FORCE_INLINE void insert(const_iterator insertPos, std::initializer_list<value_type> list)
+        {
+            insert(insertPos, list.begin(), list.end());
+        }
+#endif // #ifdef AZ_HAS_INITIALIZERS_LIST
+
         template<class InputIterator>
         AZ_FORCE_INLINE void insert(const_iterator insertPos, InputIterator first, InputIterator last)
         {

--- a/dev/Code/Framework/AzFramework/AzFramework/Math/MathUtils.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Math/MathUtils.cpp
@@ -14,8 +14,13 @@
 
 namespace AzFramework
 {
+#if defined(AZ_COMPILER_MSVC)
 #pragma warning( push )         // disable deprecated warning from our own internal calls until they are removed
 #pragma warning(disable: 4996)
+#elif defined(AZ_COMPILER_CLANG)
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#endif
 
     // Technique from published work available here
     // https://d3cw3dd2w32x2b.cloudfront.net/wp-content/uploads/2012/07/euler-angles1.pdf (Extracting Euler Angles from a Rotation Matrix - Mike Day, Insomniac Games mday@insomniacgames.com)
@@ -210,5 +215,9 @@ namespace AzFramework
         return transform;
     }
 
+#if defined(AZ_COMPILER_MSVC)
 #pragma warning( pop )
+#elif defined(AZ_COMPILER_CLANG)
+ _Pragma("GCC diagnostic pop")
+#endif
 } // namespace AzFramework

--- a/dev/Code/Framework/AzFramework/AzFramework/Physics/RigidBody.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Physics/RigidBody.h
@@ -48,6 +48,8 @@ namespace Physics
         Full,
     };
 
+    class RigidBody;
+
     /**
      * 
      */

--- a/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
+++ b/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
@@ -4228,7 +4228,12 @@ CarrierImpl::QueryStatistics(ConnectionID id, TrafficControl::Statistics* lastSe
     }
 
     Connection* conn = static_cast<Connection*>(id);
-    AZ_Assert(AZStd::find(m_connections.begin(), m_connections.end(), conn) != m_connections.end(), "This connection ID is not valid! Not in the list 0x%08x", conn);
+    bool validConnection = AZStd::find(m_connections.begin(), m_connections.end(), conn) != m_connections.end();
+    AZ_Assert(validConnection, "This connection ID is not valid! Not in the list 0x%08x", conn);
+    if (!validConnection)
+    {
+        return Carrier::CST_DISCONNECTED;
+    }
     {
         AZStd::lock_guard<AZStd::mutex> statsLock(conn->m_statsLock);
         if (lastSecond)


### PR DESCRIPTION
Linux fix readlink doesn't put zero terminated symbol
Valgrind fix for using non-initialized variables on linux dedicated server
Use the same allocation behavior on Linux as VirtualAlloc on Windows
Insert implementation with initialization list from standard is missing
Linux compilation fixes
