### PR TITLE
Allow running non-release game client on PC with null renderer

### DIFF
--- a/dev/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/dev/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -1300,6 +1300,14 @@ bool CSystem::OpenRenderLibrary(int type, const SSystemInitParams& initParams)
     {
         type = R_NULL_RENDERER;
     }
+
+#if defined(AZ_PLATFORM_WINDOWS) && !defined(_RELEASE)
+    else if (m_env.pSystem->GetICmdLine()->FindArg(eCLAT_Pre, "nullrender") != 0)
+    {
+        type = R_NULL_RENDERER;
+    }
+#endif // AZ_PLATFORM_WINDOWS && !_RELEASE
+
 #endif
 
 

--- a/dev/Code/CryEngine/RenderDll/XRenderNULL/NULL_System.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderNULL/NULL_System.cpp
@@ -46,6 +46,8 @@ WIN_HWND CNULLRenderer::Init(int x, int y, int width, int height, unsigned int c
     m_height = height;
     m_backbufferWidth = width;
     m_backbufferHeight = height;
+    m_nativeWidth = width;
+    m_nativeHeight = height;
     m_Features |= RFT_HW_NVIDIA;
 
     if (!g_shaderGeneralHeap)


### PR DESCRIPTION
This change allows running client with NULL Renderer on PC which is helpful for us when building command-line utilities within engine's environment.