### PR TITLE
Added vertex colors to EMotionFX Actor Builder

### DIFF
--- a/dev/Code/Tools/SceneAPI/FbxSDKWrapper/FbxTypeConverter.cpp
+++ b/dev/Code/Tools/SceneAPI/FbxSDKWrapper/FbxTypeConverter.cpp
@@ -30,6 +30,15 @@ namespace AZ
                 static_cast<AZ::VectorFloat>(static_cast<float>(vector[2])));
         }
 
+        Vector4 FbxTypeConverter::ToVector4(const FbxVector4& vector)
+        {
+            // Note: FbxVector4[x] is of type FbxDouble and aznumeric_caster does not accept it as cast from type.
+            return Vector4(static_cast<float>(vector[0]),
+                static_cast<float>(vector[1]),
+                static_cast<float>(vector[2]),
+                static_cast<float>(vector[3]));
+        }
+
         Transform FbxTypeConverter::ToTransform(const FbxAMatrix& matrix)
         {
             Transform transform;

--- a/dev/Code/Tools/SceneAPI/FbxSDKWrapper/FbxTypeConverter.h
+++ b/dev/Code/Tools/SceneAPI/FbxSDKWrapper/FbxTypeConverter.h
@@ -24,6 +24,7 @@ namespace AZ
         public:
             static Vector2 ToVector2(const FbxVector2& vector);
             static Vector3 ToVector3(const FbxVector4& vector);
+            static Vector4 ToVector4(const FbxVector4& vector);
             static Transform ToTransform(const FbxAMatrix& matrix);
             static Transform ToTransform(const FbxMatrix& matrix);
         };

--- a/dev/Code/Tools/SceneAPI/FbxSceneBuilder/Importers/Utilities/FbxMeshImporterUtilities.cpp
+++ b/dev/Code/Tools/SceneAPI/FbxSceneBuilder/Importers/Utilities/FbxMeshImporterUtilities.cpp
@@ -175,6 +175,37 @@ namespace AZ
                     }
                 }
 
+                // add colors
+                for (int i = 0; i < sourceMesh.GetElementVertexColorCount(); ++i)
+                {
+                    AZ_TraceContext("Vertex color index", i);
+
+                    FbxSDKWrapper::FbxVertexColorWrapper fbxVertexColors = const_cast<FbxSDKWrapper::FbxMeshWrapper&>(sourceMesh).GetElementVertexColor(i);
+
+                    const int fbxPolygonCount = sourceMesh.GetPolygonCount();
+                    const int* const fbxPolygonVertices = sourceMesh.GetPolygonVertices();
+                    for (int fbxPolygonIndex = 0; fbxPolygonIndex < fbxPolygonCount; ++fbxPolygonIndex)
+                    {
+                        const int fbxPolygonVertexCount = sourceMesh.GetPolygonSize(fbxPolygonIndex);
+                        if (fbxPolygonVertexCount < 3)
+                        {
+                            continue;
+                        }
+
+                        const int fbxVertexStartIndex = sourceMesh.GetPolygonVertexIndex(fbxPolygonIndex);
+
+                        for (int polygonVertexIndex = 0; polygonVertexIndex < fbxPolygonVertexCount; ++polygonVertexIndex)
+                        {
+                            const int fbxPolygonVertexIndex = fbxVertexStartIndex + polygonVertexIndex;
+                            const int fbxControlPointIndex = fbxPolygonVertices[fbxPolygonVertexIndex];
+
+                            FbxSDKWrapper::FbxColorWrapper color = fbxVertexColors.GetElementAt(fbxPolygonIndex, fbxPolygonVertexIndex, fbxControlPointIndex);
+
+                            mesh->AddColor(Vector4(color.GetR(), color.GetG(), color.GetB(), color.GetAlpha()) * 255.0f);
+                        }
+                    }
+                }
+
                 // Report problem if no vertex or face converted to MeshData
                 if (mesh->GetVertexCount() <= 0 || mesh->GetFaceCount() <= 0)
                 {

--- a/dev/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshData.h
+++ b/dev/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshData.h
@@ -53,10 +53,12 @@ namespace AZ
 
                 virtual unsigned int GetVertexCount() const = 0;
                 virtual bool HasNormalData() const = 0;
+                virtual bool HasColorData() const = 0;
 
                 //1 to 1 mapping from position to normal (each corner of triangle represented)
                 virtual const AZ::Vector3& GetPosition(unsigned int index) const = 0;
                 virtual const AZ::Vector3& GetNormal(unsigned int index) const = 0;
+                virtual const AZ::Vector4& GetColor(unsigned int index) const = 0;
 
                 virtual unsigned int GetFaceCount() const = 0;
                 virtual const Face& GetFaceInfo(unsigned int index) const = 0;

--- a/dev/Code/Tools/SceneAPI/SceneCore/Mocks/DataTypes/GraphData/MockIMeshData.h
+++ b/dev/Code/Tools/SceneAPI/SceneCore/Mocks/DataTypes/GraphData/MockIMeshData.h
@@ -35,12 +35,16 @@ namespace AZ
                     bool());
                 MOCK_CONST_METHOD0(HasTextureCoordinates,
                     bool());
