### PR TITLE
Wrong argument order in CTexture::SetSamplerState

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DDeferredShading.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DDeferredShading.cpp
@@ -2444,7 +2444,7 @@ void CDeferredShading::PrepareClipVolumeData(bool& bOutdoorVisible)
         states |= isGmemResolve ? GS_NOCOLMASK_R : GS_NOCOLMASK_G;
         rd->FX_SetState(states);
 
-        CTexture::SetSamplerState(4, m_nTexStatePoint, eHWSC_Pixel);
+        CTexture::SetSamplerState(m_nTexStatePoint, 4, eHWSC_Pixel);
         rd->m_DevMan.BindSRV(eHWSC_Pixel, gcpRendD3D->m_pZBufferStencilReadOnlySRV, 4);
 
         GetUtils().DrawQuadFS(CShaderMan::s_shDeferredShading, false, m_pLBufferDiffuseRT->GetWidth(), m_pLBufferDiffuseRT->GetHeight());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CTexture::SetSamplerState expects texture state as first argument and sampler index as second, currently those values are switched

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
