### PR TITLE
Extended ConsoleBus with methods for getting cvar values

### DIFF
--- a/dev/Code/CryEngine/CrySystem/XConsole.cpp
+++ b/dev/Code/CryEngine/CrySystem/XConsole.cpp
@@ -4051,5 +4051,26 @@ void CXConsole::RemoveConsoleVarSink(IConsoleVarSink* pSink)
     m_consoleVarSinks.remove(pSink);
 }
 
+//////////////////////////////////////////////////////////////////////////
+int CXConsole::GetIntCVar(const char* name)
+{
+    ICVar* cvar = GetCVar(name);
+    if (!cvar)
+    {
+        AZ_Warning("ConsoleRequestBus", false, "Trying to get non-existing CVar: '%s'", name);
+        return 0;
+    }
+    return cvar->GetIVal();
+}
 
-
+//////////////////////////////////////////////////////////////////////////
+float CXConsole::GetFloatCVar(const char* name)
+{
+    ICVar* cvar = GetCVar(name);
+    if (!cvar)
+    {
+        AZ_Warning("ConsoleRequestBus", false, "Trying to get non-existing CVar: '%s'", name);
+        return 0.f;
+    }
+    return cvar->GetFVal();
+}

--- a/dev/Code/CryEngine/CrySystem/XConsole.h
+++ b/dev/Code/CryEngine/CrySystem/XConsole.h
@@ -249,6 +249,9 @@ public:
     void SetProcessingGroup(bool isGroup) { m_bIsProcessingGroup = isGroup; }
     bool GetIsProcessingGroup(void) const { return m_bIsProcessingGroup; }
 
+    virtual int GetIntCVar(const char* name);
+    virtual float GetFloatCVar(const char* name);
+
 protected: // ----------------------------------------------------------------------------------------
     void DrawBuffer(int nScrollPos, const char* szEffect);
 

--- a/dev/Code/Framework/AzFramework/AzFramework/Components/ConsoleBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Components/ConsoleBus.h
@@ -43,6 +43,9 @@ namespace AzFramework
 
         virtual void ResetCVarsToDefaults() = 0;
 
+        virtual int GetIntCVar(const char* name) = 0;
+        virtual float GetFloatCVar(const char* name) = 0;
+
         static void Reflect(AZ::ReflectContext* context);
     };
 


### PR DESCRIPTION
Currently it is possible to set configuration variable from code via ExecuteString method, but it is not possible to retrieve console variable values (without bringing whole CrySystem to your gem) though cvars is a priceless tool for runtime configuration especially in QA context.