### PR TITLE
Added ability for DynamicContentBus to send data-received events

### DIFF
--- a/dev/Gems/CloudCanvasCommon/Code/Include/PresignedURL/PresignedURLBus.h
+++ b/dev/Gems/CloudCanvasCommon/Code/Include/PresignedURL/PresignedURLBus.h
@@ -22,8 +22,12 @@ namespace CloudCanvas
     class IPresignedURLRequest
     {
     public:
-        virtual void RequestDownloadSignedURL(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id) = 0;
-        virtual AZ::Job* RequestDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id) = 0;
+        // void(receivedDelta, totalLength)
+        typedef AZStd::function< void(uint32_t, uint32_t) > DataReceivedEventHandler;
+
+    public:
+        virtual void RequestDownloadSignedURL(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id, DataReceivedEventHandler&& dataReceivedHandler) = 0;
+        virtual AZ::Job* RequestDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id, DataReceivedEventHandler&& dataReceivedHandler) = 0;
 
         virtual AZStd::unordered_map<AZStd::string, AZStd::string> GetQueryParameters(const AZStd::string& signedURL) = 0;
     };

--- a/dev/Gems/CloudCanvasCommon/Code/Source/PresignedURL/PresignedURL.cpp
+++ b/dev/Gems/CloudCanvasCommon/Code/Source/PresignedURL/PresignedURL.cpp
@@ -37,6 +37,8 @@ AZ_POP_DISABLE_WARNING
 #include <AzCore/Jobs/JobContext.h>
 #include <AzCore/Jobs/JobFunction.h>
 #include <AzCore/Jobs/JobManagerBus.h>
+#include <AzCore/std/string/conversions.h>
+
 #include <AzCore/std/string/tokenize.h>
 #include <AzFramework/AzFramework_Traits_Platform.h>
 
@@ -57,14 +59,14 @@ namespace CloudCanvas
 
     }
 
-    AZ::Job* PresignedURLManager::RequestDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id)
+    AZ::Job* PresignedURLManager::RequestDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id, DataReceivedEventHandler&& dataReceivedHandler)
     {
-        return CreateDownloadSignedURLJob(signedURL, fileName, id);
+        return CreateDownloadSignedURLJob(signedURL, fileName, id, std::move(dataReceivedHandler));
     }
 
