### PR TITLE
Bugfix: Freeze when creating slices

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/EntityContext.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/EntityContext.cpp
@@ -792,6 +792,7 @@ namespace AzFramework
                         // as soon as possible, before we call these below notification functions, because they might result in our own functions
                         // that search this list being called again.
                         iter = m_queuedSliceInstantiations.erase(iter);
+						bool bIsIterEnd = iter == m_queuedSliceInstantiations.end();
                         // --------------------------- do not refer to 'instantiating' after the above call, it has been destroyed ------------
                         
                         bool isSliceInstantiated = false;
@@ -812,6 +813,12 @@ namespace AzFramework
                                 SliceInstantiationResultBus::Event(ticket, &SliceInstantiationResultBus::Events::OnSliceInstantiated, m_instantiatingAssetId, instance);
 
                                 isSliceInstantiated = true;
+
+								if (bIsIterEnd && iter != m_queuedSliceInstantiations.end())
+								{
+									//Items added into the queue while we were iterating on it so we'll reset the iterator at the beginning in case the asset is already ready
+									iter = m_queuedSliceInstantiations.begin();
+								}
                             }
                             else
                             {


### PR DESCRIPTION
This modification fixes a freeze that can happen when requesting slice instantiation while OnAsset ready is being dispatched.

If the last item in the queue was being Dispatched and this triggered new slice creation requests, then iter was no longer pointing to the end (it was pointing to the old end) and this was causing a freeze while spinning in the loop and progressing the iterator into unknown memory regions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
