### PR TITLE
Fix run time error messages

### DIFF
--- a/dev/Code/CryEngine/CrySystem/PerfHUD.cpp
+++ b/dev/Code/CryEngine/CrySystem/PerfHUD.cpp
@@ -358,7 +358,6 @@ void CPerfHUD::InitUI(IMiniGUI* pGUI)
     CreateCVarMenuItem(pDebugMenu, "Terrain", "e_Terrain", 0, 1);
     CreateCVarMenuItem(pDebugMenu, "Brushes", "e_Brushes", 0, 1);
     CreateCVarMenuItem(pDebugMenu, "Vegetation", "e_Vegetation", 0, 1);
-    CreateCVarMenuItem(pDebugMenu, "Characters", "ca_DrawChr", 0, 1);
     CreateCVarMenuItem(pDebugMenu, "Coverage Buffer", "e_CoverageBuffer", 0, 1);
     CreateCVarMenuItem(pDebugMenu, "Sun", "e_Sun", 0, 1);
     CreateCVarMenuItem(pDebugMenu, "Unlit", "r_Unlit", 0, 1);
@@ -414,7 +413,6 @@ void CPerfHUD::InitUI(IMiniGUI* pGUI)
     }
 
     CreateCVarMenuItem(pMenu, "Profiler", "profile", 0, 1);
-    CreateCVarMenuItem(pMenu, "Thread Summary", "r_showmt", 0, 1);
     CreateCVarMenuItem(pMenu, "Track File Access", "sys_PakLogInvalidFileAccess", 0, 1);
 
     //FPS Buckets


### PR DESCRIPTION
Fix run time error messages. 

*Description of changes:*

There are access to old cryengine cvars. Lets remove this lines to fix next errors:
<2019-10-15T16:10:07:893+03> failed to find CVar: ca_DrawChr
<2019-10-15T16:10:07:894+03> failed to find CVar: r_showmt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
