### PR TITLE
Level reloading in editor

### DIFF
--- a/dev/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
+++ b/dev/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
@@ -357,6 +357,13 @@ QMenu* LevelEditorMenuHandler::CreateFileMenu()
         DisableActionWhileLevelChanges(fileOpenLevel, e);
     }));
 
+    // Reload level
+    auto fileReloadLevel = fileMenu.AddAction(ID_FILE_RELOAD_LEVEL);
+    GetIEditor()->RegisterNotifyListener(new EditorListener(fileReloadLevel, [fileReloadLevel](EEditorNotifyEvent e)
+    {
+        DisableActionWhileLevelChanges(fileReloadLevel, e);
+    }));
+
 #ifdef ENABLE_SLICE_EDITOR
     // New slice
     auto fileNewSlice = fileMenu.AddAction(ID_FILE_NEW_SLICE);

--- a/dev/Code/Sandbox/Editor/CryEdit.cpp
+++ b/dev/Code/Sandbox/Editor/CryEdit.cpp
@@ -766,6 +766,7 @@ void CCryEditApp::RegisterActionHandlers()
     ON_COMMAND(ID_TOOLBAR_WIDGET_REDO, OnRedo)
     ON_COMMAND(ID_RELOAD_TEXTURES, OnReloadTextures)
     ON_COMMAND(ID_FILE_OPEN_LEVEL, OnOpenLevel)
+    ON_COMMAND(ID_FILE_RELOAD_LEVEL, OnReloadLevel)
 #ifdef ENABLE_SLICE_EDITOR
     ON_COMMAND(ID_FILE_NEW_SLICE, OnCreateSlice)
     ON_COMMAND(ID_FILE_OPEN_SLICE, OnOpenSlice)
@@ -1258,6 +1259,12 @@ void CCryEditApp::OnUpdateDocumentReady(QAction* action)
 void CCryEditApp::OnUpdateFileOpen(QAction* action)
 {
     action->setEnabled(!m_creatingNewLevel && !m_openingLevel && !m_savingLevel);
+}
+
+//////////////////////////////////////////////////////////////////////////
+void CCryEditApp::OnUpdateReloadLevel(QAction* action)
+{
+    action->setEnabled(GetIEditor() && GetIEditor()->GetDocument() && GetIEditor()->GetDocument()->IsDocumentReady() && !m_creatingNewLevel && !m_openingLevel && !m_savingLevel);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -6507,6 +6514,21 @@ void CCryEditApp::OnOpenLevel()
 }
 
 //////////////////////////////////////////////////////////////////////////
