### PR TITLE
Fix incorrect clang path for Linux dedicated server

### DIFF
--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/compile_rules_linux_x64_host.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/compile_rules_linux_x64_host.py
@@ -38,7 +38,7 @@ def load_linux_x64_host_settings(conf):
                                               conf.ThirdPartyPath('jinja2', 'x64')]
     v['CODE_GENERATOR_PYTHON_HOME'] = conf.Path('Tools/Python/2.7.12/linux_x64')
     v['CODE_GENERATOR_PYTHON_HOME_DEBUG'] = conf.Path('Tools/Python/2.7.12/linux_x64')
-    v['CODE_GENERATOR_INCLUDE_PATHS'] = [conf.ThirdPartyPath('Clang', 'linux_x64/release/lib/clang/6.0.0/include')]
+    v['CODE_GENERATOR_INCLUDE_PATHS'] = [conf.ThirdPartyPath('Clang', 'linux_x64/release/lib/clang/6.0.1/include')]
 
     # Detect the QT binaries, if the current capabilities selected requires it.
     _, enabled, _, _ = conf.tp.get_third_party_path(PLATFORM, 'qt')


### PR DESCRIPTION
AzCodeGenerator uses incorrect clang path during Linux dedicated build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
