### PR TITLE
Enabled EmotionFX Actor to be rendered in camera space

### DIFF
--- a/dev/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
+++ b/dev/Gems/EMotionFX/Code/Include/Integration/ActorComponentBus.h
@@ -59,6 +59,9 @@ namespace EMotionFX
             /// Enables rendering of the actor.
             virtual bool GetRenderCharacter() const = 0;
             virtual void SetRenderCharacter(bool enable) = 0;
+
+            /// Enables EmotionFX actor drawing in camera space
+            virtual void SetRenderNearest() {};
         };
 
         using ActorComponentRequestBus = AZ::EBus<ActorComponentRequests>;

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.cpp
@@ -284,13 +284,24 @@ namespace EMotionFX
 
             pD->m_uniqueObjectId = reinterpret_cast<uintptr_t>(this);
 
+            if (m_isRenderNearest)
+            {
+                rParams.dwFObjFlags |= FOB_NEAREST;
+                pObj->m_ObjFlags |= FOB_NEAREST;
+                rParams.nAfterWater = 1;
+            }
+            else
+            {
+                rParams.dwFObjFlags &= ~FOB_NEAREST;
+                pObj->m_ObjFlags &= ~FOB_NEAREST;
+            }
+
             rParams.pMatrix = &m_renderTransform;
 
             pObj->m_II.m_Matrix = *rParams.pMatrix;
             pObj->m_nClipVolumeStencilRef = rParams.nClipVolumeStencilRef;
             pObj->m_nTextureID = rParams.nTextureID;
             rParams.dwFObjFlags |= rParams.dwFObjFlags;
-            rParams.dwFObjFlags &= ~FOB_NEAREST;
             pObj->m_nMaterialLayers = rParams.nMaterialLayersBlend;
             pD->m_nHUDSilhouetteParams = rParams.nHUDSilhouettesParams;
             pD->m_nCustomData = rParams.nCustomData;
@@ -680,6 +691,14 @@ namespace EMotionFX
             {
                 renderMesh->UnlockStream(VSF_QTANGENTS);
             }
+        }
+
+        void ActorRenderNode::SetRenderNearest(bool isRenderNearest)
+        {
+            m_isRenderNearest = isRenderNearest;
+
+            // FL[FD-1234] FP geometry shadows are visible from FP view: remove when properly supported by data flow.
+            SetRndFlags(ERF_CASTSHADOWMAPS | ERF_HAS_CASTSHADOWMAPS, !m_isRenderNearest);
         }
 
         ActorAsset::ActorAsset()

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.h
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.h
@@ -209,6 +209,8 @@ namespace EMotionFX
             SSkinningData* GetSkinningData();
             void SetSkinningMethod(SkinningMethod method);
 
+            void SetRenderNearest(bool isRenderNearest);
+
             // Determines if the morph target weights were updated since the last call.
             // It is used to avoid calling UpdateDynamicSkin if the weights have not been
             // updated.
@@ -232,6 +234,8 @@ namespace EMotionFX
             SkinningMethod                          m_skinningMethod;
 
             AZStd::vector<float>                    m_lastMorphTargetWeights;
+
+            bool                                    m_isRenderNearest{ false };
 
             // history for skinning data, needed for motion blur
             struct

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -219,6 +219,16 @@ namespace EMotionFX
         }
 
         //////////////////////////////////////////////////////////////////////////
+        void ActorComponent::SetRenderNearest()
+        {
+            m_renderNearest = true;
+            if (m_renderNode)
+            {
+                m_renderNode->SetRenderNearest(true);
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////
         void ActorComponent::OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset)
         {
             OnAssetReady(asset);

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
@@ -97,6 +97,7 @@ namespace EMotionFX
             void DebugDrawRoot(bool enable) override;
             bool GetRenderCharacter() const override;
             void SetRenderCharacter(bool enable) override;
+            void SetRenderNearest() override;
             //////////////////////////////////////////////////////////////////////////
 
             //////////////////////////////////////////////////////////////////////////
@@ -169,6 +170,8 @@ namespace EMotionFX
             AnimGraphAsset::AnimGraphInstancePtr            m_animGraphInstance;        ///< Live anim graph instance.
             AZStd::unique_ptr<ActorRenderNode>              m_renderNode;               ///< Actor render node.
             bool                                            m_debugDrawRoot;            ///< Enables drawing of actor root and facing.
+
+            bool                                            m_renderNearest{ false };   ///< Enables EmotionFX actor drawing in camera space.
         };
     } //namespace Integration
 


### PR DESCRIPTION
Rendering subsystem of The Engine allows meshes to be rendered in camera space. This PR allows to enable this behaviour for EmotionFX actors.

This feature is especially important for first person games because it allows to not bother with "weapon-in-a-wall" problem which is solved by physics otherwise.