-    void PresignedURLManager::RequestDownloadSignedURL(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id)
+    void PresignedURLManager::RequestDownloadSignedURL(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id, DataReceivedEventHandler&& dataReceivedHandler)
     {
-        AZ::Job* downloadJob = CreateDownloadSignedURLJob(signedURL, fileName, id);
+        AZ::Job* downloadJob = CreateDownloadSignedURLJob(signedURL, fileName, id, std::move(dataReceivedHandler));
         if (downloadJob)
         {
             downloadJob->Start();
@@ -100,7 +102,7 @@ namespace CloudCanvas
         return keyValuePairs;
     }
 
-    AZ::Job* PresignedURLManager::CreateDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id) const
+    AZ::Job* PresignedURLManager::CreateDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id, DataReceivedEventHandler&& dataReceivedHandler) const
     {
         if (!signedURL.length())
         {
@@ -121,7 +123,7 @@ namespace CloudCanvas
         AZ::Job* job{ nullptr };
 
 #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
-         job = AZ::CreateJobFunction([signedURL, outputFile, id]()
+        job = AZ::CreateJobFunction([signedURL, outputFile, id, dataReceivedHandler]()
         {
             Aws::Client::ClientConfiguration presignedConfig;
             presignedConfig.enableTcpKeepAlive = AZ_TRAIT_AZFRAMEWORK_AWS_ENABLE_TCP_KEEP_ALIVE_SUPPORTED;
@@ -149,6 +151,21 @@ namespace CloudCanvas
             auto httpRequest(Aws::Http::CreateHttpRequest(requestURL, Aws::Http::HttpMethod::HTTP_GET, nullptr));
 
             httpRequest->SetResponseStreamFactory([outputFile]() { return Aws::New<Aws::FStream>("TRANSFER", outputFile.c_str(), std::ios_base::out | std::ios_base::in | std::ios_base::binary | std::ios_base::trunc); });
+
+            httpRequest->SetDataReceivedEventHandler([dataReceivedHandler](const Aws::Http::HttpRequest* request, Aws::Http::HttpResponse* response, long long amountReceived)
+            {
+                if (response)
+                {
+                    if (!response->HasHeader(Aws::Http::CONTENT_LENGTH_HEADER))
+                        return;
+
+                    const Aws::String& header = response->GetHeader(Aws::Http::CONTENT_LENGTH_HEADER);
+                    AZStd::string contentLength = header.c_str();
+                    uint32_t totalLength = (uint32_t)AZStd::stoi(contentLength);
+
+                    dataReceivedHandler((uint32_t)amountReceived, totalLength);
+                }
+            });
 
             auto httpResponse = httpClient->MakeRequest(httpRequest, nullptr);
 

--- a/dev/Gems/CloudCanvasCommon/Code/Source/PresignedURL/PresignedURL.h
+++ b/dev/Gems/CloudCanvasCommon/Code/Source/PresignedURL/PresignedURL.h
@@ -25,11 +25,11 @@ namespace CloudCanvas
         PresignedURLManager();
         virtual ~PresignedURLManager();
 
-        virtual void RequestDownloadSignedURL(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id) override;
-        virtual AZ::Job* RequestDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id) override;
+        virtual void RequestDownloadSignedURL(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id, DataReceivedEventHandler&& dataReceivedHandler) override;
+        virtual AZ::Job* RequestDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id, DataReceivedEventHandler&& dataReceivedHandler) override;
         AZStd::unordered_map<AZStd::string, AZStd::string> GetQueryParameters(const AZStd::string& signedURL) override;
 
-        AZ::Job* CreateDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id) const;
+        AZ::Job* CreateDownloadSignedURLJob(const AZStd::string& signedURL, const AZStd::string& fileName, AZ::EntityId id, DataReceivedEventHandler&& dataReceivedHandler) const;
     };
 } // namespace CloudCanvas
 

--- a/dev/Gems/CloudGemDynamicContent/Code/Include/DynamicContent/DynamicContentBus.h
+++ b/dev/Gems/CloudGemDynamicContent/Code/Include/DynamicContent/DynamicContentBus.h
@@ -61,11 +61,11 @@ namespace CloudCanvas
         public:
             virtual void NewContentReady(const AZStd::string& outputFile) {}
             virtual void NewPakContentReady(const AZStd::string& pakFileName) {}
-            virtual void FileStatusFailed(const AZStd::string& outputFile) {}
-            virtual void DownloadSucceeded(const AZStd::string& fileName, const AZStd::string& keyName) {}
+            virtual void FileStatusFailed(const AZStd::string& outputFile, const AZStd::string& keyName) {}
+            virtual void DownloadSucceeded(const AZStd::string& fileName, const AZStd::string& keyName, bool updated) {}
 
             // Download was attempted and failed
-            virtual void DownloadFailed(const AZStd::string& outputFile) {}
+            virtual void DownloadFailed(const AZStd::string& outputFile, const AZStd::string& keyName) {}
 
             // Broadcast when we've detected a change in file status on the back end from the WebCommunicator (New file made public, public file made private)
             virtual void FileStatusChanged(const AZStd::string& fileName, const AZStd::string& fileStatus) {}
@@ -74,6 +74,8 @@ namespace CloudCanvas
 
             // Fired when when our tick bus checks and finds no remaining pak entries to mount in the UPDATING state
             virtual void RequestsCompleted() {}
+            // Called when we've received data.  This is just the delta, not the running total of the data received.
+            virtual void OnDataReceived(const AZStd::string& fileName, uint32_t receivedData, uint32_t totalSize) {}
         };
 
         class DynamicContentUpdateTraits


### PR DESCRIPTION
This is used to track transfer progress of a download

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
