### PR TITLE
LDS memory leaks fix

### DIFF
--- a/dev/Code/CryEngine/CryPhysics/physarea.cpp
+++ b/dev/Code/CryEngine/CryPhysics/physarea.cpp
@@ -2349,8 +2349,7 @@ IPhysicalEntity* CPhysicalWorld::AddArea(Vec3* pt, int npt, float zmin, float zm
 
     pArea->m_offset = pArea->m_offset0 + pos;
     pArea->m_R = Matrix33(q) * pArea->m_R0;
-    memset(pArea->m_pMask = new unsigned int[((npt - 1 >> 5) + 1) * (MAX_PHYS_THREADS + 1)], 0, ((npt - 1 >> 5) + 1) * (MAX_PHYS_THREADS + 1) * sizeof(int));
-
+ 
     sz = Matrix33(pArea->m_R).Fabs() * pArea->m_size0 * scale;
     center = pArea->m_offset + pArea->m_R * (BBox[0] + BBox[1]) * (pArea->m_scale * 0.5f);
     pArea->m_BBox[0] = center - sz;

--- a/dev/Code/Tools/RemoteConsole/Core/RemoteConsoleCore.cpp
+++ b/dev/Code/Tools/RemoteConsole/Core/RemoteConsoleCore.cpp
@@ -129,6 +129,12 @@ void SRemoteServer::ClientDone(SRemoteClient* pClient)
         {
             it->pClient->Stop();
             delete it->pClient;
+            while (!it->pEvents->empty())
+            {
+                auto pEvent = it->pEvents->front();
+                it->pEvents->pop_front();
+                delete pEvent;
+            }
             delete it->pEvents;
             m_clients.erase(it);
             break;


### PR DESCRIPTION
Valgrind reports memory leaks on LDS

Fix double allocation in physrea. pArea->m_pMask is already allocated in ProcessBuffer function.
Fix case when client is disconnected while its event queue contains elements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
