### PR TITLE
!B Fix stack corruption on non-windows platforms

### DIFF
--- a/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -36,7 +36,7 @@ namespace ScriptCanvas
         friend class Node;
     public:
 
-        enum DataType
+        enum DataType : int
         {
             NoData,
             Data,


### PR DESCRIPTION
Hi guys!
I am  sharing your fix of stack corruption on non-windows platforms

Problem is next - during asset processing convertor serializes DataType enum as 'int', because this is the underlying type of it on msvc/windows.

But after loading it on Clang  (for example Orbis or Linux) its underlying type will be unsigned int, which will lead to ton's of erros and stack corruption after