### PR TITLE
Crashfix in BakeScaleIntoGeometry

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/utils.cpp
+++ b/dev/Code/CryEngine/CryPhysics/utils.cpp
@@ -569,6 +569,11 @@ int BakeScaleIntoGeometry(phys_geometry*& pgeom, IGeomManager* pGeoman, const Ve
     IGeometry* pGeomScaled = 0;
     if (phys_geometry* pAdam = (phys_geometry*)pgeom->pGeom->GetForeignData(DATA_UNSCALED_GEOM))
     {
+		if (!pAdam->pGeom)
+		{
+			return 0;
+		}       
+		
         if (bReleaseOld)
         {
             pGeoman->UnregisterGeometry(pgeom), bReleaseOld = 0;

--- a/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.h
@@ -266,6 +266,12 @@ namespace AzFramework
             m_overrideRootSliceLoadAuthoritative = true;
         }
 
+		void ClearRootSliceLoadModeOverride()
+		{
+			m_isAuthoritativeRootSliceLoad = false;
+			m_overrideRootSliceLoadAuthoritative = false;
+		}
+
     private:
         /**
          * \brief True if the root slice is to be loaded authoritatively

--- a/dev/Gems/CryLegacy/Code/Source/CryAction/Network/GameContextBridge.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryAction/Network/GameContextBridge.cpp
@@ -126,6 +126,7 @@ void CGameContextBridge::OnContextBridgeDataDeactivated(CGameContextBridgeDataPt
 {
     AZ_Assert(m_netData == netData, "This is not our data!");
     m_netData = nullptr;
+	ClearRootSliceLoadModeOverride();
 }
 
 void CGameContextBridge::OnStartGameContext(const SGameStartParams* pGameStartParams)


### PR DESCRIPTION
Crashfix in BakeScaleIntoGeometry

It seems there is a possibility to have a geometry for a physical object but no geometry for the physical object referenced by the Foreign data.

It seems to happen if changing the transform of an object as it is being created, here is an example callstack: 

 	CryPhysics.dll!BakeScaleIntoGeometry(phys_geometry * & pgeom, IGeomManager * pGeoman, const Vec3_tpl<float> & s, int bReleaseOld) Line 574	C++
>	CryPhysics.dll!CPhysicalEntity::SetParams(const pe_params * _params, int bThreadSafe) Line 448	C++
 	CryPhysics.dll!CRigidEntity::SetParams(const pe_params * _params, int bThreadSafe) Line 502	C++
 	Gem.LmbrCentral.ff06785f7145416b9d46fde39098cb0c.v0.1.0.dll!LmbrCentral::PhysicsComponent::SetPhysicsParameters(const pe_params & parameters) Line 591	C++
 	Gem.LmbrCentral.ff06785f7145416b9d46fde39098cb0c.v0.1.0.dll!LmbrCentral::PhysicsComponent::OnTransformChanged(const AZ::Transform & __formal, const AZ::Transform & world) Line 740	C++
 	CoffenceLauncher.exe!AZ::BusInternal::EBusEventer<AZ::EBus<AZ::TransformNotification,AZ::TransformNotification>,AZ::BusInternal::EBusImplTraits<AZ::TransformNotification,AZ::TransformNotification> >::Event<void (__cdecl AZ::TransformNotification::*)(AZ::Transform const & __ptr64,AZ::Transform const & __ptr64) __ptr64,AZ::Transform & __ptr64,AZ::Transform & __ptr64>(const AZStd::intrusive_ptr<AZ::Internal::HandlerContainer<AZ::TransformNotification,AZ::TransformNotification,1> > & ptr, void(AZ::TransformNotification::*)(const AZ::Transform &, const AZ::Transform &) func, AZ::Transform & <args_0>, AZ::Transform & <args_1>) Line 778	C++
 	CoffenceLauncher.exe!AzFramework::TransformComponent::ComputeLocalTM() Line 1180	C++
 	CoffenceLauncher.exe!AzFramework::TransformComponent::SetWorldTM(const AZ::Transform & tm) Line 377	C++
 	CoffenceLauncher.exe!AzFramework::TransformComponent::SetParentImpl(AZ::EntityId parentId, bool isKeepWorldTM) Line 1091	C++
 	CoffenceLauncher.exe!AzFramework::TransformComponent::SetParent(AZ::EntityId id) Line 387	C++
 	Gem.CoffenceLogics.60872c0bf4464f84bc371d6628d1e069.v0.1.0.dll!AZ::BusInternal::EBusEventer<AZ::EBus<AZ::TransformInterface,AZ::TransformInterface>,AZ::BusInternal::EBusImplTraits<AZ::TransformInterface,AZ::TransformInterface> >::Event<void (__cdecl AZ::TransformInterface::*)(AZ::EntityId) __ptr64,AZ::EntityId & __ptr64>(const AZ::EntityId & id, void(AZ::TransformInterface::*)(AZ::EntityId) func, AZ::EntityId & <args_0>) Line 713	C++
 	Gem.CoffenceLogics.60872c0bf4464f84bc371d6628d1e069.v0.1.0.dll!CoffenceLogics::CharacterSelectComponent::DetachEquipment() Line 1149	C++