### PR TITLE
Include MSVC debugging files in MSVC solution through WAF instead of using a batch script

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/std/azstd.waf_files
+++ b/dev/Code/Framework/AzCore/AzCore/std/azstd.waf_files
@@ -1,6 +1,13 @@
 {
     "none": 
     {
+        "std/_Debugging": [
+            "debugger tools/smartdebug/azcore.natvis",
+            "debugger tools/smartdebug/azcore_vs2013.natvis",
+            "debugger tools/smartdebug/azcore_vs2015.natvis",
+            "debugger tools/smartdebug/azcore.natjmc",
+            "debugger tools/smartdebug/azcore.natstepfilter"
+        ],
         "std":
         [
             "algorithm.h",

--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/msvs.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/msvs.py
@@ -384,6 +384,9 @@ SUPPORTED_MSVS_VALUE_TABLE = {
 }
 
 
+MSVC_DEBUGGER_FILE_EXTS = { '.natvis' : 'Natvis', '.natjmc' : 'Natjmc', '.natstepfilter' : 'Natstepfilter' }
+
+
 class VS_Configuration(object):
 
     def __init__(self, vs_spec, waf_spec, waf_configuration):
@@ -799,9 +802,15 @@ class vsnode_project(vsnode):
         required for writing the source files
         """
         name = node.name
+        name_l = name.lower()
+        for debugger_source_ext in MSVC_DEBUGGER_FILE_EXTS:
+            if name_l.endswith(debugger_source_ext):
+                return MSVC_DEBUGGER_FILE_EXTS[debugger_source_ext]
+
         if self.ctx.is_cxx_file(name):
             return 'ClCompile'
-        return 'ClInclude'
+        else:
+            return 'ClInclude'
 
     def collect_properties(self):
         """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Lumberyard very helpfully contains natvis files which define how AZStd data types are displayed in the MSVC debugger. However, currently the only way to install these is with a batch script. There are not included in the MSVC solution generated by Waf.

Using this script is very inconvenient for many reasons:

- you have to know it exists!
- it installs to the global MSVC natvis storage locations. This effectively causes different installations of LY to clobber each others’ natvis files.
- you have to re-run it if you change the natvis files
- you have to change it if you add new natvis files (see first point about not knowing it exists)
- you cannot live-edit the natvis files installed with the batch script while debugging in MSVC

On the other hand, if they were simply included in the generated solution by Waf, all of these problems would be solved. This is what this merge request does.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
