### PR TITLE
Add the ability to override how motion extraction is handled

### DIFF
--- a/dev/Gems/EMotionFX/Code/Include/Integration/MotionExtractionHandlerBus.h
+++ b/dev/Gems/EMotionFX/Code/Include/Integration/MotionExtractionHandlerBus.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+
+namespace EMotionFX
+{
+    namespace Integration
+    {
+        class MotionExtractionHandlerRequests
+            : public AZ::ComponentBus
+        {
+        public:
+
+            virtual void HandleMotionExtraction(const AZ::Vector3& deltaPosition, float deltaTime) = 0;
+        };
+        using MotionExtractionHandlerRequestBus = AZ::EBus<MotionExtractionHandlerRequests>;
+    }
+}

--- a/dev/Gems/EMotionFX/Code/emotionfx.waf_files
+++ b/dev/Gems/EMotionFX/Code/emotionfx.waf_files
@@ -7,7 +7,8 @@
     },
     "auto": {
         "Include": [
-            "Include/Integration/AnimationBus.h"
+            "Include/Integration/AnimationBus.h",
+            "Include/Integration/MotionExtractionHandlerBus.h"
         ],
         "Source/System": [
             "Source/Integration/System/AnimationModule.cpp",


### PR DESCRIPTION
Motion extraction from EMFX is currently handled one of three ways:
- PhysX character controller
- Legacy CryPhysics character controller
- TransformBus

Sometimes none of these methods are desirable. It is useful to be able to customize the handling of motion extraction depending on game mechanics. For example we might want to apply a maximum velocity to motion extracted movement.

*Issue #, if available:*

*Description of changes:*
This change adds a new bus for handling motion extraction, and adds a new check for the presence of a handler for this bus in the motion extraction logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
