### PR TITLE
Fix to Editor resetting the FOV when updating the camera,

### DIFF
--- a/dev/Code/Sandbox/Editor/GameEngine.cpp
+++ b/dev/Code/Sandbox/Editor/GameEngine.cpp
@@ -2062,7 +2062,7 @@ void CGameEngine::Update()
             }
 
             CCamera& cam = gEnv->pSystem->GetViewCamera();
-            cam.SetFrustum(width, height, pRenderViewport->GetFOV(), cam.GetNearPlane(), cam.GetFarPlane(), cam.GetPixelAspectRatio());
+            cam.SetFrustum(width, height, cam.GetFov(), cam.GetNearPlane(), cam.GetFarPlane(), cam.GetPixelAspectRatio());
         }
 
         if (gEnv->pGame && gEnv->pGame->GetIGameFramework())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Editor updates the camera using default FOV settings, effectively undoing the FOV settings in the camera component.  Fix is to use the existing FOV settings from the existing camera.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
