### PR TITLE
Avoid dangling pointer in variant reflection.

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
+++ b/dev/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
@@ -100,9 +100,9 @@ namespace AZ
             void EnumElements(void* instance, const ElementCB& cb) override
             {
                 auto variantInst = reinterpret_cast<VariantType*>(instance);
-                auto enumElementsVisitor = [cb, altClassElement = m_alternativeClassElements[variantInst->index()]](auto&& elementAlt)
+                auto enumElementsVisitor = [cb, altClassElement = &m_alternativeClassElements[variantInst->index()]](auto&& elementAlt)
                 {
-                    cb(&const_cast<AZStd::remove_cvref_t<decltype(elementAlt)>&>(elementAlt), altClassElement.m_typeId, altClassElement.m_genericClassInfo ? altClassElement.m_genericClassInfo->GetClassData() : nullptr, &altClassElement);
+                    cb(&const_cast<AZStd::remove_cvref_t<decltype(elementAlt)>&>(elementAlt), altClassElement->m_typeId, altClassElement->m_genericClassInfo ? altClassElement->m_genericClassInfo->GetClassData() : nullptr, altClassElement);
                 };
                 AZStd::visit(AZStd::move(enumElementsVisitor), *variantInst);
             }


### PR DESCRIPTION
The callback will sometimes store the pointer to the class element (fourth arg), e.g. InstanceDataHierarchy::Build

*Issue #, if available:*

*Description of changes:*
Title says it all. Current code takes a pointer to a temporary variable which is stored and later accessed after it is no longer valid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
