### PR TITLE
Wrong PhysX scene query buffer size

### DIFF
--- a/dev/Gems/PhysX/Code/Source/World.cpp
+++ b/dev/Gems/PhysX/Code/Source/World.cpp
@@ -314,7 +314,7 @@ namespace PhysX
             s_raycastBuffer.resize(maxResults);
         }
         // Raycast
-        physx::PxRaycastBuffer castResult(s_raycastBuffer.begin(), aznumeric_cast<physx::PxU32>(request.m_maxResults));
+        physx::PxRaycastBuffer castResult(s_raycastBuffer.begin(), aznumeric_cast<physx::PxU32>(maxResults));
         bool status = false;
         {
             PHYSX_SCENE_READ_LOCK(*m_world);
@@ -408,7 +408,7 @@ namespace PhysX
             }
 
             // Buffer to store results
-            physx::PxSweepBuffer pxResult(s_sweepBuffer.begin(), aznumeric_cast<physx::PxU32>(request.m_maxResults));
+            physx::PxSweepBuffer pxResult(s_sweepBuffer.begin(), aznumeric_cast<physx::PxU32>(maxResults));
 
             bool status = false;
             {
@@ -456,7 +456,7 @@ namespace PhysX
             s_overlapBuffer.resize(maxResults);
         }
         // Buffer to store results
-        physx::PxOverlapBuffer queryHits(s_overlapBuffer.begin(), aznumeric_cast<physx::PxU32>(request.m_maxResults));
+        physx::PxOverlapBuffer queryHits(s_overlapBuffer.begin(), aznumeric_cast<physx::PxU32>(maxResults));
         bool status = false;
         {
             PHYSX_SCENE_READ_LOCK(*m_world);


### PR DESCRIPTION
When performing scene query with more requested hits than maximum buffer size, passed buffer size (request.m_maxResults) will be lower than actual buffer size and may cause crashes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
