### PR TITLE
Sky Cloud component editor performance improvements

### DIFF
--- a/dev/Gems/Clouds/Code/Source/CloudComponentRenderNode.cpp
+++ b/dev/Gems/Clouds/Code/Source/CloudComponentRenderNode.cpp
@@ -174,7 +174,7 @@ namespace CloudsGem
 
             Transform parentTransform = Transform::CreateIdentity();
             EBUS_EVENT_ID_RESULT(parentTransform, m_attachedToEntityId, TransformBus, GetWorldTM);
-            UpdateWorldTransform(parentTransform);
+            SetWorldTransform(parentTransform);
 
             SystemTickBus::Handler::BusConnect();
             CloudComponentBehaviorRequestBus::Handler::BusConnect(m_attachedToEntityId);
@@ -192,11 +192,15 @@ namespace CloudsGem
         }
     }
 
-    void CloudComponentRenderNode::UpdateWorldTransform(const AZ::Transform& entityTransform)
+    void CloudComponentRenderNode::SetWorldTransform(const AZ::Transform & entityTransform)
     {
         m_worldMatrix = AZTransformToLYTransform(entityTransform);
         m_entityWorldMatrix = m_worldMatrix;
+    }
 
+    void CloudComponentRenderNode::UpdateWorldTransform(const AZ::Transform& entityTransform)
+    {
+        SetWorldTransform(entityTransform);
         Update();
         Refresh();
     }

--- a/dev/Gems/Clouds/Code/Source/CloudComponentRenderNode.cpp
+++ b/dev/Gems/Clouds/Code/Source/CloudComponentRenderNode.cpp
@@ -202,7 +202,6 @@ namespace CloudsGem
     {
         SetWorldTransform(entityTransform);
         Update();
-        Refresh();
     }
 
     void CloudComponentRenderNode::Update()

--- a/dev/Gems/Clouds/Code/Source/CloudComponentRenderNode.h
+++ b/dev/Gems/Clouds/Code/Source/CloudComponentRenderNode.h
@@ -163,6 +163,12 @@ namespace CloudsGem
         CloudParticleData& GetCloudParticleData() { return m_cloudParticleData; }
 
         /**
+        * Sets the render node's world transform properties based on given transform.
+        * @param entityTransform transform from entity
+        */
+        void SetWorldTransform(const AZ::Transform& entityTransform);
+
+        /**
          * Updates the render node's world transform based on the entity.
          * @param entityTransform transform from entity
          */

--- a/dev/Gems/Clouds/Code/Source/CloudGenerator.cpp
+++ b/dev/Gems/Clouds/Code/Source/CloudGenerator.cpp
@@ -66,6 +66,14 @@ namespace CloudsGem
         UpdateParticleData(cloudData);
     }
 
+    void CloudGenerator::Destroy()
+    {
+        m_generatedParticles.clear();
+        m_filteredParticles.clear();
+        m_numChildrenEntities = 0;
+        m_totalArea = 0.f;
+    }
+
     float CloudGenerator::GetBoxDimensions(const AZ::EntityId& entityId)
     {
         LmbrCentral::BoxShapeConfiguration boxShapeConfiguration;

--- a/dev/Gems/Clouds/Code/Source/CloudGenerator.h
+++ b/dev/Gems/Clouds/Code/Source/CloudGenerator.h
@@ -21,6 +21,7 @@ namespace CloudsGem
 
         void Generate(CloudParticleData& cloudData, const AZ::EntityId entityId, GenerationFlag flag);
         void Initialize(CloudParticleData& cloudData);
+        void Destroy();
 
         static void Reflect(AZ::ReflectContext* context);
         static void OnAtlasColumnsChanged();

--- a/dev/Gems/Clouds/Code/Source/EditorCloudComponent.cpp
+++ b/dev/Gems/Clouds/Code/Source/EditorCloudComponent.cpp
@@ -217,6 +217,7 @@ namespace CloudsGem
         EditorCloudComponentRequestBus::Handler::BusDisconnect();
 
         m_renderNode.AttachToEntity(AZ::EntityId());
+        m_cloudGenerator.Destroy();
 
         EditorComponentBase::Deactivate();
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The Sky Cloud cloud editor component has some pathological performance characteristics which make working with it very difficult.

This merge request helps to alleviate this by calling less frequently operations which have significant performance cost (particularly in the case of volumetric clouds). (6e870b1, 6e870b1)

It also fixes a bug in which particle data is duplicated each time the editor Sky Cloud component is deactivate and reactivated (dd21292).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
