### PR TITLE
Physx linux dedicated server unresolved links fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.renderWhitespace": "all",
+    "editor.detectIndentation": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "editor.renderWhitespace": "all",
-    "editor.detectIndentation": false
-}

--- a/dev/Gems/PhysX/Code/wscript
+++ b/dev/Gems/PhysX/Code/wscript
@@ -18,8 +18,8 @@ def build(bld):
         test_all_includes = [bld.Path('Code/Framework/Tests')],
         pch               = "Source/PhysX_precompiled.cpp",
         use               = ['AzFramework',
-                             'LmbrCentral'],
-        uselib			  = ['PHYSX_SDK'],
+                             'LmbrCentral', 'PHYSX_SDK'],
+        linux_includes    = [bld.Path('Gems/LmbrCentral/Code/include')],
         test_all_use      = ['AzPhysicsTests'],
         win_features      = ['crcfix'],
 

--- a/dev/Gems/PhysX/Code/wscript
+++ b/dev/Gems/PhysX/Code/wscript
@@ -19,7 +19,6 @@ def build(bld):
         pch               = "Source/PhysX_precompiled.cpp",
         use               = ['AzFramework',
                              'LmbrCentral', 'PHYSX_SDK'],
-        linux_includes    = [bld.Path('Gems/LmbrCentral/Code/include')],
         test_all_use      = ['AzPhysicsTests'],
         win_features      = ['crcfix'],
 

--- a/dev/_WAF_/3rdParty/physx.json
+++ b/dev/_WAF_/3rdParty/physx.json
@@ -49,7 +49,6 @@
             "PhysXDevice64"
         ],
         "lib_names_shared": [
-            "PhysX3Gpu",
             "${lib_names}"
         ],
         "lib_paths": [


### PR DESCRIPTION
Priority 1
Fix unresolved link issues for Linux dedicated server with new PhysX gem. Remove missed CUDA library from list of libraries to link to for LDS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
