### PR TITLE
Add unbounded overlap to physics world

### DIFF
--- a/dev/Code/Framework/AzFramework/AzFramework/Physics/World.h
+++ b/dev/Code/Framework/AzFramework/AzFramework/Physics/World.h
@@ -68,6 +68,14 @@ namespace Physics
         float GetFixedTimeStepMax() const;
     };
 
+    //! Callback for unbounded world queries. These are queries which don't require
+    // building the entire result vector, so save memory for very large numbers of hits.
+    // Called with `{ hit }' repeatedly until there are no more hits, then called with `{}', then never called again.
+    // Returns `true' to continue processing more hits, or `false' otherwise. If the function ever returns
+    //   `false', it is unspecified if the finalizing call `{}' occurs.
+    template<class HitType>
+    using HitCallback = AZStd::function<bool(AZStd::optional<HitType>&&)>;
+
     //! Physics world.
     class World
         : public AZ::EBusTraits
@@ -147,6 +155,9 @@ namespace Physics
 
         //! Perform an overlap query returning all objects that overlapped.
         virtual AZStd::vector<OverlapHit> Overlap(const OverlapRequest& request) = 0;
+
+        //! Perform an unbounded overlap query, calling the provided callback for each
+        virtual void OverlapUnbounded(const OverlapRequest& request, const HitCallback<OverlapHit>& cb) = 0;
 
         //! Perform an overlap sphere query returning all objects that overlapped.
         AZStd::vector<OverlapHit> OverlapSphere(float radius, const AZ::Transform& pose, OverlapFilterCallback filterCallback = nullptr);

--- a/dev/Gems/PhysX/Code/Source/World.h
+++ b/dev/Gems/PhysX/Code/Source/World.h
@@ -43,6 +43,7 @@ namespace PhysX
         AZStd::vector<Physics::RayCastHit> RayCastMultiple(const Physics::RayCastRequest& request);
         AZStd::vector<Physics::RayCastHit> ShapeCastMultiple(const Physics::ShapeCastRequest& request) override;
         AZStd::vector<Physics::OverlapHit> Overlap(const Physics::OverlapRequest& request) override;
+        void OverlapUnbounded(const Physics::OverlapRequest& request, const Physics::HitCallback<Physics::OverlapHit>& cb) override;
         void RegisterSuppressedCollision(const Physics::WorldBody& body0,
             const Physics::WorldBody& body1) override;
         void UnregisterSuppressedCollision(const Physics::WorldBody& body0,


### PR DESCRIPTION
This change exposes the 'unbounded' mode for PhysX overlap queries.

This is much more efficient that using the regular (bounded) overlap if: you're querying very large areas which have very many physical objects inside, and you aggregate the result of the query immediately as opposed to operating on individual objects returned from the query.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
