### PR TITLE
Fix access violation crash on pDepthTex released

### DIFF
--- a/dev/Code/CryEngine/RenderDll/Common/Shadow_Renderer.h
+++ b/dev/Code/CryEngine/RenderDll/Common/Shadow_Renderer.h
@@ -78,7 +78,7 @@ struct ShadowMapFrustum
     bool bUseShadowsPool;
     struct ShadowMapFrustum* pPrevFrustum = nullptr;
     struct ShadowMapFrustum* pFrustumOwner = nullptr;
-    class CTexture* pDepthTex;
+    _smart_ptr<ITexture> pDepthTex;
 
     //3d engine parameters
     float fFOV;

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DDeferredRender.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DDeferredRender.cpp
@@ -1387,7 +1387,7 @@ void CD3D9Renderer::FX_DeferredShadowMaskGen(const TArray<uint32>& shadowPoolLig
                         TS.m_bSRGBLookup = false;
                         TS.SetComparisonFilter(true);
 
-                        CTexture* pShadowMap = firstFrustum.bUseShadowsPool ? CTexture::s_ptexRT_ShadowPool : firstFrustum.pDepthTex;
+                        CTexture* pShadowMap = firstFrustum.bUseShadowsPool ? CTexture::s_ptexRT_ShadowPool : static_cast<CTexture*>(firstFrustum.pDepthTex.get());
                         pShadowMap->Apply(1, CTexture::GetTexState(TS), EFTT_UNKNOWN, 6);
 
                         SD3DPostEffectsUtils::SetTexture(CTextureManager::Instance()->GetDefaultTexture("ShadowJitterMap"), 7, FILTER_POINT, 0);

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DDeferredShading.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DDeferredShading.cpp
@@ -4577,7 +4577,7 @@ bool CDeferredShading::ShadowLightPasses(const SRenderLight& light)
             }
             else
             {
-                SD3DPostEffectsUtils::SetTexture(firstFrustum.pDepthTex, 3, FILTER_POINT, 0);
+                SD3DPostEffectsUtils::SetTexture(static_cast<CTexture*>(firstFrustum.pDepthTex.get()), 3, FILTER_POINT, 0);
             }
 
             SD3DPostEffectsUtils::SetTexture(CTextureManager::Instance()->GetDefaultTexture("ShadowJitterMap"), 7, FILTER_POINT, 0);

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DShadows.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DShadows.cpp
@@ -1421,7 +1421,7 @@ void CD3D9Renderer::ConfigShadowTexgen(int Num, ShadowMapFrustum* pFr, int nFrus
             else
             if (pFr->pDepthTex != NULL)
             {
-                nID = pFr->pDepthTex->GetID();
+                nID = static_cast<CTexture*>(pFr->pDepthTex.get())->GetID();
             }
 
             m_RP.m_ShadowCustomTexBind[Num * 2 + 0] = nID;

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DShadows.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DShadows.cpp
@@ -989,11 +989,11 @@ bool CD3D9Renderer::PrepareDepthMap(ShadowMapFrustum* lof, int nLightFrustumID, 
             depthTarget.nHeight = lof->nTextureHeight;
             depthTarget.nFrameAccess = -1;
             depthTarget.bBusy = false;
-            depthTarget.pTex = lof->pDepthTex;
-            depthTarget.pTarget = lof->pDepthTex->GetDevTexture()->Get2DTexture();
+            depthTarget.pTex = static_cast<CTexture*>(lof->pDepthTex.get());
+            depthTarget.pTarget = depthTarget.pTex->GetDevTexture()->Get2DTexture();
             depthTarget.pSurf = lof->bOmniDirectionalShadow && !(lof->bUnwrapedOmniDirectional)
-                ? static_cast<D3DDepthSurface*>(lof->pDepthTex->GetDeviceDepthStencilSurf(sideIndex, 1))
-                : static_cast<D3DDepthSurface*>(lof->pDepthTex->GetDeviceDepthStencilSurf());
+                ? static_cast<D3DDepthSurface*>(depthTarget.pTex->GetDeviceDepthStencilSurf(sideIndex, 1))
+                : static_cast<D3DDepthSurface*>(depthTarget.pTex->GetDeviceDepthStencilSurf());
 
             CCamera tmpCamera;
             if (!lof->bOmniDirectionalShadow)

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DShadows.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3DShadows.cpp
@@ -1920,9 +1920,9 @@ void CD3D9Renderer::FX_MergeShadowMaps(ShadowMapFrustum* pDst, const ShadowMapFr
         depthSurface.nHeight = pDst->nTextureHeight;
         depthSurface.nFrameAccess = -1;
         depthSurface.bBusy = false;
-        depthSurface.pTex = pDst->pDepthTex;
-        depthSurface.pSurf = pDst->pDepthTex->GetDeviceDepthStencilSurf();
-        depthSurface.pTarget = pDst->pDepthTex->GetDevTexture()->Get2DTexture();
+        depthSurface.pTex = static_cast<CTexture*>(pDst->pDepthTex.get());
+        depthSurface.pSurf = depthSurface.pTex->GetDeviceDepthStencilSurf();
+        depthSurface.pTarget = depthSurface.pTex->GetDevTexture()->Get2DTexture();
 
         if (bEmptyCachedFrustum)
         {
@@ -1955,7 +1955,7 @@ void CD3D9Renderer::FX_MergeShadowMaps(ShadowMapFrustum* pDst, const ShadowMapFr
             static CCryNameR paramReprojMatSrcToDst("g_mReprojSrcToDst");
             CShaderMan::s_ShaderShadowMaskGen->FXSetPSFloat(paramReprojMatSrcToDst, (Vec4*) mReprojSrcToDst.GetData(), 4);
 
-            pSrc->pDepthTex->Apply(0, CTexture::GetTexState(STexState(FILTER_POINT, true)));
+            pSrc->pDepthTex->ApplyTexture(0, CTexture::GetTexState(STexState(FILTER_POINT, true)));
 
             SPostEffectsUtils::DrawFullScreenTri(depthSurface.nWidth, depthSurface.nHeight);
             SPostEffectsUtils::ShEndPass();

--- a/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3D_SVO.cpp
+++ b/dev/Code/CryEngine/RenderDll/XRenderD3D9/D3D_SVO.cpp
@@ -1550,7 +1550,7 @@ void CSvoRenderer::SetupRsmSun(const EHWShaderClass eShClass)
         }
         else
         {
-            firstFrustum.pDepthTex->Apply(12, m_nTexStatePoint, EFTT_UNKNOWN, -1, -1, eShClass);
+            static_cast<CTexture*>(firstFrustum.pDepthTex.get())->Apply(12, m_nTexStatePoint, EFTT_UNKNOWN, -1, -1, eShClass);
             GetRsmColorMap(firstFrustum)->Apply(13, m_nTexStatePoint, EFTT_UNKNOWN, -1, -1, eShClass);
             GetRsmNormlMap(firstFrustum)->Apply(9, m_nTexStatePoint, EFTT_UNKNOWN, -1, -1, eShClass);
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix for crash

https://forums.awsgametech.com/t/ly-1-23-crash-fixed-when-pdepthtex-released-while-used-by-sun-shadow-cascade/8646

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
