### PR TITLE
adding vs2019 bin folders in the  .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,9 @@
 /dev/Bin64
 /dev/Bin64vc141
 /dev/Bin64vc141.Debug
+/dev/Bin64vc142
+/dev/Bin64vc142.Debug.Dedicated
+/dev/Cache
 /dev/Cache
 /dev/SamplesProject
 /dev/Code/SDKs
@@ -130,3 +133,4 @@
 /dev/SetupAssistantUserPreferences.ini
 /dev/_WAF_/environment.json
 /SetupAssistant.bat
+


### PR DESCRIPTION
*Description of changes:*
I noticed that in the .gitingore file that the Lumberyard Team added that bin folders for VS2017 but not for VS2019 so this PR just added that folder in right under the folders for VS2017

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
