### PR TITLE
Allow configuration of Actor BBox update type in editor

### DIFF
--- a/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.h
@@ -53,6 +53,23 @@ namespace EMotionFX
             AZ_COMPONENT(ActorComponent, "{BDC97E7F-A054-448B-A26F-EA2B5D78E377}");
             friend class EditorActorComponent;
 
+            struct BoundingBoxConfiguration
+            {
+                AZ_TYPE_INFO(BoundingBoxConfiguration, "{EBCFF975-00A5-4578-85C7-59909F52067C}");
+
+                BoundingBoxConfiguration() = default;
+
+                EMotionFX::ActorInstance::EBoundsType m_boundsType          = EMotionFX::ActorInstance::BOUNDS_STATIC_BASED;
+                bool                                  m_autoUpdateBounds    = true;
+                float                                 m_updateTimeFrequency = 0.f;
+                AZ::u32                               m_updateItemFrequency = 1;
+
+                void Set(ActorInstance* inst) const;
+                void SetAndUpdate(ActorInstance* inst) const;
+
+                static void Reflect(AZ::ReflectContext* context);
+            };
+
             /**
             * Configuration struct for procedural configuration of Actor Components.
             */
@@ -72,6 +89,7 @@ namespace EMotionFX
                 bool                            m_renderBounds;             ///< Toggles rendering of the character bounds used for visibility testing.
                 SkinningMethod                  m_skinningMethod;           ///< The skinning method for this actor
                 AZ::u32                         m_lodLevel;
+                BoundingBoxConfiguration        m_bboxConfig;
                 bool                            m_forceUpdateJointsOOV;     // Force updating the joints when it is out of camera view. By default, joints level update
                                                                             // (beside the root joint) on actor are disabled when the actor is out of view. 
 

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -61,11 +61,51 @@ namespace EMotionFX
                     ->Field("SkinningMethod", &EditorActorComponent::m_skinningMethod)
                     ->Field("UpdateJointTransformsWhenOutOfView", &EditorActorComponent::m_forceUpdateJointsOOV)
                     ->Field("LodLevel", &EditorActorComponent::m_lodLevel)
+                    ->Field("BBoxConfig", &EditorActorComponent::m_bboxConfig)
                 ;
 
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
                 if (editContext)
                 {
+                    editContext->Class<ActorComponent::BoundingBoxConfiguration>("Actor Bounding Box Config", "")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &ActorComponent::BoundingBoxConfiguration::m_boundsType,
+                                      "Bounds type",
+                                      "The method used to compute the Actor bounding box. NOTE: ordered by least expensive to compute to most expensive to compute."
+                        )
+                        ->EnumAttribute(ActorInstance::BOUNDS_STATIC_BASED, "Static bounds (source-asset bounds)")
+                        ->EnumAttribute(ActorInstance::BOUNDS_NODE_BASED, "Bone position-based")
+                        ->EnumAttribute(ActorInstance::BOUNDS_NODEOBBFAST_BASED, "Bone local min-max-based")
+                        ->EnumAttribute(ActorInstance::BOUNDS_NODEOBB_BASED, "Bone local bounding box-based")
+                        ->EnumAttribute(ActorInstance::BOUNDS_COLLISIONMESH_BASED, "Collision mesh vertex position-based (EXPENSIVE)")
+                        ->EnumAttribute(ActorInstance::BOUNDS_MESH_BASED, "Render mesh vertex position-based (VERY EXPENSIVE)")
+
+                        ->DataElement(0, &ActorComponent::BoundingBoxConfiguration::m_autoUpdateBounds,
+                                      "Automatically update bounds?",
+                                      "If true, bounds are automatically updated based on some frequency. Otherwise bounds are computed only at creation or when triggered manually"
+                        )
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+
+                        ->DataElement(0, &ActorComponent::BoundingBoxConfiguration::m_updateTimeFrequency,
+                                      "Update frequency",
+                                      "How often to update bounds automatically"
+                        )
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " seconds")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Step, 0.001f)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ActorComponent::BoundingBoxConfiguration::m_autoUpdateBounds)
+
+                        ->DataElement(0, &ActorComponent::BoundingBoxConfiguration::m_updateItemFrequency,
+                                      "Update item skip factor",
+                                      "How many items (bones or vertices) to skip when automatically updating bounds."
+                                      " <br> i.e. =1 uses every single item, =2 uses every 2nd item, =3 uses every 3rd item... "
+                        )
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " items")
+                        ->Attribute(AZ::Edit::Attributes::Min, (AZ::u32)1)
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ActorComponent::BoundingBoxConfiguration::m_autoUpdateBounds)
+                        ;
+
                     editContext->Class<EditorActorComponent>("Actor", "The Actor component manages an instance of an Actor")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Animation")
