### PR TITLE
Handle editor visibility changes in Cloud component

### DIFF
--- a/dev/Gems/Clouds/Code/Source/EditorCloudComponent.cpp
+++ b/dev/Gems/Clouds/Code/Source/EditorCloudComponent.cpp
@@ -205,6 +205,15 @@ namespace CloudsGem
         AZ::EntityBus::Handler::BusConnect(entityId);
         AzToolsFramework::EditorVisibilityNotificationBus::Handler::BusConnect(entityId);
         AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(entityId);
+
+        {
+            bool isVisible = true;
+            AzToolsFramework::EditorVisibilityRequestBus::EventResult(
+                isVisible,
+                entityId,
+                &AzToolsFramework::EditorVisibilityRequestBus::Events::GetCurrentVisibility);
+            OnEntityVisibilityChanged(isVisible);
+        }
     }
 
     void EditorCloudComponent::Deactivate()
@@ -321,6 +330,18 @@ namespace CloudsGem
     void EditorCloudComponent::OnMaterialAssetChanged()
     {
         m_renderNode.OnMaterialAssetChanged();
+    }
+
+    void EditorCloudComponent::OnEntityVisibilityChanged(bool visible)
+    {
+        if (visible)
+        {
+            m_renderNode.m_dwRndFlags &= ~ERF_HIDDEN;
+        }
+        else
+        {
+            m_renderNode.m_dwRndFlags |= ERF_HIDDEN;
+        }
     }
 
     void EditorCloudComponent::Refresh()

--- a/dev/Gems/Clouds/Code/Source/EditorCloudComponent.h
+++ b/dev/Gems/Clouds/Code/Source/EditorCloudComponent.h
@@ -83,6 +83,11 @@ namespace CloudsGem
         void Refresh() override;
         void OnMaterialAssetChanged() override;
 
+        /////////////////////////////////////////////////////////
+        // EditorVisibilityNotificationBus
+        /////////////////////////////////////////////////////////
+        void OnEntityVisibilityChanged(bool visibility) override;
+
         /** 
          * Fills out the provided array with services provided by this component
          */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This allows the cloud render node to be hidden by clicking the eye icon in the Entity Outliner

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
