### PR TITLE
get_shader_list.py doesn't work when shader list size is bigger than 1MB

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Shaders/RemoteCompiler.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/Shaders/RemoteCompiler.cpp
@@ -1110,7 +1110,7 @@ namespace NRemoteCompiler
             size_t nUncompressedLen = (size_t)nSrcUncompressedLen;
 
             // Maximum size allowed for a shader in bytes
-            static const size_t maxShaderSize = 1*(1024*1024); // 1 MB
+            static const size_t maxShaderSize = 10*(1024*1024); // 10 MB. Uncompressed shader list usually is bigger than 1MB
 
             if (nUncompressedLen > maxShaderSize)
             {


### PR DESCRIPTION
Getting shader list is failed when its size is bigger than 1MB

Uncompressed shader cannot exceed 1MB. This limitation is added as guard into network protocol to ignore shaders which are bigger. But the same network protocol is used for getting shader list which easily can be bigger than 1MB. As result once shader list is grown enough it stops working via get_shader_list.py script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
