### PR TITLE
Enum serialization

### DIFF
--- a/dev/Code/CryEngine/CryCommon/Serialization/Enum.h
+++ b/dev/Code/CryEngine/CryCommon/Serialization/Enum.h
@@ -25,12 +25,12 @@
 namespace Serialization {
     class IArchive;
 
-    struct LessStrCmp
-        : std::binary_function<const char*, const char*, bool>
+    struct EqualStrCmp
+        : AZStd::binary_function<const char*, const char*, bool>
     {
         bool operator()(const char* l, const char* r) const
         {
-            return strcmp(l, r) < 0;
+            return strcmp(l, r) == 0;
         }
     };
 
@@ -85,9 +85,9 @@ namespace Serialization {
         StringListStatic names_;
         StringListStatic labels_;
 
-        typedef AZStd::unordered_map<const char*, int, AZStd::hash<const char*>, AZStd::equal_to<const char*>, AZ::StdLegacyAllocator> NameToValue;
+        typedef AZStd::unordered_map<const char*, int, AZStd::hash<const char*>, EqualStrCmp, AZ::StdLegacyAllocator> NameToValue;
         NameToValue nameToValue_;
-        typedef AZStd::unordered_map<const char*, int, AZStd::hash<const char*>, AZStd::equal_to<const char*>, AZ::StdLegacyAllocator> LabelToValue;
+        typedef AZStd::unordered_map<const char*, int, AZStd::hash<const char*>, EqualStrCmp, AZ::StdLegacyAllocator> LabelToValue;
         LabelToValue labelToValue_;
         typedef AZStd::unordered_map<int, int, AZStd::hash<int>, AZStd::equal_to<int>, AZ::StdLegacyAllocator> ValueToIndex;
         ValueToIndex valueToIndex_;

--- a/dev/Code/Framework/AzCore/AzCore/std/hash.h
+++ b/dev/Code/Framework/AzCore/AzCore/std/hash.h
@@ -13,6 +13,7 @@
 #define AZSTD_HASH_H 1
 
 #include <AzCore/std/utils.h>
+#include <AzCore/Math/Crc.h>
 
 namespace AZStd
 {
@@ -150,6 +151,17 @@ namespace AZStd
             cast_long_double = &value;
             AZ::u64 bits = *cast_u64;
             return static_cast<result_type>((bits == 0x7fffffffffffffff ? 0 : bits));
+        }
+    };
+
+    template<>
+    struct hash< const char* >
+    {
+        typedef const char*     argument_type;
+        typedef AZStd::size_t   result_type;
+        inline result_type operator()(argument_type value) const
+        {
+            return AZ_CRC(value);
         }
     };
 


### PR DESCRIPTION
EnumDescriptor used hash/compare on pointer value instead of string value.