### PR TITLE
Fixed WaterVolume component caused crash in Editor and in Game

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/WaterVolumeRenderNode.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/WaterVolumeRenderNode.cpp
@@ -1366,7 +1366,7 @@ int OnWaterUpdate(const EventPhysAreaChange* pEvent)
         pe_status_area sa;
         sa.bUniformOnly = true;
         MARK_UNUSED sa.ctr;
-        if (pWVRN->GetPhysics() != pEvent->pEntity || !pEvent->pEntity->GetStatus(&sa))
+        if (pWVRN->GetPhysArea() != pEvent->pEntity || !pEvent->pEntity->GetStatus(&sa))
         {
             return 1;
         }

--- a/dev/Code/CryEngine/Cry3DEngine/WaterVolumeRenderNode.h
+++ b/dev/Code/CryEngine/Cry3DEngine/WaterVolumeRenderNode.h
@@ -148,6 +148,7 @@ public:
 
     virtual IPhysicalEntity* GetPhysics() const;
     virtual void SetPhysics(IPhysicalEntity*);
+    inline IPhysicalEntity* GetPhysArea() const { return m_pPhysArea; }
 
     virtual void CheckPhysicalized();
     virtual void Physicalize(bool bInstant = false);


### PR DESCRIPTION
Fixed crash of watervolume (easily reproduced in editor when entering/exiting game mode several times)