### PR TITLE
Fix out of range access for mini table columns

### DIFF
--- a/dev/Code/CryEngine/CrySystem/MiniGUI/MiniTable.cpp
+++ b/dev/Code/CryEngine/CrySystem/MiniGUI/MiniTable.cpp
@@ -70,7 +70,7 @@ void CMiniTable::OnPaint(CDrawContext& dc)
     float y = m_rect.top + indent;
 
     const int nColumns = m_columns.size();
-    int numEntries = m_columns[0].cells.size();
+    int numEntries = nColumns > 0 ? m_columns[0].cells.size() : 0;
 
     int startIdx = 0;
     int endIdx = numEntries;


### PR DESCRIPTION
Number of entries can be invalid in case of columns vector is empty.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
