### PR TITLE
Fixed CCamera unproject - now always using current camera up.

### DIFF
--- a/dev/Code/CryEngine/CryCommon/Cry_Camera.h
+++ b/dev/Code/CryEngine/CryCommon/Cry_Camera.h
@@ -995,7 +995,7 @@ ILINE bool CCamera::Unproject(const Vec3& viewportPos, Vec3& result, Vec2i topLe
     Matrix44A mProj, mView;
 
     mathMatrixPerspectiveFov(&mProj, GetFov(), GetProjRatio(), GetNearPlane(), GetFarPlane());
-    mathMatrixLookAt(&mView, GetPosition(), GetPosition() + GetViewdir(), Vec3(0, 0, 1));
+    mathMatrixLookAt(&mView, GetPosition(), GetPosition() + GetViewdir(), GetUp());
 
     int viewport[4] = {0, 0, GetViewSurfaceX(), GetViewSurfaceZ()};
 


### PR DESCRIPTION
CCamera Unproject assumes "up" to be z-up always, which breaks when a non-FPV camera is used.  Fixed to use the current camera's actual up when performing the unproject.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
