### PR TITLE
Fixed false alarm warning on level load

### DIFF
--- a/dev/Gems/CryLegacy/Code/Source/CryAction/LevelSystem.cpp
+++ b/dev/Gems/CryLegacy/Code/Source/CryAction/LevelSystem.cpp
@@ -1488,7 +1488,7 @@ ILevel* CLevelSystem::LoadLevelInternal(const char* _levelName)
 
             XmlNodeRef objectsNode = rootNode->findChild("Objects");
 
-            if (objectsNode)
+            if (objectsNode && objectsNode->getChildCount() > 0)
             {
                 gEnv->pEntitySystem->LoadEntities(objectsNode, true);
             }


### PR DESCRIPTION
This fixes false alarm warning during level load (map command): 

> CEntitySystem::LoadEntities : Not all entities were loaded correctly

which happens when there are no legacy objects in level.pak / mission_0.xml, and it happens when you use only new component entities.