### PR TITLE
Asset export

### DIFF
--- a/dev/Code/Sandbox/Editor/Export/ExportManager.cpp
+++ b/dev/Code/Sandbox/Editor/Export/ExportManager.cpp
@@ -40,6 +40,7 @@
 #include "Util/AutoDirectoryRestoreFileDialog.h"
 #include "QtUI/WaitCursor.h"
 #include "Maestro/Types/AnimParamType.h"
+#include "Material/MaterialManager.h"
 
 #include "QtUtil.h"
 
@@ -2079,9 +2080,23 @@ bool CExportManager::ImportFromFile(const char* filename)
 bool CExportManager::ExportSingleStatObj(IStatObj* pStatObj, const char* filename)
 {
     Export::CObject* pObj = new Export::CObject(Path::GetFileName(filename).toUtf8().data());
+
+    // the exporter uses m_pBaseObj to find the material and submesh settings
+    // so we create a temporary brush editor object and set the material we want to use 
+    CBaseObjectPtr editorObject = GetIEditor()->NewObject("Brush", "", "TempExportObject", 0.f, 0.f, 0.f, false);
+    if (editorObject)
+    {
+        auto material = pStatObj->GetMaterial();
+        CMaterial* editorMaterial = GetIEditor()->GetMaterialManager()->LoadMaterial(material->GetName());
+        editorObject->SetMaterial(editorMaterial);
+        m_pBaseObj = editorObject;
+    }
     AddStatObj(pObj, pStatObj);
     m_data.m_objects.push_back(pObj);
     ExportToFile(filename, true);
+
+    m_pBaseObj = nullptr;
+
     return true;
 }
 

--- a/dev/Code/Sandbox/Editor/Export/ExportManager.h
+++ b/dev/Code/Sandbox/Editor/Export/ExportManager.h
@@ -192,7 +192,7 @@ private:
     TExporters m_exporters;
     Export::CData m_data;
     bool m_isPrecaching;
-    bool m_isOccluder;
+    bool m_isOccluder = false; // if true, export lower resolution LOD if available
     float m_fScale;
     TObjectMap m_objectMap;
     bool m_bAnimationExport;

--- a/dev/Code/Sandbox/Editor/Util/FileUtil.cpp
+++ b/dev/Code/Sandbox/Editor/Util/FileUtil.cpp
@@ -2024,32 +2024,32 @@ void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, const QString& filen
 
     if (!filename.isEmpty() && filename.endsWith(".cgf", Qt::CaseInsensitive))
     {
-		action = menu->addAction(QObject::tr("Export"), [=]()
-		{
+        action = menu->addAction(QObject::tr("Export"), [=]()
+        {
             QFileInfo fi(fullPath);
             QString fileDirPath = fi.absolutePath();
-			QString saveFilePath = QFileDialog::getSaveFileName(
-					NULL,
-					QFileDialog::tr("Export Geometry"),
-					fileDirPath,
-					QFileDialog::tr("Object File (*.obj);;FBX File (*.fbx)"));
+            QString saveFilePath = QFileDialog::getSaveFileName(
+                    NULL,
+                    QFileDialog::tr("Export Geometry"),
+                    fileDirPath,
+                    QFileDialog::tr("Object File (*.obj);;FBX File (*.fbx)"));
 
-			if (saveFilePath.isEmpty())
-			{
-				return;
-			}
+            if (saveFilePath.isEmpty())
+            {
+                return;
+            }
 
-			CExportManager* exportMgr = static_cast<CExportManager*>(GetIEditor()->GetExportManager());
-			if (exportMgr)
-			{
-				QString relativeGamePath = Path::MakeGamePath(fullGamePath);
-				relativeGamePath = Path::AddSlash(relativeGamePath) + filename;
+            CExportManager* exportMgr = static_cast<CExportManager*>(GetIEditor()->GetExportManager());
+            if (exportMgr)
+            {
+                QString relativeGamePath = Path::MakeGamePath(fullGamePath);
+                relativeGamePath = Path::AddSlash(relativeGamePath) + filename;
                 constexpr bool useStreaming = false;
                 _smart_ptr<IStatObj> statObj = GetIEditor()->Get3DEngine()->LoadStatObjAutoRef(relativeGamePath.toStdString().c_str(),nullptr, nullptr, useStreaming);
                 exportMgr->ExportSingleStatObj(statObj, saveFilePath.toStdString().c_str());
-			}
-		});
-	}
+            }
+        });
+    }
 
     if (!filename.isEmpty() && GetIEditor()->IsSourceControlAvailable() && nFileAttr != SCC_FILE_ATTRIBUTE_INVALID)
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds an 'Export' option to the context menu for .cgf files in the Asset Browser.  Supports exporting to .obj or .fbx formats
This does not export all LODs, but just LOD0

Export option
![cgf_export](https://user-images.githubusercontent.com/3628857/105655800-a22d6280-5e75-11eb-9e5e-cc1470b5f6d6.PNG)

FBX export settings
![fbx_export_options](https://user-images.githubusercontent.com/3628857/105655813-af4a5180-5e75-11eb-8664-8473ab423d11.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
