### PR TITLE
Don't serialize PhysX collider scale values

### DIFF
--- a/dev/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/dev/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -471,6 +471,9 @@ namespace PhysX
 
             m_editorBody = AZ::Interface<Physics::System>::Get()->CreateStaticRigidBody(configuration);
 
+            auto& shapeConfiguration = m_shapeConfiguration.GetCurrent();
+            shapeConfiguration.m_scale = Utils::GetUniformScale(GetEntityId());
+
             if (m_shapeConfiguration.IsAssetConfig())
             {
                 AZStd::vector<AZStd::shared_ptr<Physics::Shape>> shapes;
@@ -485,7 +488,6 @@ namespace PhysX
             {
                 const Physics::ColliderConfiguration colliderConfiguration = GetColliderConfigurationScaled();
 
-                const auto& shapeConfiguration = m_shapeConfiguration.GetCurrent();
                 AZStd::shared_ptr<Physics::Shape> shape = AZ::Interface<Physics::System>::Get()->CreateShape(
                     colliderConfiguration, shapeConfiguration);
 
@@ -493,6 +495,8 @@ namespace PhysX
             }
 
             editorWorld->AddBody(*m_editorBody);
+
+            shapeConfiguration.m_scale = AZ::Vector3::CreateOne();
         }
 
         m_colliderDebugDraw.ClearCachedGeometry();
@@ -849,8 +853,6 @@ namespace PhysX
 
     void EditorColliderComponent::UpdateShapeConfigurationScale()
     {
-        auto& shapeConfiguration = m_shapeConfiguration.GetCurrent();
-        shapeConfiguration.m_scale = GetWorldTM().ExtractScale();
         m_colliderDebugDraw.ClearCachedGeometry();
     }
 

--- a/dev/Gems/PhysX/Code/Source/EditorShapeColliderComponent.cpp
+++ b/dev/Gems/PhysX/Code/Source/EditorShapeColliderComponent.cpp
@@ -247,11 +247,16 @@ namespace PhysX
             configuration.m_debugName = GetEntity()->GetName();
 
             m_editorBody = AZ::Interface<Physics::System>::Get()->CreateStaticRigidBody(configuration);
+            const AZ::Vector3 scale = Utils::GetUniformScale(GetEntityId());
 
-            for (const auto& shapeConfig : m_shapeConfigs)
+            for (auto& shapeConfig : m_shapeConfigs)
             {
+                shapeConfig->m_scale = scale;
+
                 AZStd::shared_ptr<Physics::Shape> shape = AZ::Interface<Physics::System>::Get()->CreateShape(m_colliderConfig, *shapeConfig);
                 m_editorBody->AddShape(shape);
+
+                shapeConfig->m_scale = AZ::Vector3::CreateOne();
             }
 
             if (!m_shapeConfigs.empty())
@@ -344,7 +349,6 @@ namespace PhysX
             configuration = Physics::BoxShapeConfiguration(boxDimensions);
         }
 
-        m_shapeConfigs.back()->m_scale = scale;
         m_geometryCache.m_boxDimensions = scale * boxDimensions;
     }
 
@@ -370,7 +374,6 @@ namespace PhysX
             configuration = capsuleShapeConfig;
         }
 
-        m_shapeConfigs.back()->m_scale = scale;
         const float scalarScale = scale.GetMaxElement();
         m_geometryCache.m_radius = scalarScale * capsuleShapeConfig.m_radius;
         m_geometryCache.m_height = scalarScale * capsuleShapeConfig.m_height;
@@ -396,7 +399,6 @@ namespace PhysX
             configuration = Physics::SphereShapeConfiguration(radius);
         }
         
-        m_shapeConfigs.back()->m_scale = scale;
         m_geometryCache.m_radius = scale.GetMaxElement() * radius;
     }
 


### PR DESCRIPTION
The scale values for PhysX colliders come from the entity parent transform, so when changing the scale anywhere in the parent hierarchy of a physx collider, the editor thinks thinks that the collider has changed, because this changes its serialized representation, and comparison is done based on the serialized representation.

It isn't necessary to store the scale in the serialized representation for runtime correctness, because all of the runtime colliders invariably overwrite the scale of their shapes. This is necessary for the correct instantiation of dynamic slices which might a scale override.

However instead of removing the scale from the serialized representation altogether this change simply sets the scale only when creating the collider in the PhysX world, not in the serialized representation. The serialized representation then always contains (1,1,1) as the scale.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
