### PR TITLE
Correctly upgrade PhysX mesh asset description

### DIFF
--- a/dev/Gems/PhysX/Code/Source/Pipeline/MeshGroup.cpp
+++ b/dev/Gems/PhysX/Code/Source/Pipeline/MeshGroup.cpp
@@ -850,6 +850,12 @@ namespace PhysX
                     primitiveAssetParams.m_volumeTermCoefficient = oldValue * 2.0e-5f;
                 }
                 classElement.AddElementWithData(context, "PrimitiveAssetParams", primitiveAssetParams);
+
+                // Convert 'export as convex' to 'export method'
+                // export as primitive was not previously available
+                bool exportAsConvex;
+                readAndRemoveElement(AZ::Crc32("export as convex"), exportAsConvex);
+                classElement.AddElementWithData(context, "export method", exportAsConvex ? MeshExportMethod::Convex : MeshExportMethod::TriMesh);
             }
 
             return true;


### PR DESCRIPTION
Version 1 had an 'export as convex' field which maps to 'export method' in Version 2. The existing version converter does not handle the 'export as convex' field, which causes physx colliders being upgraded from Version 1 to Version 2 to always have the default 'export method'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
