### PR TITLE
lds cpu usage optimization while no session hosted/level loaded

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/PostEffectGroup.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/PostEffectGroup.cpp
@@ -210,7 +210,9 @@ PostEffectGroupManager::PostEffectGroupManager()
     PostEffectGroup* base = new PostEffectGroup(this, "Base", PostEffectGroup::kPriorityBase, true, 0.f);
     base->SetEnable(true);
     m_groups.push_back(std::unique_ptr<PostEffectGroup>(base));
+#ifndef DEDICATED_SERVER
     gEnv->pRenderer->RegisterSyncWithMainListener(this);
+#endif
     if (gEnv->IsEditor())
     {
         //  Only monitor assets in the editor.
@@ -220,7 +222,9 @@ PostEffectGroupManager::PostEffectGroupManager()
 
 PostEffectGroupManager::~PostEffectGroupManager()
 {
+#ifndef DEDICATED_SERVER
     gEnv->pRenderer->RemoveSyncWithMainListener(this);
+#endif
     if (gEnv->IsEditor())
     {
         AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();

--- a/dev/Code/CryEngine/CrySystem/StreamEngine/NullStreamEngine.h
+++ b/dev/Code/CryEngine/CrySystem/StreamEngine/NullStreamEngine.h
@@ -1,0 +1,103 @@
+// Description : Streaming Engine null realization
+
+
+#ifndef CRYINCLUDE_CRYSYSTEM_STREAMENGINE_NULL_STREAMENGINE_H
+#define CRYINCLUDE_CRYSYSTEM_STREAMENGINE_NULL_STREAMENGINE_H
+#pragma once
+
+
+#include "IStreamEngine.h"
+
+//////////////////////////////////////////////////////////////////////////
+class CNullStreamEngine
+    : public IStreamEngine
+{
+public:
+    CNullStreamEngine()
+    {
+#ifdef STREAMENGINE_ENABLE_STATS
+        m_Statistics.nPendingReadBytes = 0;
+
+        m_Statistics.nCurrentAsyncCount = 0;
+        m_Statistics.nCurrentDecryptCount = 0;
+        m_Statistics.nCurrentDecompressCount = 0;
+        m_Statistics.nCurrentFinishedCount = 0;
+#endif
+    }
+
+    virtual IReadStreamPtr StartRead (const EStreamTaskType tSource, const char* szFile, IStreamCallback* pCallback = NULL, const StreamReadParams* pParams = NULL) { return NULL; }
+
+    // Pass a callback to preRequestCallback if you need to execute code right before the requests get enqueued; the callback is called only once per execution
+    virtual size_t StartBatchRead(IReadStreamPtr* pStreamsOut, const StreamReadBatchParams* pReqs, size_t numReqs, AZStd::function<void ()>* preRequestCallback = nullptr) { return 0; }
+
+    // Call this methods before/after submitting large number of new requests.
+    virtual void BeginReadGroup() {}
+    virtual void EndReadGroup() {}
+
+    // Pause/resumes streaming of specific data types.
+    // nPauseTypesBitmask is a bit mask of data types (ex, 1<<eStreamTaskTypeGeometry)
+    virtual void PauseStreaming(bool bPause, uint32 nPauseTypesBitmask) {}
+
+    // Get pause bit mask
+    virtual uint32 GetPauseMask() const { return 0; }
+
+    // Pause/resumes any IO active from the streaming engine
+    virtual void PauseIO(bool bPause) {}
+
+    // Description:
+    //   Is the streaming data available on harddisc for fast streaming
+    virtual bool IsStreamDataOnHDD() const { return false; }
+
+    // Description:
+    //   Inform streaming engine that the streaming data is available on HDD
+    virtual void SetStreamDataOnHDD(bool bFlag) {}
+
+    // Description:
+    //   Per frame update ofthe streaming engine, synchronous events are dispatched from this function.
+    virtual void Update() {}
+
+    // Description:
+    //   Per frame update of the streaming engine, synchronous events are dispatched from this function, by particular TypesBitmask.
+    virtual void Update(uint32 nUpdateTypesBitmask) {}
+
+    // Description:
+    //   Waits until all submitted requests are complete. (can abort all reads which are currently in flight)
+    virtual void UpdateAndWait(bool bAbortAll = false) {}
+
+    // Description:
+    //   Puts the memory statistics into the given sizer object.
+    //   According to the specifications in interface ICrySizer.
+    // See also:
+    //   ICrySizer
+    virtual void GetMemoryStatistics(ICrySizer* pSizer) {}
+
+#if defined(STREAMENGINE_ENABLE_STATS)
+    // Description:
+    //   Returns the streaming statistics collected from the previous call.
+    virtual SStreamEngineStatistics& GetStreamingStatistics() { return m_Statistics; }
+    virtual void ClearStatistics() {}
+
+    // Description:
+    //   returns the bandwidth used for the given type of streaming task
+    virtual void GetBandwidthStats(EStreamTaskType type, float* bandwidth) {}
+#endif
+
+    // Description:
+    //   Returns the counts of open streaming requests.
+    virtual void GetStreamingOpenStatistics(SStreamEngineOpenStats& openStatsOut) {}
+
+    virtual const char* GetStreamTaskTypeName(EStreamTaskType type) { return ""; }
+
+#if defined(STREAMENGINE_ENABLE_LISTENER)
+    // Description:
+    //   Sets up a listener for stream events (used for statoscope)
+    virtual void SetListener(IStreamEngineListener* pListener) {}
+    virtual IStreamEngineListener* GetListener() { return nullptr; }
+#endif
+
+#ifdef STREAMENGINE_ENABLE_STATS
+    SStreamEngineStatistics m_Statistics;
+#endif
+};
+
+#endif // CRYINCLUDE_CRYSYSTEM_STREAMENGINE_NULL_STREAMENGINE_H

--- a/dev/Code/CryEngine/CrySystem/System.h
+++ b/dev/Code/CryEngine/CrySystem/System.h
@@ -922,8 +922,8 @@ private: // ------------------------------------------------------
 
     std::map<CCryNameCRC, WIN_HMODULE> m_moduleDLLHandles;
 
-    //! THe streaming engine
-    class CStreamEngine* m_pStreamEngine;
+    //! The streaming engine
+    struct IStreamEngine* m_pStreamEngine;
 
     //! current active process
     IProcess* m_pProcess;

--- a/dev/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -4135,7 +4135,6 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
         //////////////////////////////////////////////////////////////////////////
         // AUDIO
         //////////////////////////////////////////////////////////////////////////
-        if (!startupParams.bMinimal)
         {
             if (!InitAudioSystem(startupParams))
             {
@@ -4390,7 +4389,7 @@ bool CSystem::Init(const SSystemInitParams& startupParams)
         //////////////////////////////////////////////////////////////////////////
         // Initialize Gems
         //////////////////////////////////////////////////////////////////////////
-        if (!startupParams.bPreview && !startupParams.bShaderCacheGen && !startupParams.bMinimal)
+        if (!startupParams.bPreview && !startupParams.bShaderCacheGen)
         {
             if (m_pUserCallback)
             {

--- a/dev/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -103,6 +103,7 @@
 #include "Log.h"
 #include "XML/xml.h"
 #include "StreamEngine/StreamEngine.h"
+#include "StreamEngine/NullStreamEngine.h"
 #include "BudgetingSystem.h"
 #include "PhysRenderer.h"
 #include "LocalizedStringManager.h"
@@ -2867,7 +2868,11 @@ bool CSystem::InitStreamEngine()
         m_pUserCallback->OnInitProgress("Initializing Stream Engine...");
     }
 
+#ifdef DEDICATED_SERVER
+    m_pStreamEngine = new CNullStreamEngine();
+#else
     m_pStreamEngine = new CStreamEngine();
+#endif
 
     return true;
 }

--- a/dev/Code/CryEngine/CrySystem/crysystem.waf_files
+++ b/dev/Code/CryEngine/CrySystem/crysystem.waf_files
@@ -375,7 +375,8 @@
             "StreamEngine/StreamAsyncFileRequest.h",
             "StreamEngine/StreamEngine.h",
             "StreamEngine/StreamIOThread.h",
-            "StreamEngine/StreamReadStream.h"
+            "StreamEngine/StreamReadStream.h",
+            "StreamEngine/NullStreamEngine.h"
         ]
     },
     "CrySystem_Tests_uber.cpp":

--- a/dev/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
+++ b/dev/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
@@ -144,6 +144,11 @@ namespace AZ
 
             /// Specifies which system components to create & activate. If no tags specified, all system components are used. Specify as comma separated list.
             const char* m_systemComponentTags = nullptr;
+
+            /// Specifies amount of threads used by job system
+            int m_jobThreadCount = 1;
+            /// Specifies amount of threads used by asset manager system
+            int m_assetManagerThreadCount = 1;
         };
 
         ComponentApplication();

--- a/dev/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
@@ -23,6 +23,9 @@
 #include <AzCore/std/parallel/thread.h>
 #include <AzCore/Math/MathUtils.h>
 
+#include <AzCore/Component/ComponentApplication.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
+
 namespace AZ
 {
     //=========================================================================
@@ -51,6 +54,17 @@ namespace AZ
         JobManagerThreadDesc threadDesc;
 
         int numberOfWorkerThreads = m_numberOfWorkerThreads;
+#ifdef DEDICATED_SERVER
+        AZ::ComponentApplication* app = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(app, &AZ::ComponentApplicationBus::Events::GetApplication);
+
+        if (app != nullptr)
+        {
+            const auto& params = app->GetStartupParameters();
+            numberOfWorkerThreads = params.m_jobThreadCount;
+        }
+#endif // DEDICATED_SERVER
+
         if (numberOfWorkerThreads <= 0)
         {
             numberOfWorkerThreads = AZ::GetMin(static_cast<unsigned int>(desc.m_workerThreads.capacity()), AZStd::thread::hardware_concurrency());

--- a/dev/Code/Framework/AzFramework/AzFramework/Components/SessionTickComponent.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Components/SessionTickComponent.cpp
@@ -1,0 +1,28 @@
+#include "SessionTickComponent.h"
+
+namespace AZ
+{
+    void SessionTickComponent::Activate()
+    {
+#ifdef DEDICATED_SERVER
+        AzFramework::NetBindingSystemEventsBus::Handler::BusConnect();
+#else
+        AZ::TickBus::Handler::BusConnect();
+#endif
+    }
+
+    void SessionTickComponent::Deactivate()
+    {
+#ifdef DEDICATED_SERVER
+        AzFramework::NetBindingSystemEventsBus::Handler::BusDisconnect();
+#endif
+        AZ::TickBus::Handler::BusDisconnect();
+    }
+
+    void SessionTickComponent::OnNetworkSessionCreated(GridMate::GridSession* session)
+    {
+        (void)session;
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+} // namespace AZ

--- a/dev/Code/Framework/AzFramework/AzFramework/Components/SessionTickComponent.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Components/SessionTickComponent.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzFramework/Network/NetBindingSystemBus.h>
+
+namespace AZ
+{
+    /**
+     * Abstract Component for logic that need to handle Tick update in game session
+     * for dedicated server Tick update start only after session is hosted, to prevent CPU load in standby mode
+     * for game and editor Tick update start after component activation
+     */
+    class SessionTickComponent
+        : public Component
+        , public TickBus::Handler
+        , public AzFramework::NetBindingSystemEventsBus::Handler
+    {
+    public:
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+
+        // NetBindingSystemBus
+        void OnNetworkSessionCreated(GridMate::GridSession* session) override;
+        ////////////////////////////////////////////////////////////////////////
+
+    };
+}

--- a/dev/Code/Framework/AzFramework/AzFramework/azframework.waf_files
+++ b/dev/Code/Framework/AzFramework/AzFramework/azframework.waf_files
@@ -64,7 +64,9 @@
             "Components/BootstrapReaderComponent.cpp",
             "Components/CameraBus.h",
             "Components/ConsoleBus.h",
-            "Components/ConsoleBus.cpp"
+            "Components/ConsoleBus.cpp",
+            "Components/SessionTickComponent.cpp",
+            "Components/SessionTickComponent.h"
         ],
         "FileFunc": [
             "FileFunc/FileFunc.h",

--- a/dev/Code/Launcher/DedicatedLauncher/Main.cpp
+++ b/dev/Code/Launcher/DedicatedLauncher/Main.cpp
@@ -277,6 +277,18 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 
 
         AzGameFramework::GameApplication::StartupParameters gameAppParams;
+
+        const char* sThreadCount = strstr(lpCmdLine, "job_thread_count");
+        if (sThreadCount != nullptr)
+        {
+            gameAppParams.m_jobThreadCount = atoi(sThreadCount);
+        }
+        sThreadCount = strstr(lpCmdLine, "asset_thread_count");
+        if (sThreadCount != nullptr)
+        {
+            gameAppParams.m_assetManagerThreadCount = atoi(sThreadCount);
+        }
+
 #ifdef AZ_MONOLITHIC_BUILD
         gameAppParams.m_createStaticModulesCallback = CreateStaticModules;
         gameAppParams.m_loadDynamicModules = false;

--- a/dev/Code/Launcher/LinuxLauncher/Main.cpp
+++ b/dev/Code/Launcher/LinuxLauncher/Main.cpp
@@ -275,7 +275,7 @@ int RunGame(const char* commandLine)
     startupParams.sLogFileName = "Server.log";
     startupParams.bDedicatedServer = true;
     startupParams.pUserCallback = NULL;
-    startupParams.bMinimal = false;
+    startupParams.bMinimal = true;
 
     startupParams.pSharedEnvironment = AZ::Environment::GetInstance();
 

--- a/dev/Code/Launcher/LinuxLauncher/Main.cpp
+++ b/dev/Code/Launcher/LinuxLauncher/Main.cpp
@@ -286,6 +286,18 @@ int RunGame(const char* commandLine)
 
     AzGameFramework::GameApplication gameApp;
     AzGameFramework::GameApplication::StartupParameters gameAppParams;
+
+    const char* sThreadCount = strcasestr(commandLine, "job_thread_count");
+    if (sThreadCount != nullptr)
+    {
+        gameAppParams.m_jobThreadCount = atoi(sThreadCount);
+    }
+    sThreadCount = strcasestr(commandLine, "asset_thread_count");
+    if (sThreadCount != nullptr)
+    {
+        gameAppParams.m_assetManagerThreadCount = atoi(sThreadCount);
+    }
+
 #ifdef AZ_MONOLITHIC_BUILD
     gameAppParams.m_createStaticModulesCallback = CreateStaticModules;
     gameAppParams.m_loadDynamicModules = false;

--- a/dev/Gems/CryLegacy/Code/Source/CryScriptSystem/ScriptSystem.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryScriptSystem/ScriptSystem.cpp
@@ -2067,6 +2067,13 @@ bool CScriptSystem::ToVec3(Vec3& vec, int tableIndex)
 //////////////////////////////////////////////////////////////////////////
 void CScriptSystem::Update()
 {
+#ifdef DEDICATED_SERVER
+    if (!m_levelLoaded)
+    {
+        return;
+    }
+#endif
+
     CRYPROFILE_SCOPE_PROFILE_MARKER("SysUpdate:ScriptSystem");
     FUNCTION_PROFILER_LEGACYONLY(m_pSystem, PROFILE_SCRIPT);
     AZ_TRACE_METHOD();
@@ -2322,10 +2329,12 @@ void CScriptSystem::OnSystemEvent(ESystemEvent event, UINT_PTR wparam, UINT_PTR 
     {
     case ESYSTEM_EVENT_LEVEL_POST_UNLOAD:
         ForceGarbageCollection();
+        m_levelLoaded = false;
         break;
 
     case ESYSTEM_EVENT_LEVEL_LOAD_START:
         ForceGarbageCollection();
+        m_levelLoaded = true;
         break;
     }
 

--- a/dev/Gems/CryLegacy/Code/Source/CryScriptSystem/ScriptSystem.h
+++ b/dev/Gems/CryLegacy/Code/Source/CryScriptSystem/ScriptSystem.h
@@ -315,6 +315,8 @@ public: // ---------------------------------------------------------------------
 
 	string m_sLastBreakSource;		//!
 	int    m_nLastBreakLine;		//!
+
+	bool m_levelLoaded { false };
 };
 
 #endif // CRYINCLUDE_CRYSCRIPTSYSTEM_SCRIPTSYSTEM_H

--- a/dev/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -371,6 +371,7 @@ namespace EMotionFX
         //////////////////////////////////////////////////////////////////////////
         void SystemComponent::Activate()
         {
+            AZ::SessionTickComponent::Activate();
             // Start EMotionFX allocator.
             EMotionFXAllocator::Descriptor allocatorDescriptor;
             allocatorDescriptor.m_custom = &AZ::AllocatorInstance<AZ::SystemAllocator>::Get();
@@ -411,7 +412,6 @@ namespace EMotionFX
             RegisterAssetTypesAndHandlers();
 
             SystemRequestBus::Handler::BusConnect();
-            AZ::TickBus::Handler::BusConnect();
             CrySystemEventBus::Handler::BusConnect();
             EMotionFXRequestBus::Handler::BusConnect();
 
@@ -447,7 +447,6 @@ namespace EMotionFX
             AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
 #endif // EMOTIONFXANIMATION_EDITOR
 
-            AZ::TickBus::Handler::BusDisconnect();
             CrySystemEventBus::Handler::BusDisconnect();
             EMotionFXRequestBus::Handler::BusDisconnect();
 
@@ -460,6 +459,8 @@ namespace EMotionFX
                 EMotionFX::Initializer::Shutdown();
                 MCore::Initializer::Shutdown();
             }
+
+            AZ::SessionTickComponent::Deactivate();
 
             // Memory leaks will be reported.
             AZ::AllocatorInstance<EMotionFXAllocator>::Destroy();

--- a/dev/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.h
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.h
@@ -13,8 +13,7 @@
 
 #pragma once
 
-#include <AzCore/Component/Component.h>
-#include <AzCore/Component/TickBus.h>
+#include <AzFramework/Components/SessionTickComponent.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
 #include <Integration/AnimationBus.h>
@@ -41,9 +40,8 @@ namespace EMotionFX
     namespace Integration
     {
         class SystemComponent
-            : public AZ::Component
+            : public AZ::SessionTickComponent
             , private SystemRequestBus::Handler
-            , private AZ::TickBus::Handler
             , private CrySystemEventBus::Handler
             , private EMotionFXRequestBus::Handler
 #if defined (EMOTIONFXANIMATION_EDITOR)

--- a/dev/Gems/PhysX/Code/Source/PhysXSystemComponent.h
+++ b/dev/Gems/PhysX/Code/Source/PhysXSystemComponent.h
@@ -16,8 +16,7 @@
 
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetManagerBus.h>
-#include <AzCore/Component/Component.h>
-#include <AzCore/Component/TickBus.h>
+#include <AzFramework/Components/SessionTickComponent.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzFramework/Physics/Action.h>
 #include <AzFramework/Physics/Character.h>
@@ -115,8 +114,7 @@ namespace PhysX
     * meshes and heightfields ready for use in PhysX).
     */
     class PhysXSystemComponent
-        : public AZ::Component
-        , public AZ::TickBus::Handler
+        : public AZ::SessionTickComponent
         , public LegacyTerrain::LegacyTerrainNotificationBus::Handler
         , public LegacyTerrain::LegacyTerrainRequestBus::Handler
         , public PhysXSystemRequestBus::Handler
@@ -155,7 +153,7 @@ namespace PhysX
         physx::PxPvdTransport*          m_pvdTransport = nullptr;
         physx::PxPvd*                   m_pvd = nullptr;
         physx::PxCooking*               m_cooking = nullptr;
-        AzPhysXCpuDispatcher*           m_cpuDispatcher = nullptr;
+        physx::PxCpuDispatcher*         m_cpuDispatcher = nullptr;
 
         // Terrain data
         AZStd::vector<physx::PxRigidStatic*>   m_terrainTiles;


### PR DESCRIPTION
* PhysX , subscribe on Tick Handler after session hosted
* Physx, use default cpu dispatcher to prevent thread starvation for anothers jobs on DS
* EmotionFX,  subscribe on Tick Handler after session hosted
* ScriptSystem, ignore Update while no level loaded
* Create Null realization for Stream Engine
* Disable posteffects update on DS
* Add configuration for threads used by job system and asset manager
** job_thread_count - startup argement to setup amount of threads for job system
**  asset_thread_count -  startup argement to setup amount of threads for asset manager
* bMinimal disable some of systems that isn't server related (ex. VR), but we need to have audio system and gems for correct work