### PR TITLE
Assert fix when setting scrollable entity + avoiding LHS

### DIFF
--- a/dev/Gems/LyShine/Code/Source/UiScrollBarComponent.cpp
+++ b/dev/Gems/LyShine/Code/Source/UiScrollBarComponent.cpp
@@ -258,11 +258,16 @@ AZ::EntityId UiScrollBarComponent::GetScrollableEntity()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void UiScrollBarComponent::SetScrollableEntity(AZ::EntityId entityId)
 {
+	if (m_scrollableEntity.IsValid() && UiScrollableToScrollerNotificationBus::Handler::BusIsConnected())
+	{
+		UiScrollableToScrollerNotificationBus::Handler::BusDisconnect();
+	}
+
     m_scrollableEntity = entityId;
 
-    if (m_scrollableEntity.IsValid())
+    if (entityId.IsValid())
     {
-        UiScrollableToScrollerNotificationBus::Handler::BusConnect(m_scrollableEntity);
+        UiScrollableToScrollerNotificationBus::Handler::BusConnect(entityId);
     }
 }
 


### PR DESCRIPTION
Switching scrollable entity leads to asserts in Bus connection code due to the fact that previous handler was not disconnected. So this is a pretty trivial fix.

I also changed the following calls from using the m_scrollableEntity that was just assigned to using the entity is passed as parameter to avoid load-hit-stores.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
