### PR TITLE
SliceInstantiationTicket hash performance

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Entity/EntityContextBus.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Entity/EntityContextBus.h
@@ -451,10 +451,9 @@ namespace AZStd
     {
         inline size_t operator()(const AzFramework::SliceInstantiationTicket& value) const
         {
-            AZ::Crc32 crc;
-            crc.Add(&value.m_contextId, sizeof(value.m_contextId));
-            crc.Add(&value.m_requestId, sizeof(value.m_requestId));
-            return static_cast<size_t>(static_cast<AZ::u32>(crc));
+            size_t result = value.m_contextId.GetHash();
+            AZStd::hash_combine(result, value.m_requestId);
+            return result;
         }
     };
 }


### PR DESCRIPTION
SliceInstantiationTicket is used as bus id in SliceInstantiationResultBus, as result it's used as key for internal hash table and hash function is used extensively when spawning dynamic slices.
Current implementation of hash function uses Crc32, which is quite slow - on my PC it takes around 20 microseconds, which can add up to a considerable time loss - single slice spawn causes multiple hash table operations, recalculating hash each time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
