### PR TITLE
Fixes to make shader cache gen works in CI

### DIFF
--- a/dev/Code/Tools/ShaderCacheGen/ShaderCacheGen/ShaderCacheGen.cpp
+++ b/dev/Code/Tools/ShaderCacheGen/ShaderCacheGen/ShaderCacheGen.cpp
@@ -473,7 +473,7 @@ int main_wrapped(int argc, char* argv[])
 
     if (pISystem)
     {
-        pISystem->Release();
+        pISystem->Quit();
     }
     pISystem = nullptr;
 
@@ -493,9 +493,13 @@ int main(int argc, char* argv[])
     app.Start(descriptor, startupParams);
     AcquireCryMemoryManager();
 
+    AZ::Debug::Trace::Instance().Init();
+
     int returncode = main_wrapped(argc, argv);
 
     app.Stop();
+
+    AZ::Debug::Trace::Instance().Init();
     
     ReleaseCryMemoryManager();
     AZ::AllocatorInstance<CryStringAllocator>::Destroy();


### PR DESCRIPTION
Shader cache gen fails on unrelated error, assert spam

After shader list is received the shader cache gen tool tries to release ISystem but not all engine components can be closed gracefully. As result our Jenkins CI plan randomly fails with successfully received shader list. In order to cope we just quit more aggressive via Quit method.
Another issue is related to missed Trace system initialization for shader cache gen application. As result asserts are not handled properly. For example the same assert stack isn't put into ignore list and we get our Jenkins plan overloaded with assert spam.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
