### PR TITLE
Enabled rain and snow to be simulated in edit mode

### DIFF
--- a/dev/Gems/Rain/Code/Source/EditorRainComponent.h
+++ b/dev/Gems/Rain/Code/Source/EditorRainComponent.h
@@ -40,6 +40,7 @@ namespace Rain
         : public AzToolsFramework::Components::EditorComponentBase
         , public AZ::TransformNotificationBus::Handler
         , public AzFramework::EntityDebugDisplayEventBus::Handler
+        , public AZ::TickBus::Handler
     {
     public:
         friend class RainConverter;
@@ -63,6 +64,9 @@ namespace Rain
         // EntityDebugDisplayEventBus
         void DisplayEntity(bool& handled) override;
 
+        // TickBus
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time);
+
         static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
         {
             provided.push_back(AZ_CRC("RainService"));
@@ -85,6 +89,7 @@ namespace Rain
 
         //Unreflected Data
         AZ::Vector3 m_currentWorldPos;
+        AZ::Transform m_currentWorldTransform;
     };
 
     class RainConverter : public AZ::LegacyConversion::LegacyConversionEventBus::Handler

--- a/dev/Gems/Snow/Code/Source/EditorSnowComponent.cpp
+++ b/dev/Gems/Snow/Code/Source/EditorSnowComponent.cpp
@@ -175,7 +175,7 @@ namespace Snow
     void EditorSnowComponent::UpdateSnow()
     {
         //If the snow component is disabled, set the snow amount to 0
-        if (!m_enabled || gEnv->IsEditor() && !gEnv->IsEditorSimulationMode() && !gEnv->IsEditorGameMode())
+        if (!m_enabled)
         {
             TurnOffSnow();
             return;


### PR DESCRIPTION
Currently snow and rain are not simulated in Edit mode of the Editor (only in simulation/game mode) which makes very painful to setup snow and rain on level for artists, because for seeing every effect change you have to enter/exit game/simulation mode.