### PR TITLE
Allow specifying initial value for AnimGraph string parameter in editor

### DIFF
--- a/dev/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
@@ -422,6 +422,10 @@ namespace EMotionFX
                     {
                         SetNamedParameterBool(paramName, static_cast<AZ::ScriptPropertyBoolean*>(parameter)->m_value);
                     }
+                    else if (azrtti_istypeof<AZ::ScriptPropertyString>(parameter))
+                    {
+                        SetNamedParameterString(paramName, static_cast<AZ::ScriptPropertyString*>(parameter)->m_value.c_str());
+                    }
                     else
                     {
                         AZ_Warning("EMotionFX", false, "Invalid type for anim graph parameter \"%s\".", paramName);

--- a/dev/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorAnimGraphComponent.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorAnimGraphComponent.cpp
@@ -20,6 +20,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <EMotionFX/Source/Parameter/BoolParameter.h>
 #include <EMotionFX/Source/Parameter/FloatParameter.h>
+#include <EMotionFX/Source/Parameter/StringParameter.h>
 #include <EMotionFX/Source/Parameter/IntParameter.h>
 #include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.h>
 #include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h>
@@ -239,7 +240,8 @@ namespace EMotionFX
         {
             return (azrtti_istypeof<FloatParameter>(param) ||
                     azrtti_istypeof<IntParameter>(param) ||
-                    azrtti_istypeof<BoolParameter>(param));
+                    azrtti_istypeof<BoolParameter>(param) ||
+                    azrtti_istypeof<StringParameter>(param));
         }
 
         //////////////////////////////////////////////////////////////////////////
@@ -311,6 +313,10 @@ namespace EMotionFX
                         const EMotionFX::BoolParameter* boolParam = static_cast<const EMotionFX::BoolParameter*>(param);
                         m_parameterDefaults.m_parameters.emplace_back(aznew AZ::ScriptPropertyBoolean(paramName.c_str(), boolParam->GetDefaultValue()));
                     }
+                    else if (azrtti_istypeof<EMotionFX::StringParameter>(param))
+                    {
+                        const EMotionFX::StringParameter* stringParam = static_cast<const EMotionFX::StringParameter*>(param);
+                        m_parameterDefaults.m_parameters.emplace_back(aznew AZ::ScriptPropertyString(paramName.c_str(), stringParam->GetDefaultValue().c_str()));
                     else
                     {
                         AZ_Assert(!IsSupportedScriptPropertyType(param), "This value parameter of this type ('%s') should not be supported. Please update the IsSupportedScriptPropertyType() method.", param->GetTypeDisplayName());


### PR DESCRIPTION
The editor AnimGraph component allows you to specify the default values for some, but not all, AnimGraph parameter types.

This change adds support for specifying the default value for string AnimGraph parameters in the Editor AnimGraph component.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
