### PR TITLE
Script canvas performance optimization

### DIFF
--- a/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
+++ b/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
@@ -305,6 +305,7 @@ namespace ScriptCanvas
             // Also add a mapping of the InvalidUniqueRuntimeId to the graph uniqueId
             // as well as an identity mapping for the EntityId and the UniqueId
             assetToRuntimeEntityIdMap.insert(assetToRuntimeInternalMap.begin(), assetToRuntimeInternalMap.end());
+            AZStd::swap(assetToRuntimeEntityIdMap, loadedGameEntityIdMap);
             assetToRuntimeEntityIdMap.insert(loadedGameEntityIdMap.begin(), loadedGameEntityIdMap.end());
             // Add only entities within the m_assetToRuntimeEntityIdMap that has been mapped to a new value
             for (const auto& assetToRuntimeEntityIdPair : m_variableEntityIdMap)


### PR DESCRIPTION
Priority 1
New entity spawn creates significant performance drop (5-10 fps) on levels with amount of entities is more than 10K. It happens because of copying all loaded entities into new map for Id remapping progress. This fix optimize this routine by copying newly added into already loaded.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
