### PR TITLE
Fixed e_coverageBufferDebug rendering artifacts

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/CCullRenderer.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/CCullRenderer.cpp
@@ -14,6 +14,35 @@
 #include "StdAfx.h"
 #include "CCullRenderer.h"
 
+#include <3dEngine.h>
+#include <cmath>
+
 namespace NAsyncCull
 {
+
+
+    int UpdateCullDebugData(const float* __restrict pVMemZ, uint32 x, float* colorData, int numElem)
+    {
+        // level details near or far from camera could be done by adjusting color curve
+        const float fColorCurvePow = C3DEngine::GetCVars()->e_CoverageBufferOccludersViewDistRatio * 0.8f;
+        const int multPerChannelSize = 3;
+        const float multPerChannel[multPerChannelSize]{ 0.03125f, 0.0625f, 0.013125f };
+        const int colorArraySize = 4;
+        float fValueColor[colorArraySize]{ pow((pVMemZ[x + 0]), fColorCurvePow) , pow((pVMemZ[x + 1]),
+            fColorCurvePow), pow((pVMemZ[x + 2]), fColorCurvePow), pow((pVMemZ[x + 3]), fColorCurvePow) };
+
+        for (int colorIndex = 0; colorIndex < colorArraySize; ++colorIndex)
+        {
+            for (int multIndex = 0; multIndex < multPerChannelSize; ++multIndex)
+            {
+                colorData[numElem] = fValueColor[colorIndex] * multPerChannel[multIndex];
+                ++numElem;
+            }
+            colorData[numElem] = 255; // alpha is a constant value
+            ++numElem;
+        }
+
+        return numElem;
+    }
+
 }

--- a/dev/Code/CryEngine/Cry3DEngine/CCullRenderer.h
+++ b/dev/Code/CryEngine/Cry3DEngine/CCullRenderer.h
@@ -82,6 +82,9 @@ namespace NAsyncCull
 
     extern const NVMath::vec4 MaskNot3;
 
+
+    int UpdateCullDebugData(const float* __restrict pVMemZ, uint32 x, float* colorData, int numElem);
+
     template<uint32 SIZEX, uint32 SIZEY>
     class CCullRenderer
     {
@@ -1512,6 +1515,10 @@ namespace NAsyncCull
             float fTopOffSet = 35.0f;
             float fSideOffSet = 35.0f;
 
+            const int n32BitChannels = 4;
+            float* colorData = new float[SIZEY*SIZEX*n32BitChannels];
+            int numElem = 0;
+
             // draw z-buffer after reprojection (unknown parts are red)
             fTopOffSet += 200.0f;
             for (uint32 y = 0; y < SIZEY; y += 1)
@@ -1547,12 +1554,13 @@ namespace NAsyncCull
                     ColorB Color2(ValueColor2, ValueColor2 * 16, ValueColor2 * 256, 222);
                     ColorB Color3(ValueColor3, ValueColor3 * 16, ValueColor3 * 256, 222);
 
-                    NAsyncCull::Debug::Draw2DBox(fX0, fY, 3.0f, 3.0f, Color0, fScreenHeight, fScreenWidth, pRenderer->GetIRenderAuxGeom());
-                    NAsyncCull::Debug::Draw2DBox(fX1, fY, 3.0f, 3.0f, Color1, fScreenHeight, fScreenWidth, pRenderer->GetIRenderAuxGeom());
-                    NAsyncCull::Debug::Draw2DBox(fX2, fY, 3.0f, 3.0f, Color2, fScreenHeight, fScreenWidth, pRenderer->GetIRenderAuxGeom());
-                    NAsyncCull::Debug::Draw2DBox(fX3, fY, 3.0f, 3.0f, Color3, fScreenHeight, fScreenWidth, pRenderer->GetIRenderAuxGeom());
+                    numElem = UpdateCullDebugData(pVMemZ, x, colorData, numElem);
+
                 }
             }
