### PR TITLE
Bugfix: Peer can not activate netsynced entities after disconnecting …

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.h
@@ -266,6 +266,12 @@ namespace AzFramework
             m_overrideRootSliceLoadAuthoritative = true;
         }
 
+		void ClearRootSliceLoadModeOverride()
+		{
+			m_isAuthoritativeRootSliceLoad = false;
+			m_overrideRootSliceLoadAuthoritative = false;
+		}
+
     private:
         /**
          * \brief True if the root slice is to be loaded authoritatively

--- a/dev/Gems/CryLegacy/Code/Source/CryAction/Network/GameContextBridge.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryAction/Network/GameContextBridge.cpp
@@ -126,6 +126,7 @@ void CGameContextBridge::OnContextBridgeDataDeactivated(CGameContextBridgeDataPt
 {
     AZ_Assert(m_netData == netData, "This is not our data!");
     m_netData = nullptr;
+	ClearRootSliceLoadModeOverride();
 }
 
 void CGameContextBridge::OnStartGameContext(const SGameStartParams* pGameStartParams)


### PR DESCRIPTION
…from server

Fixes the issue where a peer disconnecting from a server could not automatically activate net-synced entities when loading a new local-only level.