### PR TITLE
Fixes for AudioEngine gem heap memory corruption on Playstation

### DIFF
--- a/dev/Gems/AudioEngineWwise/Code/Source/Engine/AudioInput/AudioInputFile.cpp
+++ b/dev/Gems/AudioEngineWwise/Code/Source/Engine/AudioInput/AudioInputFile.cpp
@@ -87,7 +87,7 @@ namespace Audio
                 if (IsOk())
                 {
                     // Allocate a new buffer to hold the data...
-                    m_dataPtr = new AZ::u8[m_dataSize];
+                    m_dataPtr = static_cast<AZ::u8*>(azmalloc(m_dataSize));
 
                     // Read file into internal buffer...
                     size_t bytesRead = fileStream.Read(m_dataSize, m_dataPtr);
@@ -110,7 +110,7 @@ namespace Audio
     {
         if (m_dataPtr)
         {
-            delete [] m_dataPtr;
+            azfree(m_dataPtr);
             m_dataPtr = nullptr;
         }
         m_dataSize = 0;

--- a/dev/Gems/AudioEngineWwise/Code/Source/Engine/AudioInput/AudioInputStream.cpp
+++ b/dev/Gems/AudioEngineWwise/Code/Source/Engine/AudioInput/AudioInputStream.cpp
@@ -34,11 +34,11 @@ namespace Audio
 
         if (m_config.m_sampleType == AudioInputSampleType::Float && m_config.m_bitsPerSample == 32)
         {
-            m_buffer.reset(new RingBuffer<float>(numSamples));
+            m_buffer.reset(aznew RingBuffer<float>(numSamples));
         }
         else if (m_config.m_sampleType == AudioInputSampleType::Int && m_config.m_bitsPerSample == 16)
         {
-            m_buffer.reset(new RingBuffer<AZ::s16>(numSamples));
+            m_buffer.reset(aznew RingBuffer<AZ::s16>(numSamples));
         }
         else
         {


### PR DESCRIPTION
Pure new function causes heap corruption for PS4/XboxOne platforms in AudioEngine gem, aznew and azmalloc calls allow us to avoid heap corruption.