+
+            pRenderer->DebugCull(colorData, SIZEX, SIZEY, n32BitChannels);
+            delete[] colorData;
 #endif
         }
 

--- a/dev/Code/CryEngine/Cry3DEngine/CCullThread.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/CCullThread.cpp
@@ -760,13 +760,14 @@ namespace NAsyncCull
                 __debugbreak(); // unknown culler job type
             }
         }
-
+#if !defined(_RELEASE)
         if (GetCVars()->e_CoverageBufferDebug)
         {
             float fGreen[4] = {0, 1, 0, 1};
             gEnv->pRenderer->Draw2dLabel(16.0f, 32.0f, 1.6f, fGreen, false, AZStd::string::format("Octree Nodes Culled %i, Octree Nodes Visible %i",octreeNodesCulled, octreeNodesVisible).c_str());
             gEnv->pRenderer->Draw2dLabel(16.0f, 64.0f, 1.6f, fGreen, false, AZStd::string::format("Terrain Nodes Culled %i, Terrain Nodes Visible %i",terrainNodesCulled, terrainNodesVisible).c_str());
         }
+#endif
 
         GetObjManager()->RemoveCullJobProducer();
     }

--- a/dev/Code/CryEngine/Cry3DEngine/cvars.cpp
+++ b/dev/Code/CryEngine/Cry3DEngine/cvars.cpp
@@ -44,6 +44,26 @@ void OnCGFStreamingChange(ICVar* pArgs)
     }
 }
 
+#ifndef _RELEASE
+void OnCoverageBufferDebugChange(ICVar* pArgs)
+{
+    if (pArgs->GetIVal() != 0)
+    {
+        gEnv->pConsole->ExecuteString("r_ShowDynTexturesFilter $DebugCull");
+        gEnv->pConsole->ExecuteString("r_ShowDynTextures 1");
+        gEnv->pConsole->ExecuteString("r_ShowDynTexturesMaxCount 4");
+        Cry3DEngineBase::GetCVars()->e_CoverageBufferDebug = 1;
+    }
+    else
+    {
+        gEnv->pConsole->ExecuteString("r_ShowDynTexturesFilter *");
+        gEnv->pConsole->ExecuteString("r_ShowDynTextures 0");
+        gEnv->pConsole->ExecuteString("r_ShowDynTexturesMaxCount 32");
+        Cry3DEngineBase::GetCVars()->e_CoverageBufferDebug = 0;
+    }
+}
+#endif // _RELEASE
+
 void OnPerCharacterShadowsChange(ICVar* pArgs)
 {
     Cry3DEngineBase::Get3DEngine()->ObjectsTreeMarkAsUncompiled(NULL);
@@ -534,8 +554,10 @@ void CVars::Init()
             "Terrain lod ratio for mesh rendered into cbuffer");
     */REGISTER_CVAR(e_CoverageBufferVersion, 2, VF_NULL,
         "1 Vladimir's, 2MichaelK's");
