### PR TITLE
Fix for EmotionFX Actor skin attachments in Editor

### DIFF
--- a/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.cpp
@@ -712,6 +712,11 @@ namespace EMotionFX
             }
         }
 
+        void ActorRenderNode::EnableFrustumCulling(bool enable)
+        {
+            SetRndFlags(ERF_RENDER_ALWAYS, !enable);
+        }
+
         ActorAsset::ActorAsset()
         {
         }

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.h
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.h
@@ -209,6 +209,8 @@ namespace EMotionFX
             SSkinningData* GetSkinningData();
             void SetSkinningMethod(SkinningMethod method);
 
+            void EnableFrustumCulling(bool enable);
+
             // Determines if the morph target weights were updated since the last call.
             // It is used to avoid calling UpdateDynamicSkin if the weights have not been
             // updated.

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -47,6 +47,7 @@ namespace EMotionFX
                 serializeContext->Class<Configuration>()
                     ->Version(3)
                     ->Field("ActorAsset", &Configuration::m_actorAsset)
+                    ->Field("DoNotFrustumCull", &Configuration::m_doNotFrustumCull)
                     ->Field("MaterialPerLOD", &Configuration::m_materialPerLOD)
                     ->Field("RenderSkeleton", &Configuration::m_renderSkeleton)
                     ->Field("RenderCharacter", &Configuration::m_renderCharacter)
@@ -305,6 +306,7 @@ namespace EMotionFX
 
                 m_renderNode = AZStd::make_unique<ActorRenderNode>(GetEntityId(), m_actorInstance, m_configuration.m_actorAsset, transform);
                 m_renderNode->SetMaterials(m_configuration.m_materialPerLOD);
+                m_renderNode->EnableFrustumCulling(!m_configuration.m_doNotFrustumCull);
                 m_renderNode->RegisterWithRenderer();
                 m_renderNode->SetSkinningMethod(m_configuration.m_skinningMethod);
                 m_renderNode->Hide(!m_configuration.m_renderCharacter);

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
@@ -72,6 +72,8 @@ namespace EMotionFX
 
                 Configuration();
 
+                bool m_doNotFrustumCull { false };
+
                 AZ::Data::Asset<ActorAsset>     m_actorAsset;               ///< Selected actor asset.
                 ActorAsset::MaterialList        m_materialPerLOD;           ///< Material assignment per LOD.
                 AZ::EntityId                    m_attachmentTarget;         ///< Target entity this actor should attach to.


### PR DESCRIPTION
This fix enables EmotionFX skin attachments in editor mode allowing debug of complex animation sequences and cutscenes.

Changs:
* EditorActorComponent was extended with code that performs AttachmentSkin(s) creation and management. Mostly copied relevant pieces from ActorComponent;
* Added "DoNotFrustumCull" option to force cutscene animated characters rendering. This is current workaround for the issue with BBoxes update after animation-driven displacement of character.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
