### PR TITLE
Statistics collection and thread safety fixes for AZ::IO::DedicatedCache

### DIFF
--- a/dev/Code/Framework/AzCore/AzCore/IO/Streamer/DedicatedCache.cpp
+++ b/dev/Code/Framework/AzCore/AzCore/IO/Streamer/DedicatedCache.cpp
@@ -13,11 +13,14 @@
 #include <AzCore/IO/Streamer/FileRequest.h>
 #include <AzCore/IO/Streamer/DedicatedCache.h>
 #include <AzCore/std/string/string.h>
+#include <AzCore/std/parallel/lock.h>
 
 namespace AZ
 {
     namespace IO
     {
+        using RecursiveLockGuard = AZStd::lock_guard<AZStd::recursive_mutex>;
+
         DedicatedCache::DedicatedCache(u64 cacheSize, u32 blockSize, bool onlyEpilogWrites)
             : StreamStackEntry("Dedicated cache")
             , m_cacheSize(cacheSize)
@@ -29,6 +32,9 @@ namespace AZ
         void DedicatedCache::SetNext(AZStd::shared_ptr<StreamStackEntry> next)
         {
             m_next = AZStd::move(next);
+
+            RecursiveLockGuard lock(m_cacheMutex);
+
             for (AZStd::unique_ptr<BlockCache>& cache : m_cachedFileCaches)
             {
                 cache->SetNext(m_next);
@@ -38,6 +44,9 @@ namespace AZ
         void DedicatedCache::SetContext(StreamerContext& context)
         {
             StreamStackEntry::SetContext(context);
+
+            RecursiveLockGuard lock(m_cacheMutex);
+
             for (AZStd::unique_ptr<BlockCache>& cache : m_cachedFileCaches)
             {
                 cache->SetContext(context);
@@ -62,10 +71,16 @@ namespace AZ
         bool DedicatedCache::ExecuteRequests()
         {
             bool hasProcessedRequest = false;
-            for (AZStd::unique_ptr<BlockCache>& cache : m_cachedFileCaches)
+
             {
-                hasProcessedRequest = cache->ExecuteRequests() || hasProcessedRequest;
+                RecursiveLockGuard lock(m_cacheMutex);
+
+                for (AZStd::unique_ptr<BlockCache>& cache : m_cachedFileCaches)
+                {
+                    hasProcessedRequest = cache->ExecuteRequests() || hasProcessedRequest;
+                }
             }
+
             return StreamStackEntry::ExecuteRequests() || hasProcessedRequest;
         }
 
@@ -73,108 +88,143 @@ namespace AZ
         {
             FileRequest::ReadData& data = request->GetReadData();
 
-            size_t index = FindCache(*data.m_path, data.m_offset);
-            if (index == s_fileNotFound)
             {
-                if (m_next)
+                RecursiveLockGuard lock(m_cacheMutex);
+
+                size_t index = FindCache(*data.m_path, data.m_offset);
+                if (index != s_fileNotFound)
                 {
-                    m_next->PrepareRequest(request);
+                    m_cachedFileCaches[index]->PrepareRequest(request);
+                    return;
                 }
             }
-            else
+
+            if (m_next)
             {
-                m_cachedFileCaches[index]->PrepareRequest(request);
+                m_next->PrepareRequest(request);
             }
         }
 
         void DedicatedCache::FlushCache(const RequestPath& filePath)
         {
-            size_t count = m_cachedFileNames.size();
-            for (size_t i = 0; i < count; ++i)
             {
-                if (m_cachedFileNames[i] == filePath)
+                RecursiveLockGuard lock(m_cacheMutex);
+
+                size_t count = m_cachedFileNames.size();
+                for (size_t i = 0; i < count; ++i)
                 {
-                    m_cachedFileCaches[i]->FlushCache(filePath);
+                    if (m_cachedFileNames[i] == filePath)
+                    {
+                        m_cachedFileCaches[i]->FlushCache(filePath);
+                    }
                 }
             }
+
             StreamStackEntry::FlushCache(filePath);
         }
 
         void DedicatedCache::FlushEntireCache()
         {
-            for (AZStd::unique_ptr<BlockCache>& cache : m_cachedFileCaches)
             {
-                cache->FlushEntireCache();
+                RecursiveLockGuard lock(m_cacheMutex);
+
+                for (AZStd::unique_ptr<BlockCache>& cache : m_cachedFileCaches)
+                {
+                    cache->FlushEntireCache();
+                }
             }
+
             StreamStackEntry::FlushEntireCache();
         }
 
         void DedicatedCache::CollectStatistics(AZStd::vector<Statistic>& statistics) const
         {
-            size_t count = m_cachedFileNames.size();
-            for (size_t i = 0; i < count; ++i)
             {
-                double hitRate = m_cachedFileCaches[i]->CalculateHitRatePercentage();
-                double cacheable = m_cachedFileCaches[i]->CalculateCacheableRatePercentage();
-                s32 slots = m_cachedFileCaches[i]->CalculateAvailableRequestSlots();
-                
-                AZStd::string name;
-                if (m_cachedFileRanges[i].IsEntireFile())
-                {
-                    name = AZStd::string::format("%s/%s", m_name.c_str(), m_cachedFileNames[i].GetRelativePath());
-                }
-                else
-                {
-                    name = AZStd::string::format("%s/%s %llu:%llu", m_name.c_str(), m_cachedFileNames[i].GetRelativePath(),
-                        m_cachedFileRanges[i].GetOffset(), m_cachedFileRanges[i].GetEndPoint());
-                }
+                RecursiveLockGuard lock(m_cacheMutex);
 
-                statistics.push_back(Statistic::CreatePercentage(name, "Cache Hit Rate", hitRate));
-                statistics.push_back(Statistic::CreatePercentage(name, "Cacheable", cacheable));
-                statistics.push_back(Statistic::CreateInteger(name, "Available slots", slots));
+                size_t count = m_cachedFileNames.size();
+                for (size_t i = 0; i < count; ++i)
+                {
+                    double hitRate = m_cachedFileCaches[i]->CalculateHitRatePercentage();
+                    double cacheable = m_cachedFileCaches[i]->CalculateCacheableRatePercentage();
+                    s32 slots = m_cachedFileCaches[i]->CalculateAvailableRequestSlots();
+
+                    DedicatedCache* _this = const_cast<DedicatedCache*>(this);
+                    AZStd::string_view name;
+
+                    if (m_cachedFileRanges[i].IsEntireFile())
+                    {
+                        name = _this->AddOrUpdateCachedName(i, AZStd::string::format("%s/%s", m_name.c_str(), m_cachedFileNames[i].GetRelativePath()));
+                    }
+                    else
+                    {
+                        name = _this->AddOrUpdateCachedName(i, AZStd::string::format("%s/%s %llu:%llu", m_name.c_str(), m_cachedFileNames[i].GetRelativePath(),
+                            m_cachedFileRanges[i].GetOffset(), m_cachedFileRanges[i].GetEndPoint()));
+                    }
+
+                    statistics.push_back(Statistic::CreatePercentage(name, "Cache Hit Rate", hitRate));
+                    statistics.push_back(Statistic::CreatePercentage(name, "Cacheable", cacheable));
+                    statistics.push_back(Statistic::CreateInteger(name, "Available slots", slots));
+                }
             }
+
             StreamStackEntry::CollectStatistics(statistics);
         }
 
         void DedicatedCache::CreateDedicatedCache(const RequestPath& filename, const FileRange& range)
         {
-            size_t index = FindCache(filename, range);
-            if (index == s_fileNotFound)
             {
-                index = m_cachedFileCaches.size();
-                m_cachedFileNames.push_back(filename);
-                m_cachedFileRanges.push_back(range);
-                m_cachedFileCaches.push_back(AZStd::make_unique<BlockCache>(m_cacheSize, m_blockSize, m_onlyEpilogWrites));
-                m_cachedFileCaches[index]->SetNext(m_next);
-                m_cachedFileCaches[index]->SetContext(*m_context);
-                m_cachedFileRefCounts.push_back(1);
+                RecursiveLockGuard lock(m_cacheMutex);
+
+                size_t index = FindCache(filename, range);
+                if (index == s_fileNotFound)
+                {
+                    index = m_cachedFileCaches.size();
+                    m_cachedFileNames.push_back(filename);
+                    m_cachedFileRanges.push_back(range);
+                    m_cachedFileCaches.push_back(AZStd::make_unique<BlockCache>(m_cacheSize, m_blockSize, m_onlyEpilogWrites));
+                    m_cachedFileCaches[index]->SetNext(m_next);
+                    m_cachedFileCaches[index]->SetContext(*m_context);
+                    m_cachedFileRefCounts.push_back(1);
+                }
+                else
+                {
+                    ++m_cachedFileRefCounts[index];
+                }
             }
-            else
-            {
-                ++m_cachedFileRefCounts[index];
-            }
+
             StreamStackEntry::CreateDedicatedCache(filename, range);
         }
 
         void DedicatedCache::DestroyDedicatedCache(const RequestPath& filename, const FileRange& range)
         {
-            size_t index = FindCache(filename, range);
-            if (index != s_fileNotFound)
             {
-                AZ_Assert(m_cachedFileRefCounts[index] > 0, "A dedicated cache entry without references was left.");
-                --m_cachedFileRefCounts[index];
-                if (m_cachedFileRefCounts[index] == 0)
+                RecursiveLockGuard lock(m_cacheMutex);
+
+                size_t index = FindCache(filename, range);
+                if (index != s_fileNotFound)
                 {
-                    m_cachedFileNames.erase(m_cachedFileNames.begin() + index);
-                    m_cachedFileRanges.erase(m_cachedFileRanges.begin() + index);
-                    m_cachedFileCaches.erase(m_cachedFileCaches.begin() + index);
-                    m_cachedFileRefCounts.erase(m_cachedFileRefCounts.begin() + index);
+                    AZ_Assert(m_cachedFileRefCounts[index] > 0, "A dedicated cache entry without references was left.");
+                    --m_cachedFileRefCounts[index];
+                    if (m_cachedFileRefCounts[index] == 0)
+                    {
+                        if (m_cachedStatNames.size() > index)
+                        {
+                            m_cachedStatNames.erase(m_cachedStatNames.begin() + index);
+                        }
+
+                        m_cachedFileNames.erase(m_cachedFileNames.begin() + index);
+                        m_cachedFileRanges.erase(m_cachedFileRanges.begin() + index);
+                        m_cachedFileCaches.erase(m_cachedFileCaches.begin() + index);
+                        m_cachedFileRefCounts.erase(m_cachedFileRefCounts.begin() + index);
+                    }
+                }
+                else
+                {
+                    AZ_Assert(false, "Attempting to destroy a dedicated cache that doesn't exist or was already destroyed.");
                 }
             }
-            else
-            {
-                AZ_Assert(false, "Attempting to destroy a dedicated cache that doesn't exist or was already destroyed.");
-            }
+
             StreamStackEntry::DestroyDedicatedCache(filename, range);
         }
 
@@ -202,6 +252,20 @@ namespace AZ
                 }
             }
             return s_fileNotFound;
+        }
+
+        AZStd::string_view DedicatedCache::AddOrUpdateCachedName(size_t index, AZStd::string&& name)
+        {
+            if (m_cachedStatNames.size() <= index)
+            {
+                m_cachedStatNames.push_back(AZStd::forward<AZStd::string>(name));
+            }
+            else
+            {
+                m_cachedStatNames[index].assign(AZStd::forward<AZStd::string>(name));
+            }
+
+            return m_cachedStatNames.at(index);
         }
     } // namespace IO
 } // namespace AZ

--- a/dev/Code/Framework/AzCore/AzCore/IO/Streamer/DedicatedCache.h
+++ b/dev/Code/Framework/AzCore/AzCore/IO/Streamer/DedicatedCache.h
@@ -18,6 +18,7 @@
 #include <AzCore/IO/Streamer/StreamStackEntry.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/parallel/mutex.h>
 
 namespace AZ
 {
@@ -52,6 +53,7 @@ namespace AZ
             void ReadFile(FileRequest* request); 
             size_t FindCache(const RequestPath& filename, FileRange range);
             size_t FindCache(const RequestPath& filename, u64 offset);
+            AZStd::string_view AddOrUpdateCachedName(size_t index, AZStd::string&& name);
 
             static constexpr size_t s_fileNotFound = static_cast<size_t>(-1);
 
@@ -59,6 +61,9 @@ namespace AZ
             AZStd::vector<FileRange> m_cachedFileRanges;
             AZStd::vector<AZStd::unique_ptr<BlockCache>> m_cachedFileCaches;
             AZStd::vector<size_t> m_cachedFileRefCounts;
+            AZStd::vector<AZStd::string> m_cachedStatNames;
+
+            mutable AZStd::recursive_mutex m_cacheMutex;
 
             u64 m_cacheSize;
             u32 m_blockSize;


### PR DESCRIPTION
This commit addresses 2 problems we've encountered:
1. Broken RAD telemetry plots (collected statistics) for AZ::IO::Streamer;
2. Rare crashes of game client.

For the first issue we have a following visualization:
![image](https://user-images.githubusercontent.com/2987638/83808962-50ee1a00-a6be-11ea-8f7f-9b271d8000d0.png)

Streamer stat names appeared to be corrupted. This happened because of Statistic::CreateXXX(...) functions, accepting AZStd::string_view as a first argument, were supplied with AZStd::string variables living in method scope. To fix this we've introduced a separate cache for stat names.

Second issue (crash) was preceded by the following assertion:

`<2020-05-29T18:22:20:529+03> (System) - Trace::Assert ...\Code\Framework\AzCore\AzCore/std/containers/vector.h(585): (14664) 'const class std::unique_ptr<class AZ::IO::BlockCache,struct std::default_delete<class AZ::IO::BlockCache> > &__cdecl AZStd::vector<class std::unique_ptr<class AZ::IO::BlockCache,struct std::default_delete<class AZ::IO::BlockCache> >,class AZStd::allocator>::operator [](unsigned __int64) const'`
`<2020-05-29T18:22:20:529+03> (System) - AZStd::vector<>::at - position is out of range`
`<2020-05-29T18:22:20:530+03> (System) - ------------------------------------------------`
`<2020-05-29T18:23:37:320+03> (System) - 00007FF7B9793A27 (game01Launcher) : AZ::IO::FullFileDecompressor::CollectStatistics`
`<2020-05-29T18:23:37:321+03> (System) - 00007FFC2188AEE9 (CryRenderD3D11) : AZ::IO::Device::CollectStatistics`
`<2020-05-29T18:23:37:321+03> (System) - 00007FFC21890D54 (CryRenderD3D11) : AZ::IO::Device::OnTick`
`<2020-05-29T18:23:37:321+03> (System) - 00007FF7B968B787 (game01Launcher) : AZ::Internal::EBusContainer<AZ::TickEvents,AZ::TickEvents,0,2>::Dispatcher<AZ::EBus<AZ::TickEvents,AZ::TickEvents> >::Broadcast<void (__cdecl AZ::TickEvents::*)(float,AZ::ScriptTimePoint) __ptr64,float & __ptr64,AZ::Sc`
`<2020-05-29T18:23:37:321+03> (System) - 00007FF7B96E57C7 (game01Launcher) : AZ::ComponentApplication::Tick`
`<2020-05-29T18:23:37:321+03> (System) - 00007FF7B9178292 (game01Launcher) : LumberyardLauncher::Run`
`<2020-05-29T18:23:37:321+03> (System) - 00007FF7B9179A33 (game01Launcher) : WinMain`
`<2020-05-29T18:23:37:321+03> (System) - 00007FF7B9AC2FCE (game01Launcher) : __scrt_common_main_seh`
`<2020-05-29T18:23:37:321+03> (System) - 00007FFCBE897974 (KERNEL32) : BaseThreadInitThunk`
`<2020-05-29T18:23:37:321+03> (System) - 00007FFCBFBCA271 (ntdll) : RtlUserThreadStart`

This can happen due to the fact that DedicatedCache::CollectStatistics() and DedicatedCache::DestroyDedicatedCache() methods can be called from different threads (main and streamer threads respectively). While this happens rarely, access to DedicatedCache internal structures should be protected with sync constructs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
