### PR TITLE
Carrier can't send large messages with data compression enabled

### DIFF
--- a/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
+++ b/dev/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
@@ -1300,6 +1300,8 @@ CarrierThread::CarrierThread(const CarrierDesc& desc, AZStd::shared_ptr<Compress
         bool isInit = m_compressor->Init();
         AZ_UNUSED(isInit);
         AZ_Error("GridMate", isInit, "GridMate carrier failed to initialize compression\n");
+        
+        m_maxMsgDataSizeBytes -= k_sizeOfCompressedHintHeader;
     }
     //////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
When sending data, that exceed maximum message size, Carrier will split in into several smaller ones. Maximum message data size is defined by variable m_maxMsgDataSizeBytes, which is calculated as following:
m_maxMsgDataSizeBytes = m_maxDataGramSizeBytes - GetDataGramHeaderSize() - GetMaxMessageHeaderSize();
When data compression is enabled, in addition to datagram and message headers, carrier adds additional header with compression hint flags (added in CarrierThread::SendDatagram).
Compression header is not accounted in m_maxMsgDataSizeBytes and resulting split messages won't be sent due to following code from CarrierThread::GenerateOutgoingDataGram:
                //If this Message can fit into the remaining Datagram buffer space
                if ((msg.m_dataSize + GetMessageHeaderSize(msg, isWriteMessageSequenceId, isWriteReliableMessageSequenceId, isWriteChannel))
                        > (maxDatagramSize - writeBuffer.Size()))
                {
                    break; // we can't add this message
                }

Moreover, these messages will remain in send queue and completely block the network. 
Issue happens only for messages, sent through custom network channels and not for regular game synchronization performed by replica manager. Replica manager uses channel 0, which is not included in message header, freeing up a necessary byte.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
