### PR TITLE
EMotionFX crash when used with replication

### DIFF
--- a/dev/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
+++ b/dev/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
@@ -173,6 +173,7 @@ namespace EMotionFX
         //////////////////////////////////////////////////////////////////////////
         AnimGraphComponent::AnimGraphComponent(const Configuration* config)
         {
+            m_animGraphInstance.reset();
             if (config)
             {
                 m_configuration = *config;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fixes an uninitialized variable in an EmotionFX component. (m_animGraphInstance)

This variable will cause a crash, especially in a replicated situation where Activate is not called on this component - as it doesn't use a weak pointer container. 

m_animGraphInstance needs to be set to null before being used - otherwise, the pointer will be considered valid memory as it's set to a non-null, garbage memory value by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
