### PR TITLE
Fix MakeDerivedEntity method super class assignment

### DIFF
--- a/dev/Engine/Scripts/Utils/EntityUtils.lua
+++ b/dev/Engine/Scripts/Utils/EntityUtils.lua
@@ -29,7 +29,7 @@ function MakeDerivedEntity( _DerivedClass,_Parent )
 	-- Add derived class properties.
 	mergef(_DerivedClass.Properties,derivedProperties,1);
 
-	_DerivedClass.__super = BasicEntity;
+	_DerivedClass.__super = _Parent;
 	return _DerivedClass;
 end
 


### PR DESCRIPTION
MakeDerivedEntity always sets its __super reference to BasicEntity, instead of parent entity as it should.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.