### PR TITLE
Enabled MeshComponent to be rendered in camera space

### DIFF
--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.cpp
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.cpp
@@ -744,6 +744,13 @@ namespace LmbrCentral
             m_objectMoved = false;
         }
 
+        if (m_isRenderNearest)
+        {
+            rParams.dwFObjFlags |= FOB_NEAREST;
+            m_dwRndFlags |= ERF_RENDER_ALWAYS;
+            rParams.nAfterWater = 1;
+        }
+
         rParams.pMatrix = &m_renderTransform;
         rParams.bForceDrawStatic = !m_renderOptions.m_dynamicMesh;
         if (rParams.pMatrix->IsValid())
@@ -1076,5 +1083,11 @@ namespace LmbrCentral
     void MeshComponent::SetVisibility(bool isVisible)
     {
         m_meshRenderNode.SetVisible(isVisible);
+    }
+
+    void MeshComponent::SetRenderNearest()
+    {
+        m_meshRenderNode.SetRndFlags(ERF_RENDER_ALWAYS, true);
+        m_meshRenderNode.SetRenderNearest(true);
     }
 } // namespace LmbrCentral

--- a/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.h
+++ b/dev/Gems/LmbrCentral/Code/Source/Rendering/MeshComponent.h
@@ -143,6 +143,8 @@ namespace LmbrCentral
         void SetVisible(bool isVisible);
         bool GetVisible();
 
+        void SetRenderNearest(bool isRenderNearest) { m_isRenderNearest = isRenderNearest; }
+
         static void Reflect(AZ::ReflectContext* context);
 
         static float GetDefaultMaxViewDist();
@@ -279,6 +281,9 @@ namespace LmbrCentral
 
         //! Tracks if the object was moved so we can notify the renderer.
         bool m_objectMoved;
+
+        //! Defines if mesh is to be rendered in camera space
+        bool m_isRenderNearest = false;
     };
 
 
@@ -312,6 +317,7 @@ namespace LmbrCentral
         AZ::Data::Asset<AZ::Data::AssetData> GetMeshAsset() override { return m_meshRenderNode.GetMeshAsset(); }
         void SetVisibility(bool newVisibility) override;
         bool GetVisibility() override;
+        void SetRenderNearest() override;
         ///////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////

--- a/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshComponentBus.h
+++ b/dev/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshComponentBus.h
@@ -59,6 +59,12 @@ namespace LmbrCentral
         * Sets the current visibility of the mesh
         */
         virtual void SetVisibility(bool isVisible) {}
+
+        /**
+          Sets mesh to be rendered in camera space
+        */
+        virtual void SetRenderNearest() {};
+
     };
 
     using MeshComponentRequestBus = AZ::EBus<MeshComponentRequests>;


### PR DESCRIPTION
Rendering subsystem of The Engine allows meshes to be rendered in camera space. This PR allows to enable this behaviour for mesh component.

This feature is especially important for first person games because it allows to not bother with "weapon-in-a-wall" problem which is solved by physics otherwise.