### PR TITLE
Bad render target in snow displacement

### DIFF
--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DDeferredPasses.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DDeferredPasses.cpp
@@ -673,6 +673,8 @@ bool CD3D9Renderer::FX_DeferredRainGBuffer()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+static CTexture* s_snowDisplacement = nullptr;
+
 bool CD3D9Renderer::FX_DeferredSnowLayer()
 {
     const SSnowParams& snowVolParams = m_p3DEngineCommon.m_SnowInfo;
@@ -692,6 +694,16 @@ bool CD3D9Renderer::FX_DeferredSnowLayer()
         return false;
     }
 
+    if (!s_snowDisplacement || s_snowDisplacement->GetWidth() != CTexture::s_ptexSceneDiffuse->GetWidth() || s_snowDisplacement->GetHeight() != CTexture::s_ptexSceneDiffuse->GetHeight())
+    {
+        SD3DPostEffectsUtils::CreateRenderTarget(
+            "$SnowDisplacement", s_snowDisplacement,
+            CTexture::s_ptexSceneDiffuse->GetWidth(), CTexture::s_ptexSceneDiffuse->GetHeight(), Clr_Empty, eTT_2D,
+            FT_DONT_STREAM | FT_USAGE_RENDERTARGET,
+            eTF_R8G8B8A8
+        );
+    }
+
     PROFILE_LABEL_SCOPE("DEFERRED_SNOW_ACCUMULATION");
 
     if (!gcpRendD3D->FX_GetEnabledGmemPath(nullptr)) // needed RTs already in GMEM
@@ -704,10 +716,9 @@ bool CD3D9Renderer::FX_DeferredSnowLayer()
         gcpRendD3D->FX_PushRenderTarget(0, CTexture::s_ptexSceneDiffuse, &gcpRendD3D->m_DepthBufferOrigMSAA);
         gcpRendD3D->FX_PushRenderTarget(1, CTexture::s_ptexSceneNormalsMap, NULL);
         gcpRendD3D->FX_PushRenderTarget(2, CTexture::s_ptexSceneSpecular, NULL);
-
         if (CRenderer::CV_r_snow_displacement)
         {
-            gcpRendD3D->FX_PushRenderTarget(3, CTexture::s_ptexStereoR, NULL);
+            gcpRendD3D->FX_PushRenderTarget(3, s_snowDisplacement, NULL);
         }
     }
     else
@@ -815,7 +826,6 @@ bool CD3D9Renderer::FX_DeferredSnowLayer()
         gcpRendD3D->FX_PopRenderTarget(0);
         gcpRendD3D->FX_PopRenderTarget(1);
         gcpRendD3D->FX_PopRenderTarget(2);
-
         if (CRenderer::CV_r_snow_displacement)
         {
             gcpRendD3D->FX_PopRenderTarget(3);
@@ -891,7 +901,7 @@ bool CD3D9Renderer::FX_DeferredSnowDisplacement()
 
         pShader->FXSetPSFloat(param5Name, (Vec4*)matView.GetData(), 3);
 
-        PostProcessUtils().SetTexture(CTexture::s_ptexStereoR, 0, FILTER_POINT);
+        PostProcessUtils().SetTexture(s_snowDisplacement, 0, FILTER_POINT);
 
         SD3DPostEffectsUtils::DrawFullScreenTri(CTexture::s_ptexBackBuffer->GetWidth(), CTexture::s_ptexBackBuffer->GetHeight());
 


### PR DESCRIPTION
stereoL and stereoR are not resized automatically in
CDeferredShading::CreateDeferredMaps, so it's very likely that stereo{L/R} are
different sizes than the other gbuffer render targets! This breaks things since
all render targets must be the same size.

Also, stereoR is overwritten by SSDO in between snow accumulation and snow
displacement passes. We cannot use stereoR here even if it was the right size.

*Issue #, if available:*

*Description of changes:*
This patch changes the snow displacement render pass to use its own dedicated texture called `$SnowDisplacement` instead of trying to re-use `CTexture::s_ptexStereoR` which doesn't work for several reasons (see above).

It might be the case that there's some other texture which already exists which we can re-use. In this case, this is extremely fragile, because the snow displacement texture is written to right after the z-pass but then used to actually perform snow displacement after deferred tiled lighting, opaque and transparent passes (e.g. water, emissive pass, decals, fog, particles). Any of these draw calls could clobber any "global" texture that we attempt to re-use as the snow displacement RT. So using a dedicated texture is the most robust possible solution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
