### PR TITLE
Speed up search of assets in Asset Browser

### DIFF
--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.cpp
@@ -64,7 +64,6 @@ namespace AzToolsFramework
                 return true;
             }
 
-            // FL[FD-10097] Speed up search of assets in Asset Browser
             // we can safely accept entry if it's parent folder is accepted already
             if (entry->parent() && static_cast<AssetBrowserEntry*>(entry->parent())->GetEntryType() == AssetBrowserEntry::AssetEntryType::Folder)
             {
@@ -75,7 +74,6 @@ namespace AzToolsFramework
             {
                 return true;
             }
-
 
             if (m_filter->Match(entry))
             {
@@ -159,14 +157,13 @@ namespace AzToolsFramework
                 }
             }
 
-            // FL[FD-10097] Speed up search of assets in Asset Browser
             m_seenAndAcceptedIndices.clear();
+
             beginResetModel();
             endResetModel();
 
             Q_EMIT filterChanged();
 
-            // FL[FD-10097] Speed up search of assets in Asset Browser
             m_seenAndAcceptedIndices.clear();
         }
 
@@ -176,7 +173,6 @@ namespace AzToolsFramework
             {
                 m_alreadyRecomputingFilters = true;
                 // de-bounce it, since we may get many filter updates all at once.
-                // FL[FD-10097] Speed up search of assets in Asset Browser
                 QTimer::singleShot(500, this, [this]()
                 {
                     m_alreadyRecomputingFilters = false;

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h
@@ -24,14 +24,12 @@ AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QCollatorSor
 #include <QCollator>
 AZ_POP_DISABLE_WARNING
 
-// FL[FD-10097] Speed up search of assets in Asset Browser
 #include <AzCore/std/containers/unordered_set.h>
 
 namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
-        // FL[FD-10097] Speed up search of assets in Asset Browser
         namespace detail
         {
             struct QModelIndexEqualityPredicate : AZStd::binary_function<QModelIndex, QModelIndex, bool>
@@ -91,8 +89,6 @@ namespace AzToolsFramework
             QWeakPointer<const StringFilter> m_stringFilter;
             QWeakPointer<const CompositeFilter> m_assetTypeFilter;
             QCollator m_collator;  // cache the collator as its somewhat expensive to constantly create and destroy one.
-
-            // FL[FD-10097] Speed up search of assets in Asset Browser
             detail::QModelIndexSet m_seenAndAcceptedIndices;
         };
     } // namespace AssetBrowser

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
@@ -86,12 +86,15 @@ namespace AzToolsFramework
             , m_stringFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
             , m_typesFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::OR))
         {
-            m_filter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+            // FL[FD-10097] Speed up search of assets in Asset Browser
+            m_filter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
 
-            m_stringFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Up);
+            // FL[FD-10097] Speed up search of assets in Asset Browser
+            m_stringFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
             m_stringFilter->SetTag("String");
 
-            m_typesFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+            // FL[FD-10097] Speed up search of assets in Asset Browser
+            m_typesFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
             m_typesFilter->SetTag("AssetTypes");
 
             connect(this, &AzQtComponents::FilteredSearchWidget::TextFilterChanged, this,

--- a/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
+++ b/dev/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/SearchWidget.cpp
@@ -86,14 +86,11 @@ namespace AzToolsFramework
             , m_stringFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::AND))
             , m_typesFilter(new CompositeFilter(CompositeFilter::LogicOperatorType::OR))
         {
-            // FL[FD-10097] Speed up search of assets in Asset Browser
             m_filter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
 
-            // FL[FD-10097] Speed up search of assets in Asset Browser
             m_stringFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
             m_stringFilter->SetTag("String");
 
-            // FL[FD-10097] Speed up search of assets in Asset Browser
             m_typesFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::None);
             m_typesFilter->SetTag("AssetTypes");
 


### PR DESCRIPTION
**LY-104815**

*Overal*
- Disabled upward/downward propagation for all filters;
- Added 500 ms delay before **FilterUpdatedSlotImmediate** is called. This allowes to make less filter updates when entering multiple symbols at once;
- Filter invalidation (**invalidateFilter** call) changed to model reset (**begin**/**endResetModel** calls). This is simply cheaper considering the amount of rows in the model;

*In **filterAcceptsRow** method implementation:*
- Added check for the entry's parent being a folder;
- Added cache of previously seen and accepted entries;
- Added recursive children lookup as a replacement for disabled filters propagation option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
