### PR TITLE
Fix asset processor batch crash on big number of assets

### DIFF
--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetDatabase/AssetDatabaseConnection.cpp
@@ -2463,6 +2463,9 @@ namespace AzToolsFramework
                 {
                     if (includeLegacySubIDs)
                     {
+                        // clear legacy ID array from previous assets
+                        combined.m_legacySubIDs.clear();
+
                         QueryLegacySubIdsByProductID(combined.m_productID, [&combined](LegacySubIDsEntry& entry)
                         {
                             combined.m_legacySubIDs.emplace_back(AZStd::move(entry));


### PR DESCRIPTION
Priority 1
Asset processor batch is crashed on big number of assets. The reason of crash is that legacy IDs array is not cleared between assets and constantly growing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
