### PR TITLE
Fixed area components disappear in Editor when their bounding box is …

### DIFF
--- a/dev/Gems/Visibility/Code/Source/EditorOccluderAreaComponent.cpp
+++ b/dev/Gems/Visibility/Code/Source/EditorOccluderAreaComponent.cpp
@@ -168,6 +168,7 @@ namespace Visibility
         AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
         AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(GetEntityId());
         EntitySelectionEvents::Bus::Handler::BusConnect(GetEntityId());
+        AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());
 
         UpdateObject();
     }
@@ -180,6 +181,7 @@ namespace Visibility
         AzFramework::EntityDebugDisplayEventBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect(GetEntityId());
         OccluderAreaRequestBus::Handler::BusDisconnect(GetEntityId());
+        AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusDisconnect(GetEntityId());
         Base::Deactivate();
     }
 
@@ -293,6 +295,17 @@ namespace Visibility
         {
             UpdateObject();
         };
+    }
+
+    AZ::Aabb EditorOccluderAreaComponent::GetEditorSelectionBounds()
+    {
+        AZ::Aabb bbox = AZ::Aabb::CreateNull();
+        for (auto vertex : m_config.m_vertices)
+        {
+            bbox.AddPoint(vertex);
+        }
+        bbox.ApplyTransform(GetWorldTM());
+        return bbox;
     }
 
     AZ::LegacyConversion::LegacyConversionResult OccluderAreaConverter::ConvertEntity(CBaseObject* entityToConvert)

--- a/dev/Gems/Visibility/Code/Source/EditorOccluderAreaComponent.h
+++ b/dev/Gems/Visibility/Code/Source/EditorOccluderAreaComponent.h
@@ -16,6 +16,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzToolsFramework/Manipulators/EditorVertexSelection.h>
+#include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
 #include <LegacyEntityConversion/LegacyEntityConversionBus.h>
 #include <OccluderAreaComponentBus.h>
 #include "OccluderAreaComponent.h"
@@ -47,6 +48,7 @@ namespace Visibility
         , private OccluderAreaRequestBus::Handler
         , private AzFramework::EntityDebugDisplayEventBus::Handler
         , private AzToolsFramework::EntitySelectionEvents::Bus::Handler
+        , private AzToolsFramework::EditorComponentSelectionRequestsBus::Handler
         , public AZ::TransformNotificationBus::Handler
     {
         friend class OccluderAreaConverter;
@@ -75,6 +77,8 @@ namespace Visibility
 
         // TransformNotificationBus
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
+
+        AZ::Aabb GetEditorSelectionBounds() override;
 
         /// Update the object runtime after changes to the Configuration.
         /// Called by the default RequestBus SetXXX implementations,

--- a/dev/Gems/Visibility/Code/Source/EditorPortalComponent.cpp
+++ b/dev/Gems/Visibility/Code/Source/EditorPortalComponent.cpp
@@ -168,6 +168,7 @@ namespace Visibility
         AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
         AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(GetEntityId());
         EntitySelectionEvents::Bus::Handler::BusConnect(GetEntityId());
+        AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());
 
         //Call OnTransformChanged manually to cache current transform since it won't be called
         //automatically for us when the level starts up.
@@ -187,6 +188,7 @@ namespace Visibility
         AzFramework::EntityDebugDisplayEventBus::Handler::BusDisconnect(GetEntityId());
         AZ::TransformNotificationBus::Handler::BusDisconnect(GetEntityId());
         PortalRequestBus::Handler::BusDisconnect();
+        AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusDisconnect(GetEntityId());
         Base::Deactivate();
     }
 
@@ -467,6 +469,18 @@ namespace Visibility
         m_vertexSelection.Create(GetEntityId(), managerId,
             AzToolsFramework::TranslationManipulator::Dimensions::Three,
             AzToolsFramework::ConfigureTranslationManipulatorAppearance3d);
+    }
+
+    AZ::Aabb EditorPortalComponent::GetEditorSelectionBounds()
+    {
+        AZ::Aabb bbox = AZ::Aabb::CreateNull();
+        for (auto vertex : m_config.m_vertices)
+        {
+            bbox.AddPoint(vertex);
+        }
+        bbox.AddPoint(bbox.GetMax() + AZ::Vector3(0.0f, 0.0f, m_config.m_height));
+        bbox.ApplyTransform(GetWorldTM());
+        return bbox;
     }
 
     AZ::LegacyConversion::LegacyConversionResult PortalConverter::ConvertEntity(CBaseObject* entityToConvert)

