### PR TITLE
hash obj folders

### DIFF
--- a/dev/Tools/build/waf-1.7.13/lmbrwaflib/msvc_helper.py
+++ b/dev/Tools/build/waf-1.7.13/lmbrwaflib/msvc_helper.py
@@ -337,8 +337,15 @@ def add_pch_msvc(self):
 
     # Generate PCH per target project idx
     # Avoids the case where two project have the same PCH output path but compile the PCH with different compiler options i.e. defines, includes, ...
-    self.pch_file = pch_source.change_ext('.%d.pch' % self.target_uid)
-    self.pch_object = pch_source.change_ext('.%d.obj' % self.target_uid)
+    # creating the output node
+    objfolder = self.bld.bldnode.find_or_declare("obj")
+    m = hashlib.md5()
+    m.update(pch_source.parent.abspath())
+    md5folder = objfolder.find_or_declare(m.hexdigest())
+
+    self.pch_file = md5folder.find_or_declare(pch_source.change_ext_name('.%d.pch' % self.target_uid))
+    self.pch_object = md5folder.find_or_declare(pch_source.change_ext_name('.%d.obj' % self.target_uid))
+    
     # Create PCH Task
     self.pch_task = pch_task = self.create_task('pch_msvc', pch_source, [self.pch_object, self.pch_file])
     pch_task.env.append_value('PCH_NAME', self.pch_header_name)

--- a/dev/Tools/build/waf-1.7.13/waflib/Node.py
+++ b/dev/Tools/build/waf-1.7.13/waflib/Node.py
@@ -793,7 +793,7 @@ class Node(object):
 		return node
 
 	# helpers for building things
-	def change_ext(self, ext, ext_in=None):
+	def change_ext_name(self, ext, ext_in=None):
 		"""
 		:return: A build node of the same path, but with a different extension
 		:rtype: :py:class:`waflib.Node.Node`
@@ -808,6 +808,14 @@ class Node(object):
 		else:
 			name = name[:- len(ext_in)] + ext
 
+		return name
+        
+	def change_ext(self, ext, ext_in=None):
+		"""
+		:return: A build node of the same path, but with a different extension
+		:rtype: :py:class:`waflib.Node.Node`
+		"""
+		name = self.change_ext_name(ext, ext_in)
 		return self.parent.find_or_declare([name])
 
 	def nice_path(self, env=None):


### PR DESCRIPTION
.obj files are now stored inside a md5 folder instead of cloning the whole path.
This prevent the engine to fail compiling some files with long path names (or if engine is stored in a long path)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
