### PR TITLE
add warning for ignored shaders flags 

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderParse.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderParse.cpp
@@ -737,7 +737,6 @@ uint64 CShaderMan::mfGetShaderGlobalMaskGenFromString(const char* szShaderGen)
         {
             nMaskGen |= pIter->second;
         }
-        AZ_Warning("Shaders", pIter != pEnd, "Failed to find property \"%s\". Shader macro is ignored.", pCurrFlag);
     }
 
     return nMaskGen;

--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderParse.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/ShaderParse.cpp
@@ -737,6 +737,7 @@ uint64 CShaderMan::mfGetShaderGlobalMaskGenFromString(const char* szShaderGen)
         {
             nMaskGen |= pIter->second;
         }
+        AZ_Warning("Shaders", pIter != pEnd, "Failed to find property \"%s\". Shader macro is ignored.", pCurrFlag);
     }
 
     return nMaskGen;


### PR DESCRIPTION
*Description of changes:*
Add warning for ignored shaders flags. 
https://gamedev.amazon.com/forums/articles/74764/shader-property-is-ignored.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