+                MOCK_CONST_METHOD0(HasColorData,
+                    bool());
                 MOCK_CONST_METHOD1(GetPosition,
                     const AZ::Vector3 & (unsigned int index));
                 MOCK_CONST_METHOD1(GetNormal,
                     const AZ::Vector3 & (unsigned int index));
                 MOCK_CONST_METHOD1(GetTextureCoordinates,
                     const AZ::Vector2 & (unsigned int index));
+                MOCK_CONST_METHOD1(GetColor,
+                    const AZ::Vector4 & (unsigned int index));
                 MOCK_CONST_METHOD0(GetFaceCount,
                     unsigned int());
                 MOCK_CONST_METHOD1(GetFaceInfo,

--- a/dev/Code/Tools/SceneAPI/SceneData/GraphData/MeshData.cpp
+++ b/dev/Code/Tools/SceneAPI/SceneData/GraphData/MeshData.cpp
@@ -34,6 +34,11 @@ namespace AZ
                 m_normals.push_back(normal);
             }
 
+            void MeshData::AddColor(const AZ::Vector4& color)
+            {
+                m_colors.push_back(color);
+            }
+
             //assume consistent winding - no stripping or fanning expected (3 index per face)
             //indices can be used for position and normal
             void MeshData::AddFace(unsigned int index1, unsigned int index2, unsigned int index3, unsigned int faceMaterialId)
@@ -76,6 +81,11 @@ namespace AZ
                 return m_controlPointToUsedVertexIndexMap.size();
             }
 
