### PR TITLE
Fixed ComputeLocalTM in TransformComponent

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -1192,7 +1192,7 @@ namespace AzFramework
         {
             m_localTM = m_parentTM->GetWorldTM().GetInverseFull() * m_worldTM;
         }
-        else
+        else if (!m_parentId.IsValid())
         {
             m_localTM = m_worldTM;
         }


### PR DESCRIPTION
Fixed ComputeLocalTM function in TransformComponent which led object to disappear in Editor's game mode.

The same was already done for ComputeWorldTM in LY code.