### PR TITLE
PopcornFX decals

### DIFF
--- a/dev/Code/CryEngine/Cry3DEngine/DecalRenderNode.h
+++ b/dev/Code/CryEngine/Cry3DEngine/DecalRenderNode.h
@@ -60,7 +60,7 @@ public:
     static void ResetDecalUpdatesCounter() { CDecalRenderNode::m_nFillBigDecalIndicesCounter = 0; }
 
     // SetMatrix only supports changing position, this will do the full transform
-    void SetMatrixFull(const Matrix34& mat);
+    virtual void SetMatrixFull(const Matrix34& mat);
 public:
     CDecalRenderNode();
     void RequestUpdate() { m_updateRequested = true; DeleteDecal(); }

--- a/dev/Code/CryEngine/CryCommon/IEntityRenderState.h
+++ b/dev/Code/CryEngine/CryCommon/IEntityRenderState.h
@@ -818,6 +818,7 @@ struct IDecalRenderNode
     virtual const SDecalProperties* GetDecalProperties() const = 0;
     virtual const Matrix34& GetMatrix() = 0;
     virtual void CleanUpOldDecals() = 0;
+    virtual void SetMatrixFull(const Matrix34& mat) = 0;
     // </interfuscator:shuffle>
 };
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allows to call SetMatrixFull on DecalRenderNode for PopcornFX decals

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
