### PR TITLE
Replacing pointer comparing to comparing string content

### DIFF
--- a/dev/Code/CryEngine/CrySystem/AZCoreLogSink.h
+++ b/dev/Code/CryEngine/CrySystem/AZCoreLogSink.h
@@ -149,7 +149,7 @@ public:
             return false; // allow AZCore to do its default behavior.
         }
 
-        if (window == AZ::Debug::Trace::GetDefaultSystemWindow())
+        if (_stricmp(window, AZ::Debug::Trace::GetDefaultSystemWindow()) == 0)
         {
             CryLogAlways("%s", message);
         }


### PR DESCRIPTION
This fix allows AzPrintF and AzTracePrintf macros to write to log files (Editor.log and game.log) when window is set to "Default"

I think that is was was intended but never worked.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
