### PR TITLE
Clear cache after Metastream server shutdown

### DIFF
--- a/dev/Gems/Metastream/Code/Source/MetastreamGem.cpp
+++ b/dev/Gems/Metastream/Code/Source/MetastreamGem.cpp
@@ -357,6 +357,11 @@ namespace Metastream
             m_server->Stop();
             m_server.reset();
 
+            if (m_cache)
+            {
+                m_cache->ClearCache();
+            }
+
             m_serverEnabled = 0;
         }
     }


### PR DESCRIPTION
Metastream has access to old cache, after shutdown and starting again