+            bool MeshData::HasColorData() const
+            {
+                return !m_colors.empty();
+            }
+
             int MeshData::GetUsedPointIndexForControlPoint(int controlPointIndex) const
             {
                 auto iter = m_controlPointToUsedVertexIndexMap.find(controlPointIndex);
@@ -109,6 +119,12 @@ namespace AZ
             {
                 AZ_Assert(index < m_normals.size(), "GetNormal index not in range");
                 return m_normals[index];
+            }
+
+            const AZ::Vector4& MeshData::GetColor(unsigned int index) const
+            {
+                AZ_Assert(index < m_colors.size(), "GetColor index not in range");
+                return m_colors[index];
             }
 
             unsigned int MeshData::GetFaceCount() const

--- a/dev/Code/Tools/SceneAPI/SceneData/GraphData/MeshData.h
+++ b/dev/Code/Tools/SceneAPI/SceneData/GraphData/MeshData.h
@@ -18,6 +18,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/Math/Vector4.h>
 
 
 namespace AZ
@@ -37,6 +38,7 @@ namespace AZ
                 //positions with more than one normal or uv (seam) will duplicate shared values in multiple verts
                 SCENE_DATA_API virtual void AddPosition(const AZ::Vector3& position);
                 SCENE_DATA_API virtual void AddNormal(const AZ::Vector3& normal);
+                SCENE_DATA_API virtual void AddColor(const AZ::Vector4& color);
 
                 //assume consistent winding - no stripping or fanning expected (3 index per face)
                 SCENE_DATA_API void AddFace(unsigned int index1, unsigned int index2, unsigned int index3,
@@ -51,9 +53,11 @@ namespace AZ
 
                 SCENE_DATA_API unsigned int GetVertexCount() const override;
                 SCENE_DATA_API bool HasNormalData() const override;
+                SCENE_DATA_API bool HasColorData() const override;
 
                 SCENE_DATA_API const AZ::Vector3& GetPosition(unsigned int index) const override;
                 SCENE_DATA_API const AZ::Vector3& GetNormal(unsigned int index) const override;
+                SCENE_DATA_API const AZ::Vector4& GetColor(unsigned int index) const override;
 
                 SCENE_DATA_API unsigned int GetFaceCount() const override;
                 SCENE_DATA_API const AZ::SceneAPI::DataTypes::IMeshData::Face& GetFaceInfo(unsigned int index) const override;
@@ -64,6 +68,7 @@ namespace AZ
             protected:
                 AZStd::vector<AZ::Vector3>                              m_positions;
                 AZStd::vector<AZ::Vector3>                              m_normals;
+                AZStd::vector<AZ::Vector4>                              m_colors;
 
                 AZStd::vector<AZ::SceneAPI::DataTypes::IMeshData::Face> m_faceList;
 

--- a/dev/Gems/EMotionFX/Code/EMotionFX/Pipeline/RCExt/Actor/ActorBuilder.cpp
+++ b/dev/Gems/EMotionFX/Code/EMotionFX/Pipeline/RCExt/Actor/ActorBuilder.cpp
@@ -26,6 +26,7 @@
 #include <SceneAPI/SceneCore/DataTypes/GraphData/ISkinWeightData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexTangentData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexBitangentData.h>
+#include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexColorData.h>
 #include <SceneAPI/SceneCore/DataTypes/DataTypeUtilities.h>
 #include <SceneAPI/SceneCore/DataTypes/Rules/IBlendShapeRule.h>
 #include <SceneAPI/SceneCore/DataTypes/Rules/IMaterialRule.h>
@@ -456,6 +457,14 @@ namespace EMotionFX
             EMotionFX::MeshBuilderVertexAttributeLayerVector3* normalsLayer = EMotionFX::MeshBuilderVertexAttributeLayerVector3::Create(numOrgVerts, EMotionFX::Mesh::ATTRIB_NORMALS, false, true);
             meshBuilder->AddLayer(normalsLayer);
 
+            // The color layer
+            EMotionFX::MeshBuilderVertexAttributeLayerVector4* pColorsLayer = nullptr;
+            if (meshData->HasColorData())
+            {
+                pColorsLayer = EMotionFX::MeshBuilderVertexAttributeLayerVector4::Create(numOrgVerts, EMotionFX::Mesh::ATTRIB_COLORS32, false, true);
+                meshBuilder->AddLayer(pColorsLayer);
+            }
+
             // A Mesh can have multiple children that contain UV, tangent or bitangent data.
             SceneDataTypes::IMeshVertexUVData*                  meshUVDatas[2]      = { nullptr, nullptr };
             SceneDataTypes::IMeshVertexTangentData*             meshTangentData     = nullptr;
@@ -526,6 +535,7 @@ namespace EMotionFX
             AZ::Vector3 bitangent;
             AZ::Vector4 newTangent;
             AZ::PackedVector3f bitangentVec;
+            AZ::Vector4 color;
             const AZ::u32 numTriangles = meshData->GetFaceCount();
             for (AZ::u32 i = 0; i < numTriangles; ++i)
             {
@@ -630,6 +640,12 @@ namespace EMotionFX
                         }
                         bitangentVec.Set(bitangent.GetX(), bitangent.GetY(), bitangent.GetZ());
                         bitangentLayer->SetCurrentVertexValue(&bitangentVec);
+                    }
+
+                    if (pColorsLayer)
+                    {
+                        color = meshData->GetColor(vertexIndex);
+                        pColorsLayer->SetCurrentVertexValue(&color);
                     }
 
                     meshBuilder->AddPolygonVertex(orgVertexNumber);

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.cpp
@@ -729,6 +729,7 @@ namespace EMotionFX
                 bool hasUVs2 = false;
                 bool hasTangents = false;
                 bool hasBitangents = false;
+                bool hasColors = false;
 
                 // Find the number of submeshes in the full actor.
                 // This will be the number of primitives.
@@ -763,6 +764,8 @@ namespace EMotionFX
                     hasUVs  = (mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_UVCOORDS, 0) != nullptr);
                     hasUVs2 = (mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_UVCOORDS, 1) != nullptr);
                     hasTangents = (mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_TANGENTS) != nullptr);
