### PR TITLE
Bugfix net binding destroying random entities

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.cpp
+++ b/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.cpp
@@ -65,10 +65,11 @@ namespace AzFramework
             EBUS_EVENT(GameEntityContextRequestBus, CancelDynamicSliceInstantiation, m_ticket);
         }
 
-        for (AZ::Entity* entity : m_boundEntities)
+        for (AZ::EntityId boundEntityId : m_boundEntities)
         {
-            AZ_ExtraTracePrintf("NetBindingSystemImpl", "Cleanup - deleting %llu\n", entity->GetId());
-            EBUS_EVENT(GameEntityContextRequestBus, DestroyGameEntity, entity->GetId());
+			AZ_Assert(boundEntityId != AZ::SystemEntityId, "NetBindingSliceInstantiationHandler is destroying the system entity");
+			AZ_ExtraTracePrintf("NetBindingSystemImpl", "Cleanup - deleting %llu\n", boundEntityId);
+			EBUS_EVENT(GameEntityContextRequestBus, DestroyGameEntity, boundEntityId);
         }
     }
 
@@ -123,9 +124,12 @@ namespace AzFramework
 
     bool NetBindingSliceInstantiationHandler::HasActiveEntities() const
     {
-        for (const AZ::Entity* entity : m_boundEntities)
+		for (const AZ::EntityId boundEntityId : m_boundEntities)
         {
-            if (entity->GetState() == AZ::Entity::ES_ACTIVE)
+			AZ::Entity* entity = nullptr;
+			AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, boundEntityId);
+
+            if (entity && entity->GetState() == AZ::Entity::ES_ACTIVE)
             {
                 return true;
             }
@@ -196,7 +200,7 @@ namespace AzFramework
             }
 
             AZ_ExtraTracePrintf("NetBindingSystemImpl", "Adding %llu \n", sliceEntity->GetId());
-            m_boundEntities.push_back(sliceEntity);
+			m_boundEntities.push_back(sliceEntity->GetId());
         }
 
         m_state = State::Spawned;
@@ -247,8 +251,8 @@ namespace AzFramework
         }
 
         const AZ::EntityId actualRuntimeEntityId = actualRuntimeIter->second;
-        const auto itCache = AZStd::find_if(m_boundEntities.begin(), m_boundEntities.end(), [&actualRuntimeEntityId](AZ::Entity* entity) {
-            return entity->GetId() == actualRuntimeEntityId;
+		const auto itCache = AZStd::find_if(m_boundEntities.begin(), m_boundEntities.end(), [&actualRuntimeEntityId](AZ::EntityId boundEntityId) {
+            return boundEntityId == actualRuntimeEntityId;
         });
 
         if (itCache != m_boundEntities.end())
@@ -495,9 +499,12 @@ namespace AzFramework
                     if (itSliceHandler != itCurrentContextQueue->second.end())
                     {
                         NetBindingSliceInstantiationHandler& sliceHandler = itSliceHandler->second;
-                        for (AZ::Entity* entity : sliceHandler.m_boundEntities)
+                        for (AZ::EntityId boundEntityId : sliceHandler.m_boundEntities)
                         {
-                            if (entity->GetId() == entityId)
+							AZ::Entity* entity = nullptr;
+							AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, boundEntityId);
+
+                            if (entity)
                             {
                                 entity->Deactivate();
                                 return;

--- a/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Network/NetBindingSystemImpl.h
@@ -103,7 +103,7 @@ namespace AzFramework
          * \breif a cache of entities that might be networked at some point
          * \note they might be bound and unbound if their replicas leave and come back in the view
          */
-        AZStd::vector<AZ::Entity*> m_boundEntities;
+        AZStd::vector<AZ::EntityId> m_boundEntities;
 
         /**
          * \brief identifies which slice instance the instantiation will be performed for


### PR DESCRIPTION
When a client is deleting netbound entities (for which he is not the authority), this leaves the NetBinding system with pointers to invalid entities in the m_boundEntities. Causing either crashes or deletion of random entities when the authority actually signals destruction of the netreplicated slice.

To remedy this issue, I'm changingthe m_boundEntities vector contents from Entity pointers to Entity Ids.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