--- a/dev/Gems/Visibility/Code/Source/EditorPortalComponent.h
+++ b/dev/Gems/Visibility/Code/Source/EditorPortalComponent.h
@@ -14,6 +14,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzToolsFramework/ToolsComponents/EditorVisibilityBus.h>
 #include <AzToolsFramework/Manipulators/EditorVertexSelection.h>
@@ -50,6 +51,7 @@ namespace Visibility
         , private PortalRequestBus::Handler
         , private AzFramework::EntityDebugDisplayEventBus::Handler
         , private AzToolsFramework::EntitySelectionEvents::Bus::Handler
+        , private AzToolsFramework::EditorComponentSelectionRequestsBus::Handler
         , public AZ::TransformNotificationBus::Handler
     {
         friend class PortalConverter;
@@ -99,6 +101,8 @@ namespace Visibility
 
         // TransformNotificationBus
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
+
+        AZ::Aabb GetEditorSelectionBounds() override;
 
         /// Update the object runtime after changes to the Configuration.
         /// Called by the default RequestBus SetXXX implementations,

--- a/dev/Gems/Visibility/Code/Source/EditorVisAreaComponent.cpp
+++ b/dev/Gems/Visibility/Code/Source/EditorVisAreaComponent.cpp
@@ -196,6 +196,7 @@ namespace Visibility
         AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(GetEntityId());
         AzToolsFramework::EditorEntityInfoNotificationBus::Handler::BusConnect();
         EntitySelectionEvents::Bus::Handler::BusConnect(GetEntityId());
+        AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());
 
         //Apply callbacks to VertexContainer directly
         auto containerChanged = [this]()
@@ -258,7 +259,7 @@ namespace Visibility
         AzToolsFramework::EditorEntityInfoNotificationBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect(GetEntityId());
         VisAreaComponentRequestBus::Handler::BusDisconnect(GetEntityId());
-
+        AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusDisconnect(GetEntityId());
         Base::Deactivate();
     }
 
@@ -442,6 +443,18 @@ namespace Visibility
         m_vertexSelection.Create(GetEntityId(), managerId,
             AzToolsFramework::TranslationManipulator::Dimensions::Three,
             AzToolsFramework::ConfigureTranslationManipulatorAppearance3d);
+    }
+
+    AZ::Aabb EditorVisAreaComponent::GetEditorSelectionBounds()
+    {
+        AZ::Aabb bbox = AZ::Aabb::CreateNull();
+        for (auto vertex : m_config.m_vertexContainer.GetVertices())
+        {
+            bbox.AddPoint(vertex);
+        }
+        bbox.AddPoint(bbox.GetMax() + AZ::Vector3(0.0f, 0.0f, m_config.m_Height));
+        bbox.ApplyTransform(GetWorldTM());
+        return bbox;
     }
 
     AZ::LegacyConversion::LegacyConversionResult VisAreaConverter::ConvertEntity(CBaseObject* entityToConvert)

--- a/dev/Gems/Visibility/Code/Source/EditorVisAreaComponent.h
+++ b/dev/Gems/Visibility/Code/Source/EditorVisAreaComponent.h
@@ -15,6 +15,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzToolsFramework/Manipulators/EditorVertexSelection.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
@@ -53,6 +54,7 @@ namespace Visibility
         , private AzFramework::EntityDebugDisplayEventBus::Handler
         , private AzToolsFramework::EntitySelectionEvents::Bus::Handler
         , private AzToolsFramework::EditorEntityInfoNotificationBus::Handler
+        , private AzToolsFramework::EditorComponentSelectionRequestsBus::Handler
         , public AZ::TransformNotificationBus::Handler
     {
         friend class VisAreaConverter;
@@ -76,6 +78,8 @@ namespace Visibility
 
         // TransformNotificationBus
         void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
+
+        AZ::Aabb GetEditorSelectionBounds() override;
 
         /// Apply the component's settings to the underlying vis area
         void UpdateVisArea();


### PR DESCRIPTION
**Fixed Problem:**
Editor does not display entities whose bounding boxes are not in viewport and it makes (especialy large) area components to disappear when turning camera angle.
This fixes bounding boxes for:
  - Editor VisArea Component
  - Editor Portal Component
  - Occluder Area Component