### PR TITLE
Added reading vertex normals into render mesh

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/RenderMesh.cpp
+++ b/dev/Code/CryEngine/RenderDll/Common/RenderMesh.cpp
@@ -1662,7 +1662,10 @@ IIndexedMesh* CRenderMesh::GetIndexedMesh(IIndexedMesh* pIdxMesh)
 
     strided_pointer<Vec3> pVtx;
     strided_pointer<SPipTangents> pTangs;
+    strided_pointer<SMeshNormal> pNorm;
+
     pVtx.data = (Vec3*)GetPosPtr(pVtx.iStride, FSL_READ);
+    pNorm.data = (SMeshNormal*)GetNormPtr(pNorm.iStride, FSL_READ);
 
     bool texCoordAllocationSucceeded = true;
     AZStd::vector<strided_pointer<Vec2>> stridedTexCoordPointers;
@@ -1692,7 +1695,7 @@ IIndexedMesh* CRenderMesh::GetIndexedMesh(IIndexedMesh* pIdxMesh)
     for (uint32 i = 0; i < m_nVerts; i++)
     {
         pMesh->m_pPositions[i] = pVtx[i];
-        pMesh->m_pNorms    [i] = SMeshNormal(Vec3(0, 0, 1));//pNorm[i];
+        pMesh->m_pNorms[i] = pNorm.data == NULL ? SMeshNormal(Vec3(0, 0, 1)) : pNorm[i];
         pMesh->m_pTangents [i] = SMeshTangents(pTangs[i]);
     }
 


### PR DESCRIPTION
*Description of changes:*

Added reading vertex normals from geometry description into render mesh. Currently vertex normals are set to defaul (0, 0, 1) vector even if content has vertex normals stream.