### PR TITLE
IDataContainer::GetElement (for variant) must return valid element when given DefaultElementCrc

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
+++ b/dev/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
@@ -67,19 +67,25 @@ namespace AZ
             AZStdVariantContainer()
             {
                 CreateClassElementArray(AZStd::make_index_sequence<s_variantSize>{});
+
+                // Set basic information about this type
+                m_thisClassElement.m_name = GetDefaultElementName();
+                m_thisClassElement.m_nameCrc = GetDefaultElementNameCrc();
+                m_thisClassElement.m_dataSize = sizeof(VariantType);
+                m_thisClassElement.m_offset = 0;
+                m_thisClassElement.m_azRtti = GetRttiHelper<VariantType>();
+                m_thisClassElement.m_flags = SerializeContext::ClassElement::FLG_DYNAMIC_FIELD;
+                m_thisClassElement.m_typeId = SerializeGenericTypeInfo<VariantType>::GetClassTypeId();
+
+                // Setup attribute allocates
+                m_thisClassElement.m_attributes.set_allocator(AZ::AZStdFunctorAllocator([]() -> AZ::IAllocatorAllocate& { return AZ::GetCurrentSerializeContextModule().GetAllocator(); }));
+
             }
 
             /// Returns the element generic (offsets are mostly invalid 0xbad0ffe0, there are exceptions). Null if element with this name can't be found.
             const SerializeContext::ClassElement* GetElement(u32 elementNameCrc) const override
             {
-                for (const SerializeContext::ClassElement& classElement : m_alternativeClassElements)
-                {
-                    if (classElement.m_nameCrc == elementNameCrc)
-                    {
-                        return &classElement;
-                    }
-                }
-                return nullptr;
+                return elementNameCrc == m_thisClassElement.m_nameCrc ? &m_thisClassElement : nullptr;
             }
 
             bool GetElement(SerializeContext::ClassElement& resultClassElement, const SerializeContext::DataElement& dataElement) const override
@@ -210,6 +216,8 @@ namespace AZ
             }
 
             SerializeContext::ClassElement m_alternativeClassElements[s_variantSize];
+            SerializeContext::ClassElement m_thisClassElement;
+
         private:
             template <typename AltType>
             void CreateClassElementAtIndex(SerializeContext::ClassElement& altClassElement, const char* elementName)
@@ -432,6 +440,9 @@ namespace AZ
                 using ContainerType = AttributeContainerType<AZStd::function<void(SerializeContext::EnumerateInstanceCallContext&,
                     const void*, const SerializeContext::ClassData&, const SerializeContext::ClassElement*)>>;
                 m_classData.m_attributes.emplace_back(AZ_CRC("ObjectStreamWriteElementOverride", 0x35eb659f), CreateModuleAttribute<ContainerType>(&ObjectStreamWriter));
+
+                // Tie the knot
+                m_variantContainer.m_thisClassElement.m_genericClassInfo = this;
             }
 
             SerializeContext::ClassData* GetClassData() override
@@ -519,7 +530,8 @@ namespace AZ
 
         static const Uuid& GetClassTypeId()
         {
-            return GetGenericInfo()->GetClassData()->m_typeId;
+            static const Uuid typ = azrtti_typeid<VariantType>();
+            return typ;
         }
     };
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The following code (InstanceDataHierarchy.cpp:263) which handles adding elements to containers through their IDataContainer implementation assumes this is true:

```
    const AZ::SerializeContext::ClassElement* containerClassElement = container->GetElement(container->GetDefaultElementNameCrc());

    AZ_Assert(containerClassElement != NULL, "We should have a valid default element in the container, otherwise we don't know what elements to make!");
```
It’s easy enough to add an early exit if the assertion fails, however, this doesn’t allow the variant data container (or any other data container which returns null from GetElement when given GetDefaultElementNameCrc) to actually function as a container.

Other contains implement this GetElement function by returning an element only for the default element name; and the contents of the element are “synthetic” in the sense that they contain meta-data which describes what kind of elements can go into the container, how to display those elements, how to query the user for datums of that element type, etc., as opposed to describing a “physical” element which is really stored in the parent datum (which by necessity would have things like a real offset, a non-dummy name, etc.). (Aside: SerializeContext::ClassElement probably shouldn’t be used for this purpose, but that’s for another issue).

This merge request changes the variant IDataContainer to conform to these semantics.

Note that this patch uses SerializeGenericTypeInfo of the variant type inside the IDataContainer implementation, which would cause an infinite loop; so the GetClassTypeId implementation is changed to avoid this. Unlike most containers, variant cannot return a class element here whose type indicates the element type, because variant has many different element types, and there is not necessarily a preferred choice - return the leftmost element type or anything else which gives preferences to a particular alternative will only require more special casing in other places which consume such “synthetic” class elements. I’ve chosen to implement this synthetic element with a `m_typeId` which is precisely that of the variant class, because it makes the most sense to me. However, no choice of type ID “really” makes sense here - SerializeContext::ClassElement is simply the wrong datum to return from this function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