+                    hasColors |= (mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_COLORS32) != nullptr);
+                    hasColors |= (mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_COLORS128) != nullptr);
 
                     const AZ::PackedVector3f*   sourcePositions     = static_cast<AZ::PackedVector3f*>(mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_POSITIONS));
                     const AZ::PackedVector3f*   sourceNormals       = static_cast<AZ::PackedVector3f*>(mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_NORMALS));
@@ -772,6 +775,7 @@ namespace EMotionFX
                     const AZ::Vector2*          sourceUVs           = static_cast<AZ::Vector2*>(mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_UVCOORDS, 0));
                     const AZ::Vector2*          sourceUVs2          = static_cast<AZ::Vector2*>(mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_UVCOORDS, 1));
                     EMotionFX::SkinningInfoVertexAttributeLayer* sourceSkinningInfo = static_cast<EMotionFX::SkinningInfoVertexAttributeLayer*>(mesh->FindSharedVertexAttributeLayer(EMotionFX::SkinningInfoVertexAttributeLayer::TYPE_ID));
+                    const AZ::Vector4* sourceColors = static_cast<AZ::Vector4*>(mesh->FindOriginalVertexData(EMotionFX::Mesh::ATTRIB_COLORS32));
 
                     // For each sub-mesh within each mesh, we want to create a separate sub-piece.
                     const uint32 numSubMeshes = mesh->GetNumSubMeshes();
@@ -810,6 +814,10 @@ namespace EMotionFX
                         {
                             primitive.m_mesh->ReallocStream(CMesh::TEXCOORDS, 1, subMesh->GetNumVertices());
                         }
+                        if (hasColors)
+                        {
+                            primitive.m_mesh->ReallocStream(CMesh::COLORS, 0, subMesh->GetNumVertices());
+                        }
 
                         primitive.m_mesh->m_pBoneMapping = primitive.m_vertexBoneMappings.data();
 
@@ -821,6 +829,7 @@ namespace EMotionFX
                         SMeshTexCoord* destTexCoords2 = primitive.m_mesh->GetStreamPtr<SMeshTexCoord>(CMesh::TEXCOORDS, 1);
                         SMeshTangents* destTangents = primitive.m_mesh->GetStreamPtr<SMeshTangents>(CMesh::TANGENTS);
                         SMeshBoneMapping_uint16* destBoneMapping = primitive.m_vertexBoneMappings.data();
+                        SMeshColor* destColor = primitive.m_mesh->GetStreamPtr<SMeshColor>(CMesh::COLORS);
 
                         primitive.m_mesh->m_subsets.push_back();
                         SMeshSubset& subset     = primitive.m_mesh->m_subsets.back();
@@ -945,6 +954,14 @@ namespace EMotionFX
                                     *destTangents = SMeshTangents();
                                     ++destTangents;
                                 }
+                            }
+                        }
+
+                        if (sourceColors)
+                        {
+                            for (uint32 vertexIndex = subMesh->GetStartVertex(); vertexIndex < numSubMeshVertices; ++vertexIndex, ++destColor)
+                            {
+                                *destColor = SMeshColor(AZVec4ToLYVec4(sourceColors[vertexIndex]));
                             }
                         }
 


### PR DESCRIPTION
Engine's rendering subsystem, shaders and layouts support vertex colors (as well as mesh components) and they are convinient for different rendering tasks.

This PR adds support for vertex colors in EMotionFX Actors.