### PR TITLE
Add auth header and upgrade SSL version to sslv23

### DIFF
--- a/dev/Gems/Websockets/Code/Include/Websockets/WebsocketsBus.h
+++ b/dev/Gems/Websockets/Code/Include/Websockets/WebsocketsBus.h
@@ -55,6 +55,9 @@ namespace Websockets
         //!avoided in production.
         virtual AZStd::unique_ptr<IWebsocketClient> CreateClient(const AZStd::string& websocket,
             const OnMessage& messageFunc, WebsocketType type) = 0;
+
+        virtual AZStd::unique_ptr<IWebsocketClient> CreateClientWithAuth(const AZStd::string& websocket,
+            const OnMessage& messageFunc, const AZStd::string& authorization) = 0;
     };
 
 

--- a/dev/Gems/Websockets/Code/Source/Platform/Common/Default/SecureWebsocketClient_Default.cpp
+++ b/dev/Gems/Websockets/Code/Source/Platform/Common/Default/SecureWebsocketClient_Default.cpp
@@ -27,7 +27,7 @@ namespace Websockets
         }
     }
 
-    bool SecureWebsocketClient_Default::ConnectWebsocket(const AZStd::string & websocket, const OnMessage & messageFunc)
+    bool SecureWebsocketClient_Default::ConnectWebsocket(const AZStd::string & websocket, const OnMessage & messageFunc, const AZStd::string& authorization)
     {
         m_messageFunction = messageFunc;
 
@@ -42,7 +42,7 @@ namespace Websockets
         //TLS handler (Transport Layer Security, also often referred to as SSL secure socket handler)
         m_client.set_tls_init_handler([](websocketpp::connection_hdl hdl) -> websocketpp::lib::shared_ptr<asio::ssl::context>
         {
-            websocketpp::lib::shared_ptr<asio::ssl::context> contextPtr(new asio::ssl::context(asio::ssl::context::tlsv1));
+            websocketpp::lib::shared_ptr<asio::ssl::context> contextPtr(new asio::ssl::context(asio::ssl::context::sslv23));
 
             websocketpp::lib::error_code errorCode;
             contextPtr->set_options(asio::ssl::context::default_workarounds
@@ -73,6 +73,11 @@ namespace Websockets
         if (!m_connection)
         {
             return false;
+        }
+
+        if (!authorization.empty())
+        {
+            m_connection->append_header("Authorization", authorization.c_str());
         }
 
         // Connect only requests a connection. No network messages are

--- a/dev/Gems/Websockets/Code/Source/Platform/Common/Default/SecureWebsocketClient_Default.h
+++ b/dev/Gems/Websockets/Code/Source/Platform/Common/Default/SecureWebsocketClient_Default.h
@@ -26,7 +26,7 @@ namespace Websockets
 
         void Destroy();
 
-        bool ConnectWebsocket(const AZStd::string& websocket, const OnMessage& messageFunc);
+        bool ConnectWebsocket(const AZStd::string& websocket, const OnMessage& messageFunc, const AZStd::string& authorization);
 
         bool IsConnectionOpen() const;
         void SendWebsocketMessage(const AZStd::string& msgBody);

--- a/dev/Gems/Websockets/Code/Source/Platform/Common/Unimplemented/SecureWebsocketClient_Unimplemented.cpp
+++ b/dev/Gems/Websockets/Code/Source/Platform/Common/Unimplemented/SecureWebsocketClient_Unimplemented.cpp
@@ -19,7 +19,7 @@ namespace Websockets
 
     }
 
-    bool SecureWebsocketClient_Unimplemented::ConnectWebsocket(const AZStd::string & websocket, const OnMessage & messageFunc)
+    bool SecureWebsocketClient_Unimplemented::ConnectWebsocket(const AZStd::string & websocket, const OnMessage & messageFunc, const AZStd::string& authorization)
     {
         return false;
     }

--- a/dev/Gems/Websockets/Code/Source/Platform/Common/Unimplemented/SecureWebsocketClient_Unimplemented.h
+++ b/dev/Gems/Websockets/Code/Source/Platform/Common/Unimplemented/SecureWebsocketClient_Unimplemented.h
@@ -23,7 +23,7 @@ namespace Websockets
 
         void Destroy();
 
-        bool ConnectWebsocket(const AZStd::string& websocket, const OnMessage& messageFunc);
+        bool ConnectWebsocket(const AZStd::string& websocket, const OnMessage& messageFunc, const AZStd::string& authorization);
 
         bool IsConnectionOpen() const;
         void SendWebsocketMessage(const AZStd::string& msgBody);

--- a/dev/Gems/Websockets/Code/Source/SecureWebsocketClient.cpp
+++ b/dev/Gems/Websockets/Code/Source/SecureWebsocketClient.cpp
@@ -34,6 +34,11 @@ namespace Websockets
         }
     }
 
+    bool SecureWebsocketClient::ConnectWebsocket(const AZStd::string& websocket, const OnMessage& messageFunc, const AZStd::string& authorization)
+    {
+        return Platform::ConnectWebsocket(websocket, messageFunc, authorization);
+    }
+
     bool SecureWebsocketClient::ConnectWebsocket(const AZStd::string& websocket, const OnMessage& messageFunc)
     {
         return Platform::ConnectWebsocket(websocket, messageFunc);

--- a/dev/Gems/Websockets/Code/Source/SecureWebsocketClient.h
+++ b/dev/Gems/Websockets/Code/Source/SecureWebsocketClient.h
@@ -38,7 +38,7 @@ namespace Websockets
 
         static void Reflect(AZ::ReflectContext* context);
 
-        bool ConnectWebsocket(const AZStd::string& websocket, const OnMessage& messageFunc);
+        bool ConnectWebsocket(const AZStd::string& websocket, const OnMessage& messageFunc, const AZStd::string& authorization = "");
 
         //interface functions
         bool IsConnectionOpen() const override;

--- a/dev/Gems/Websockets/Code/Source/WebsocketsSystemComponent.cpp
+++ b/dev/Gems/Websockets/Code/Source/WebsocketsSystemComponent.cpp
@@ -60,6 +60,25 @@ namespace Websockets
         WebsocketsRequestBus::Handler::BusDisconnect();
     }
 
+    AZStd::unique_ptr<IWebsocketClient> WebsocketsSystemComponent::CreateClientWithAuth(const AZStd::string& websocket, const OnMessage& messageFunc, const AZStd::string& authorization)
+    {
+        AZStd::unique_ptr<SecureWebsocketClient> socket = AZStd::make_unique<SecureWebsocketClient>();
+
+        if (!socket)
+        {
+            AZ_Error("Websocket Gem", socket, "Socket not created!");
+            return nullptr;
+        }
+
+        if (!socket->ConnectWebsocket(websocket, messageFunc, authorization))
+        {
+            AZ_Error("Websocket Gem", false, "Socket connection unsuccessful");
+            return nullptr;
+        }
+
+        return socket;
+    }
+    
     AZStd::unique_ptr<IWebsocketClient> WebsocketsSystemComponent::CreateClient(const AZStd::string& websocket, const OnMessage& messageFunc, WebsocketType type)
     {
         switch (type)

--- a/dev/Gems/Websockets/Code/Source/WebsocketsSystemComponent.h
+++ b/dev/Gems/Websockets/Code/Source/WebsocketsSystemComponent.h
@@ -36,6 +36,9 @@ namespace Websockets
         void Activate() override;
         void Deactivate() override;
 
+        AZStd::unique_ptr<IWebsocketClient> CreateClientWithAuth(const AZStd::string& websocket,
+            const OnMessage& messageFunc, const AZStd::string& authorization) override;
+
         AZStd::unique_ptr<IWebsocketClient> CreateClient(const AZStd::string& websocket,
             const OnMessage& messageFunc, WebsocketType type = WebsocketType::Secure) override;
     };


### PR DESCRIPTION
*Issue:*
It is not possible to provide Authorization header to setup secure access into websocket gateway exposed to public internet.
Generic TLS version 1 is not accepted by modern nginx setup so changed it into sslv23.

*Description of changes:*
These changes are made to keep diff as small as possible to show places where gem's clients need modifications. It is not a good idea to take it as is but it is good starting point to understand what should be exposed via public gem bus.
So it would be awesome to have possibilities to add own headers and configure SSL/TLS versions for secure connections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