+void CCryEditApp::OnReloadLevel()
+{
+    if (auto* doc = GetIEditor()->GetDocument())
+    {
+        OpenDocumentFileWrapper([&]{
+            if (doc->SaveModified())
+            {
+                // Actually open the level file
+                doc->OnOpenDocument(doc->GetLevelPathName());
+            }
+        });
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
 void CCryEditApp::OnOpenSlice()
 {
     QString fileName = QFileDialog::getOpenFileName(MainWindow::instance(),
@@ -6522,6 +6544,14 @@ void CCryEditApp::OnOpenSlice()
 
 //////////////////////////////////////////////////////////////////////////
 CCryEditDoc* CCryEditApp::OpenDocumentFile(LPCTSTR lpszFileName)
+{
+    return OpenDocumentFileWrapper([&]{
+        m_pDocManager->OpenDocumentFile(lpszFileName, true);
+    });
+}
+
+template<class DoOpen>
+inline CCryEditDoc* CCryEditApp::OpenDocumentFileWrapper(DoOpen&& doOpen)
 {
     if (m_openingLevel)
     {
@@ -6547,7 +6577,7 @@ CCryEditDoc* CCryEditApp::OpenDocumentFile(LPCTSTR lpszFileName)
 
         // in this case, we set bAddToMRU to always be true because adding files to the MRU list
         // automatically culls duplicate and normalizes paths anyway
-        m_pDocManager->OpenDocumentFile(lpszFileName, true);
+        doOpen();
 
         if (openDocTraceHandler.HasAnyErrors())
         {

--- a/dev/Code/Sandbox/Editor/CryEdit.h
+++ b/dev/Code/Sandbox/Editor/CryEdit.h
@@ -207,6 +207,7 @@ public:
     // Implementation
     void OnCreateLevel();
     void OnOpenLevel();
+    void OnReloadLevel();
     void OnCreateSlice();
     void OnOpenSlice();
     void OnAppAbout();
@@ -416,6 +417,7 @@ public:
     void OnFileConvertLegacyEntities();
     void OnUpdateDocumentReady(QAction* action);
     void OnUpdateFileOpen(QAction* action);
+    void OnUpdateReloadLevel(QAction* action);
     void OnUpdateCurrentLayer(QAction* action);
     void OnUpdateNonGameMode(QAction* action);
 
@@ -459,6 +461,10 @@ private:
     //! can happen after the level is loaded. This method will wait for a few idle updates and then
     //! display the load errors to ensure all errors are displayed properly.
     void DisplayLevelLoadErrors();
+
+    // Performs any work before and after opening a level file
+    template<class DoOpen>
+    CCryEditDoc* OpenDocumentFileWrapper(DoOpen&& doOpen);
 
 #if AZ_TESTS_ENABLED
     //! Runs tests in the plugin specified as the file argument to the command line,

--- a/dev/Code/Sandbox/Editor/MainWindow.cpp
+++ b/dev/Code/Sandbox/Editor/MainWindow.cpp
@@ -866,6 +866,11 @@ void MainWindow::InitActions()
         .SetMetricsIdentifier("MainEditor", "OpenLevel")
         .SetStatusTip(tr("Open an existing level"))
         .RegisterUpdateCallback(cryEdit, &CCryEditApp::OnUpdateFileOpen);
+    am->AddAction(ID_FILE_RELOAD_LEVEL, tr("Reload Level"))
+        .SetShortcut(tr("Ctrl+R"))
+        .SetMetricsIdentifier("MainEditor", "ReloadLevel")
+        .SetStatusTip(tr("Reload the current level"))
+        .RegisterUpdateCallback(cryEdit, &CCryEditApp::OnUpdateReloadLevel);
 #ifdef ENABLE_SLICE_EDITOR
     am->AddAction(ID_FILE_NEW_SLICE, tr("New Slice"))
         .SetMetricsIdentifier("MainEditor", "NewSlice")

--- a/dev/Code/Sandbox/Editor/Resource.h
+++ b/dev/Code/Sandbox/Editor/Resource.h
@@ -382,6 +382,7 @@
 #define ID_TOOLS_ENABLEFILECHANGEMONITORING        34185
 #define ID_FILE_OPEN_LEVEL                         34196
 #define ID_FILE_SAVE_LEVEL                         34197
+#define ID_FILE_RELOAD_LEVEL                       37198
 #define ID_PANEL_LAYERS_SAVE_EXTERNAL_LAYERS       34198
 #define ID_TV_SYNC_TO_BASE                         34199
 #define ID_TV_SYNC_FROM_BASE                       34200

--- a/dev/Editor/UI/Resource.h
+++ b/dev/Editor/UI/Resource.h
@@ -382,6 +382,7 @@
 #define ID_TOOLS_ENABLEFILECHANGEMONITORING        34185
 #define ID_FILE_OPEN_LEVEL                         34196
 #define ID_FILE_SAVE_LEVEL                         34197
+#define ID_FILE_RELOAD_LEVEL                       37198
 #define ID_PANEL_LAYERS_SAVE_EXTERNAL_LAYERS       34198
 #define ID_TV_SYNC_TO_BASE                         34199
 #define ID_TV_SYNC_FROM_BASE                       34200


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some time ago the editor would actually reload the level (from disk, re-creating all entities, etc.) when you selected the same level as currently loading in the “Load level” dialogue. Now it will skip loading the current level if that’s what you choose.

Sometimes you want to reload the current level because you broke something. Currently the only way to do this is to load another level, then load your original level, which is quite tedious.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
