### PR TITLE
Fix for LOD meshes selection in Scene Settings

### DIFF
--- a/dev/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeTreeSelectionWidget.cpp
+++ b/dev/Code/Tools/SceneAPI/SceneUI/RowWidgets/NodeTreeSelectionWidget.cpp
@@ -47,6 +47,14 @@ namespace AZ
             void NodeTreeSelectionWidget::SetList(const DataTypes::ISceneNodeSelectionList& list)
             {
                 m_list = list.Copy();
+
+                if (m_list->GetSelectedNodeCount() == 0 && m_list->GetUnselectedNodeCount() == 0)
+                {
+                    if (const auto* root = ManifestWidget::FindRoot(this))
+                    {
+                        Utilities::SceneGraphSelector::UnselectAll(root->GetScene()->GetGraph(), *m_list);
+                    }
+                }
             }
 
             void NodeTreeSelectionWidget::CopyListTo(DataTypes::ISceneNodeSelectionList& target)


### PR DESCRIPTION
Broken summary for LODs selection in the newly created elements of Lod Meshes list @ Scene Settings tool.

STR:
1) Start Editor with an empty level;
2) Place entity and add mesh component to it;
3) Assign some asset to the mesh;
4) Go o the Scene Settings (double click on mesh asset);
5) Add a new element to Lod Meshes;
6) Try to select any LOD for the new element.

Result: element summary states: "All Lod meshes selected" no matter what was selected in the last step _except_ for the "Select All/Unselect All" options.

Fix details: 
* Added empty selection list initialization (with unsellect all)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.