@@ -124,6 +164,10 @@ namespace EMotionFX
                         ->DataElement(0, &EditorActorComponent::m_lodLevel,
                         "LOD Level", "Preview the LOD Level of the current actor.")
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnLODLevelChanged)
+
+                        ->DataElement(0, &EditorActorComponent::m_bboxConfig,
+                                      "Bounding box configuration", "")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorActorComponent::OnBBoxConfigChanged)
                     ;
                 }
             }
@@ -435,6 +479,14 @@ namespace EMotionFX
             return refreshLevel;
         }
 
+        void EditorActorComponent::OnBBoxConfigChanged()
+        {
+            if (m_actorInstance)
+            {
+                m_bboxConfig.SetAndUpdate(m_actorInstance.get());
+            }
+        }
+
         void EditorActorComponent::LaunchAnimationEditor(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType&)
         {
             if (assetId.IsValid())
@@ -534,6 +586,7 @@ namespace EMotionFX
 
             // Force an update of node transforms so we can get an accurate bounding box.
             m_actorInstance->UpdateTransformations(0.0f, true, false);
+            OnBBoxConfigChanged(); // Apply BBox config
 
             RenderBackend* renderBackend = AZ::Interface<RenderBackendManager>::Get()->GetRenderBackend();
             m_renderActorInstance.reset(renderBackend->CreateActorInstance(GetEntityId(),
@@ -666,6 +719,7 @@ namespace EMotionFX
             cfg.m_attachmentJointIndex = m_attachmentJointIndex;
             cfg.m_lodLevel = m_lodLevel;
             cfg.m_skinningMethod = m_skinningMethod;
+            cfg.m_bboxConfig = m_bboxConfig;
             cfg.m_forceUpdateJointsOOV = m_forceUpdateJointsOOV;
 
             gameEntity->AddComponent(aznew ActorComponent(&cfg));

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.h
@@ -105,6 +105,7 @@ namespace EMotionFX
             AZ::Crc32 OnAttachmentTypeChanged();
             AZ::Crc32 OnAttachmentTargetChanged();
             AZ::Crc32 OnAttachmentTargetJointSelect();
+            void OnBBoxConfigChanged();
             bool AttachmentTargetVisibility();
             bool AttachmentTargetJointVisibility();
             AZStd::string AttachmentJointButtonText();
@@ -149,6 +150,7 @@ namespace EMotionFX
             AZStd::string                       m_attachmentJointName;      ///< Joint name on target to which to attach (if ActorAttachment).
             AZ::u32                             m_attachmentJointIndex;
             AZ::u32                             m_lodLevel;
+            ActorComponent::BoundingBoxConfiguration m_bboxConfig;
             bool                                m_forceUpdateJointsOOV = false;
             // \todo attachmentTarget node nr
 


### PR DESCRIPTION
ActorInstance has several different modes and configuration values for computing its bounding box. This is especially useful when some animations might move the actor far outside its static bounds, in which case the actor render node will dissapear even when the actor mesh is still visible.

These settings are not exposed to the frontend (ActorComponent). This change simply adds these settings to the Actor configuration and to the Editor Actor edit context.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
