### PR TITLE
Avoid derefencing nullptr in EMFX

### DIFF
--- a/dev/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -686,12 +686,11 @@ namespace EMotionFX
                         LmbrCentral::CryCharacterPhysicsRequestBus::EventResult(hasCryPhysicsController, entityId, &LmbrCentral::CryCharacterPhysicsRequests::IsCryCharacterControllerPresent);
 
                         // If we have a physics controller.
-                        AZ::TransformInterface* entityTransform = entity->GetTransform();
                         if (hasPhysicsController || hasCryPhysicsController)
                         {
                             const float deltaTimeInv = (timeDelta > 0.0f) ? (1.0f / timeDelta) : 0.0f;
 
-                            AZ::Transform currentTransform = entityTransform->GetWorldTM();
+                            AZ::Transform currentTransform; EBUS_EVENT_ID_RESULT(currentTransform, entityId, AZ::TransformBus, GetWorldTM);
                             const AZ::Vector3 actorInstancePosition = actorInstance->GetWorldSpaceTransform().mPosition;
 
                             const AZ::Vector3 currentPos = currentTransform.GetPosition();
@@ -714,13 +713,13 @@ namespace EMotionFX
                             if (!rotationDelta.IsIdentity(AZ::g_fltEps))
                             {
                                 currentTransform = currentTransform * AZ::Transform::CreateFromQuaternion(rotationDelta);
-                                entityTransform->SetWorldTM(currentTransform);
+                                EBUS_EVENT_ID(entityId, AZ::TransformBus, SetWorldTM, currentTransform);
                             }
                         }
                         else // There is no physics controller, just use EMotion FX's actor instance transform directly.
                         {                            
                             const AZ::Transform newTransform = MCore::EmfxTransformToAzTransform(actorInstance->GetWorldSpaceTransform());
-                            entityTransform->SetWorldTM(newTransform);
+                            EBUS_EVENT_ID(entityId, AZ::TransformBus, SetWorldTM, newTransform);
                         }
                     }
                 }


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
See title.

We could just check if `entityTransform' is non-null before accessing it, but the more idiomatic way to access the transform is through bus calls. So, this merge request also replaces `AZ::Entity::GetTransform` with EBus calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
