### PR TITLE
Only update PhysX editor colliders if transform has actually changed

### DIFF
--- a/dev/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/dev/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -292,6 +292,8 @@ namespace PhysX
         LmbrCentral::MeshComponentNotificationBus::Handler::BusConnect(GetEntityId());
         EditorColliderComponentRequestBus::Handler::BusConnect(AZ::EntityComponentIdPair(GetEntityId(), GetId()));
 
+        EBUS_EVENT_ID_RESULT(m_cachedWorldTm, GetEntityId(), AZ::TransformBus, GetWorldTM);
+
         // Debug drawing
         m_colliderDebugDraw.Connect(GetEntityId());
         m_colliderDebugDraw.SetDisplayCallback(this);
@@ -819,8 +821,14 @@ namespace PhysX
         return GetWorldTM().RetrieveScale();
     }
 
-    void EditorColliderComponent::OnTransformChanged(const AZ::Transform& /*local*/, const AZ::Transform& /*world*/)
+    void EditorColliderComponent::OnTransformChanged(const AZ::Transform& /*local*/, const AZ::Transform& world)
     {
+        if (world.IsClose(m_cachedWorldTm))
+        {
+            return;
+        }
+        m_cachedWorldTm = world;
+
         UpdateShapeConfigurationScale();
         CreateStaticEditorCollider();
         Physics::EditorWorldBus::Broadcast(&Physics::EditorWorldRequests::MarkEditorWorldDirty);

--- a/dev/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/dev/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -235,5 +235,6 @@ namespace PhysX
         void ValidateMaterialSurfaces();
 
         DebugDraw::Collider m_colliderDebugDraw;
+        AZ::Transform m_cachedWorldTm;
     };
 } // namespace PhysX

--- a/dev/Gems/PhysX/Code/Source/EditorShapeColliderComponent.cpp
+++ b/dev/Gems/PhysX/Code/Source/EditorShapeColliderComponent.cpp
@@ -602,6 +602,8 @@ namespace PhysX
         LmbrCentral::ShapeComponentNotificationsBus::Handler::BusConnect(GetEntityId());
         PhysX::ColliderShapeRequestBus::Handler::BusConnect(GetEntityId());
 
+        EBUS_EVENT_ID_RESULT(m_cachedWorldTm, GetEntityId(), AZ::TransformBus, GetWorldTM);
+
         bool refreshPropertyTree = true;
         UpdateShapeConfigs(refreshPropertyTree);
 
@@ -642,8 +644,14 @@ namespace PhysX
     }
 
     // TransformBus
-    void EditorShapeColliderComponent::OnTransformChanged(const AZ::Transform& /*local*/, const AZ::Transform& /*world*/)
+    void EditorShapeColliderComponent::OnTransformChanged(const AZ::Transform& /*local*/, const AZ::Transform& world)
     {
+        if (world.IsClose(m_cachedWorldTm))
+        {
+            return;
+        }
+        m_cachedWorldTm = world;
+
         bool refreshPropertyTree = false;
         UpdateShapeConfigs(refreshPropertyTree);
 

--- a/dev/Gems/PhysX/Code/Source/EditorShapeColliderComponent.h
+++ b/dev/Gems/PhysX/Code/Source/EditorShapeColliderComponent.h
@@ -140,5 +140,6 @@ namespace PhysX
         //! @note 16 is the number of subdivisions in the debug cylinder that is loaded as a mesh (not generated procedurally)
         AZ::u8 m_subdivisionCount = 16; 
         mutable GeometryCache m_geometryCache; //!< Cached data for generating sample points inside the attached shape.
+        AZ::Transform m_cachedWorldTm;
     };
 } // namespace PhysX


### PR DESCRIPTION
In the editor, PhysX colliders cannot be moved and are instead destroyed and re-created in the physical world every time the transform changes. This update is a relatively expensive operation which adds up quickly if the transform is updated very frequently e.g. every tick, and you have many colliders in your level.

This change adds a check in OnTransformChanged to see if the transform is actually different.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
