### PR TITLE
Fix uninitialized value in const cvar for release

### DIFF
--- a/dev/Code/CryEngine/CryCommon/ISystem.h
+++ b/dev/Code/CryEngine/CryCommon/ISystem.h
@@ -2236,7 +2236,7 @@ namespace Detail
 
 #else
 
-# define DeclareConstIntCVar(name, defaultValue) int name
+# define DeclareConstIntCVar(name, defaultValue) int name { defaultValue }
 # define DeclareStaticConstIntCVar(name, defaultValue) static int name
 # define DefineConstIntCVarName(strname, name, defaultValue, flags, help) \
     (gEnv->pConsole == 0 ? 0 : gEnv->pConsole->Register(strname, &name, defaultValue, flags | CONST_CVAR_FLAGS, CVARHELP(help)))


### PR DESCRIPTION
*Issue #, if available:*

Some of cvars declared using DeclareConstIntCVar contains uninitialized value in release build. This fix sets such cvars to its default value.
For example cvar: e_MemoryProfiling. For release there is only declaration but initialization is excluded by RELEASE define as result we have random cases when such cvar is not zero and memory profiling info is displayed on the screen

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