-    DefineConstIntCVar(e_CoverageBufferDebug, 0, VF_CHEAT,
-        "Display content of main camera coverage buffer");
+#ifndef _RELEASE
+    REGISTER_CVAR_CB(e_CoverageBufferDebug, 0, VF_CHEAT,
+        "Display content of main camera coverage buffer", OnCoverageBufferDebugChange);
+#endif
     DefineConstIntCVar(e_CoverageBufferDebugFreeze, 0, VF_CHEAT,
         "Freezes view matrix/-frustum ");
     DefineConstIntCVar(e_CoverageBufferDrawOccluders, 0, VF_CHEAT,

--- a/dev/Code/CryEngine/CryCommon/IRenderer.h
+++ b/dev/Code/CryEngine/CryCommon/IRenderer.h
@@ -2332,6 +2332,8 @@ struct IRenderer
 
     virtual int GetRecursionLevel() = 0;
 
+    virtual void DebugCull(void * colorData, int width, int height, int bytesperpixel) = 0;
+
     virtual int GetIntegerConfigurationValue(const char* varName, int defaultValue) = 0;
     virtual float GetFloatConfigurationValue(const char* varName, float defaultValue) = 0;
     virtual bool GetBooleanConfigurationValue(const char* varName, bool defaultValue) = 0;

--- a/dev/Code/CryEngine/RenderDll/Common/Renderer.h
+++ b/dev/Code/CryEngine/RenderDll/Common/Renderer.h
@@ -833,6 +833,8 @@ public:
     virtual bool FlushRTCommands(bool bWait, bool bImmediatelly, bool bForce);
     virtual bool ForceFlushRTCommands();
 
+    virtual void DebugCull(void * colorData, int width, int height, int bytesperpixel) override = 0;
+
     virtual int GetOcclusionBuffer(uint16* pOutOcclBuffer, Matrix44* pmCamBuffer) = 0;
     virtual void WaitForParticleBuffer(threadID nThreadId) = 0;
 

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DriverD3D.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DriverD3D.cpp
@@ -8019,3 +8019,35 @@ IHWMouseCursor* CD3D9Renderer::GetIHWMouseCursor()
 
 #endif
 
+void CD3D9Renderer::DebugCull(void * colorData, int width, int height, int wordsperpixel)
+{
+#ifndef _RELEASE
+    assert(wordsperpixel == 4);
+
+    if (!IsEditorMode())
+    {
+        return;
+    }
+
+    // this texture is never released
+    static CTexture* sptexDebugCull = CTexture::CreateTextureObject("$DebugCull", 0, 0, 1, eTT_2D, FT_DONT_RELEASE | FT_NOMIPS | FT_USAGE_DYNAMIC, eTF_R32G32B32A32F);
+
+    if (!CTexture::IsTextureExist(sptexDebugCull))
+    {
+        sptexDebugCull->Create2DTexture(width, height, 1,
+            FT_DONT_RELEASE | FT_NOMIPS | FT_USAGE_DYNAMIC,
+            0, eTF_R32G32B32A32F, eTF_R32G32B32A32F);
+    }
+
+    if (CTexture::IsTextureExist(sptexDebugCull))
+    {
+        STALL_PROFILER("update subresource")
+            CDeviceTexture * pDevTex = sptexDebugCull->GetDevTexture();
+        pDevTex->UploadFromStagingResource(0, [=](void* pData, uint32 rowPitch, uint32 slicePitch)
+        {
+            cryMemcpy(pData, colorData, width * height * wordsperpixel * sizeof(f32));
+            return true;
+        });
+    }
+#endif // _RELEASE
+}

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/DriverD3D.h
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/DriverD3D.h
@@ -857,6 +857,8 @@ public:
 #endif
     bool IsDeviceContextValid() { return m_DeviceContext != nullptr; }
 
+    virtual void DebugCull(void * colorData, int width, int height, int bytesperpixel) override;
+
     /////////////////////////////////////////////////////////////////////////////
     // Debug Functions to check that the D3D DeviceContext is only accessed
     // by its owning thread

--- a/dev/Code/CryEngine/RenderDll/XRenderNULL/NULL_Renderer.h
+++ b/dev/Code/CryEngine/RenderDll/XRenderNULL/NULL_Renderer.h
@@ -419,6 +419,8 @@ public:
     virtual IHWMouseCursor* GetIHWMouseCursor() { return NULL; }
 #endif
 
+    virtual void DebugCull(void * colorData, int width, int height, int bytesperpixel) {};
+
 private:
     CNULLRenderAuxGeom* m_pNULLRenderAuxGeom;
     IColorGradingController* m_pNULLColorGradingController;


### PR DESCRIPTION
Right now in engine version 1.16 e_coverageBufferDebug renders cpu filled image which flickers with artifactrs and it actually very hard to use such culling debug.

This fix performs copying cpu filled texture into rendering device texture which produces smooth monochrome (green) texture without flickering and rendering artifacts.