### PR TITLE
Fix mess in profiler output on dedicated server

### DIFF
--- a/dev/Code/CryEngine/CrySystem/WindowsConsole.cpp
+++ b/dev/Code/CryEngine/CrySystem/WindowsConsole.cpp
@@ -781,6 +781,8 @@ void CWindowsConsole::CleanUp()
 
 void CWindowsConsole::DrawFull()
 {
+    m_fullScreenBuffer.Clear(); 
+
     for (DynArray< SConDrawCmd >::iterator iter = m_drawCmds.begin(); iter != m_drawCmds.end(); ++iter)
     {
         m_fullScreenBuffer.PutText(iter->x, iter->y, iter->text);


### PR DESCRIPTION
Priority 2
profile command output isn't properly rendered on Windows dedicated server console.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
