### PR TITLE
Fixed _displ not defaulting to Displacement in RC + new suffixes for terrain albedos

### DIFF
--- a/dev/Code/Tools/RC/ResourceCompilerImage/ImageCompiler.cpp
+++ b/dev/Code/Tools/RC/ResourceCompilerImage/ImageCompiler.cpp
@@ -448,6 +448,7 @@ static string AutoselectPreset(const ConvertContext& CC, const uint32 width, con
     const char* const defaultPow2       = "Albedo";
     const char* const defaultPow2Alpha  = "AlbedoWithGenericAlpha";
     const char* const defaultNonpow2    = "ReferenceImage";
+    const char* const defaultHeight     = "Displacement";
 
     const string fileName = CC.config->GetAsString("overwritefilename", CC.sourceFileNameOnly, CC.sourceFileNameOnly);
 
@@ -473,6 +474,10 @@ static string AutoselectPreset(const ConvertContext& CC, const uint32 width, con
     else if (SuffixUtil::HasSuffix(fileName.c_str(), '_', "ddna"))
     {
         presetName = defaultNormalmapGloss;
+    }
+    else if (SuffixUtil::HasSuffix(fileName.c_str(), '_', "displ"))
+    {
+        presetName = defaultHeight;
     }
     else if (SuffixUtil::HasSuffix(fileName.c_str(), '_', "cm") || (StringHelpers::EndsWithIgnoreCase(CC.sourceFileNameOnly, ".hdr")))
     {

--- a/dev/Code/Tools/RC/ResourceCompilerImage/ImageCompiler.cpp
+++ b/dev/Code/Tools/RC/ResourceCompilerImage/ImageCompiler.cpp
@@ -449,6 +449,8 @@ static string AutoselectPreset(const ConvertContext& CC, const uint32 width, con
     const char* const defaultPow2Alpha  = "AlbedoWithGenericAlpha";
     const char* const defaultNonpow2    = "ReferenceImage";
     const char* const defaultHeight     = "Displacement";
+    const char* const defaultTerrain   = "Terrain_Albedo";
+    const char* const defaultHighpassed   = "Terrain_Albedo_HighPassed";
 
     const string fileName = CC.config->GetAsString("overwritefilename", CC.sourceFileNameOnly, CC.sourceFileNameOnly);
 
@@ -478,6 +480,14 @@ static string AutoselectPreset(const ConvertContext& CC, const uint32 width, con
     else if (SuffixUtil::HasSuffix(fileName.c_str(), '_', "displ"))
     {
         presetName = defaultHeight;
+    }
+    else if (SuffixUtil::HasSuffix(fileName.c_str(), '_', "diffT"))
+    {
+        presetName = defaultTerrain;
+    }
+    else if (SuffixUtil::HasSuffix(fileName.c_str(), '_', "diffTHP"))
+    {
+        presetName = defaultHighpassed;
     }
     else if (SuffixUtil::HasSuffix(fileName.c_str(), '_', "cm") || (StringHelpers::EndsWithIgnoreCase(CC.sourceFileNameOnly, ".hdr")))
     {


### PR DESCRIPTION
was getting really annoyed having to manually set my _displ textures to Displacement in RC, and having to set my terrain material _diff textures to "Terrain_Albedo_HighPassed" so added the _diffTHP suffix for that.

also added a _diffT suffix for people who don't have Photoshop to highpass the texture, and want to save time not having to manually set the RC to "Terrain_Albedo" (which highpasses the texture for them).