### PR TITLE
Fix an spelling mistake in the comment

### DIFF
--- a/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariable.h
+++ b/dev/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariable.h
@@ -18,7 +18,7 @@
 
 #include <ScriptCanvas/Core/DatumBus.h>
 
-// Version Converion Information
+// Version Conversion Information
 #include <ScriptCanvas/Deprecated/VariableHelpers.h>
 ////
 


### PR DESCRIPTION
*Description of changes:*
Fixing a spelling mistake. The original had the word "Converion" and I just changed it to "Conversion"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
